### PR TITLE
boilerplate validation

### DIFF
--- a/src/KitchenSink.js
+++ b/src/KitchenSink.js
@@ -18,6 +18,7 @@ import {
   InfoMessage,
   TextInput,
   ZipInput,
+  ZipInputValidator,
 } from './components/index.js'
 
 import './KitchenSink.scss'
@@ -134,9 +135,11 @@ const KitchenSink = () => {
             name="this-zip-input-example"
             labelCopy="What is your zip code?"
             data-tid='the-zip-input'
-            onValidation={(errors) =>
-              console.log('e.g. if I was a form I\'d get: ', errors)
-            }
+            validator={(zip) => {
+              const errors = ZipInputValidator(zip)
+              // More custom logic here should you wish
+              return errors
+            }}
           />
           <h2>RadioButtonGroup</h2>
           <RadioButtonGroup

--- a/src/components/Inputs/ZipInput/ZipInput.js
+++ b/src/components/Inputs/ZipInput/ZipInput.js
@@ -2,28 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { TextInput } from '../TextInput';
 
-// Currently, we only support USA. When we start to support
-// other locales, refer to http://html5pattern.com/Postal_Codes.
-const validZipRegex = /^(\d{5}([\-]\d{4})?)$/;
-
-const ZIP_CODE_INVALID_ERROR_MESSAGE = 'Please enter a valid Zip Code.'
-
 export const ZipInput = (props) => {
-  const {onValidation, ...prunedProps} = props;
-
-  const validator = (postal) => {
-    const errorMessage = validZipRegex.test(postal)
-      ? ''
-      : ZIP_CODE_INVALID_ERROR_MESSAGE
-
-    if (onValidation) {
-      onValidation.call(null, errorMessage)
-    }
-    return errorMessage
-  }
-
   return (
-    <TextInput validator={validator} {...prunedProps} />
+    <TextInput {...props} />
   )
 };
 
@@ -32,7 +13,7 @@ ZipInput.PUBLIC_PROPS = {
   disabled: PropTypes.bool,
   name: PropTypes.string.isRequired,
   labelCopy: PropTypes.string.isRequired,
-  onValidation: PropTypes.func,
+  validator: PropTypes.func
 }
 
 ZipInput.propTypes = {

--- a/src/components/Inputs/ZipInput/ZipInput.md
+++ b/src/components/Inputs/ZipInput/ZipInput.md
@@ -1,10 +1,15 @@
+The `ZipInput` takes a `validator`, and `ZipInputValidator` gives you validation for valid zip format. You can pass that directly, or, wrap it
+for any custom or additional logic you may wish to use.
 ```jsx
+import { ZipInputValidator } from './index.js';
 <ZipInput
   name="this-zip-input-example"
   labelCopy="What is your zip code?"
   data-tid='the-zip-input'
-  onValidation={(errors) =>
-    console.log('e.g. if I was a form I\'d get: ', errors)
-  }
+  validator={(zip) => {
+    const errors = ZipInputValidator(zip)
+    // More custom logic here should you wish
+    return errors
+  }}
 />
 ```

--- a/src/components/Inputs/ZipInput/ZipInput.test.js
+++ b/src/components/Inputs/ZipInput/ZipInput.test.js
@@ -9,7 +9,7 @@ describe('ZipInput', () => {
         name="le-zip"
         labelCopy="What is your zip code?"
         data-tid='le-zip'
-        onValidation={(errors) => {}}
+        validator={(errors) => {}}
       />).toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/src/components/Inputs/ZipInput/ZipInputValidator.js
+++ b/src/components/Inputs/ZipInput/ZipInputValidator.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+// Currently, we only support USA. When we start to support
+// other locales, refer to http://html5pattern.com/Postal_Codes.
+const validZipRegex = /^(\d{5}([\-]\d{4})?)$/;
+
+const ZIP_CODE_INVALID_ERROR_MESSAGE = 'Please enter a valid Zip Code.'
+
+const ZipInputValidator = (postal) => {
+  return validZipRegex.test(postal)
+    ? ''
+    : ZIP_CODE_INVALID_ERROR_MESSAGE
+}
+
+export default ZipInputValidator

--- a/src/components/Inputs/ZipInput/ZipInputValidator.test.js
+++ b/src/components/Inputs/ZipInput/ZipInputValidator.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import zipInputValidator from './ZipInputValidator.js';
+
+describe('ZipInputValidator', () => {
+  it('validates 5 digit zip codes', () => {
+    expect(zipInputValidator('9').length === 0).toBeFalsy()
+    expect(zipInputValidator('94').length === 0).toBeFalsy()
+    expect(zipInputValidator('945').length === 0).toBeFalsy()
+    expect(zipInputValidator('9454').length === 0).toBeFalsy()
+    expect(zipInputValidator('94546').length === 0).toBeTruthy()
+  });
+
+  // hyphenated part e.g. 94546-1234
+  it('validates 5 digit, hyphen, 4 digits', () => {
+    expect(zipInputValidator('94546-').length === 0).toBeFalsy()
+    expect(zipInputValidator('94546-1').length === 0).toBeFalsy()
+    expect(zipInputValidator('94546-12').length === 0).toBeFalsy()
+    expect(zipInputValidator('94546-123').length === 0).toBeFalsy()
+    expect(zipInputValidator('94546-1234').length === 0).toBeTruthy()
+  });
+});

--- a/src/components/Inputs/ZipInput/index.js
+++ b/src/components/Inputs/ZipInput/index.js
@@ -1,1 +1,2 @@
 export { ZipInput } from './ZipInput.js'
+export { default as ZipInputValidator } from './ZipInputValidator.js'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,7 +8,8 @@ export { RadioButtonGroup } from './RadioButtons'
 export { Spacer } from './Spacer'
 export { TextInput } from './Inputs/TextInput'
 export { InfoMessage } from './InfoMessage'
-export { ZipInput } from './Inputs/ZipInput'
+export { ZipInput, ZipInputValidator } from './Inputs/ZipInput'
+
 export {
   Body,
   Caption,


### PR DESCRIPTION
Removes onValidation. Now, per our discussion, we'll take a validator prop which gives the caller visibility. Also, we move the boiler-plate validator into corresponding external file; caller is expected to use that or provide their own validation (or both if they choose to wrap the boilerplate)

