### PR TITLE
Adding buttonStyles to ButtonSelectGroup

### DIFF
--- a/src/KitchenSink.js
+++ b/src/KitchenSink.js
@@ -44,12 +44,12 @@ const KitchenSink = () => {
           <Button.Medium.WhiteOutline>
             Button.Medium.WhiteOutline
           </Button.Medium.WhiteOutline>
-          <Button.Medium.Stateful>
+          <Button.Medium.Stateful.Default>
             Button.Medium.Stateful
-          </Button.Medium.Stateful>
-          <Button.Medium.Stateful isSelected={true}>
+          </Button.Medium.Stateful.Default>
+          <Button.Medium.Stateful.Default isSelected={true}>
             Button.Medium.Stateful
-          </Button.Medium.Stateful>
+          </Button.Medium.Stateful.Default>
           <Button.Unstyled>Button.Unstyled</Button.Unstyled>
         </section>
         <section>

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -142,6 +142,7 @@ PrivateButton.STYLES = {
   // WHITE: 'White', // TODO pending spec
   WHITE_OUTLINE: 'WhiteOutline',
   STATEFUL: 'Stateful',
+  STATEFUL_WHITE: 'Stateful White',
 
   // For semantic <buttons> that are not styled as buttons:
   UNSTYLED: 'Unstyled',
@@ -163,6 +164,7 @@ function ButtonFactory(privateProps) {
   return PublicButtonComponent
 }
 
+// TODO: We need to figure out a better way to compose these button styles
 export const Button = {
   Medium: {
     Black: ButtonFactory({
@@ -177,10 +179,16 @@ export const Button = {
       size: PrivateButton.SIZES.MEDIUM,
       style: PrivateButton.STYLES.WHITE_OUTLINE,
     }),
-    Stateful: ButtonFactory({
-      size: PrivateButton.SIZES.MEDIUM,
-      style: PrivateButton.STYLES.STATEFUL,
-    }),
+    Stateful: {
+      Default: ButtonFactory({
+        size: PrivateButton.SIZES.MEDIUM,
+        style: PrivateButton.STYLES.STATEFUL,
+      }),
+      White: ButtonFactory({
+        size: PrivateButton.SIZES.MEDIUM,
+        style: PrivateButton.STYLES.STATEFUL_WHITE
+      })
+    }
   },
   Unstyled: ButtonFactory({
     size: PrivateButton.SIZES.UNSIZED,

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -153,6 +153,10 @@ button,
     min-width: var(--ButtonMediumStatefulMinWidth);
   }
 
+  &.White {
+    background-color: var(--White);
+  }
+
   @mixin button-stateful-is-active-or-selected {
     // These are used in both the HTML "active" state (mid-click), as well as
     // the custom "is selected" state (this button is in the "on" state).

--- a/src/components/Button/Button.test.js
+++ b/src/components/Button/Button.test.js
@@ -11,6 +11,8 @@ describe('Button', () => {
       expect(Button.Medium.BlackOutline).toBeDefined()
       expect(Button.Medium.WhiteOutline).toBeDefined()
       expect(Button.Medium.Stateful).toBeDefined()
+      expect(Button.Medium.Stateful.Default).toBeDefined()
+      expect(Button.Medium.Stateful.White).toBeDefined()
       expect(Button.Unstyled).toBeDefined()
     })
   })
@@ -29,9 +31,19 @@ describe('Button', () => {
     test('Stateful isSelected', () => {
       const tree = renderer
         .create(
-          <Button.Medium.Stateful isSelected={true} data-tid="foo" name="bar">
+          <Button.Medium.Stateful.Default isSelected={true} data-tid="foo" name="bar">
             test
-          </Button.Medium.Stateful>
+          </Button.Medium.Stateful.Default>
+        )
+        .toJSON()
+      expect(tree).toMatchSnapshot()
+    })
+    test('Stateful isSelected White', () => {
+      const tree = renderer
+        .create(
+          <Button.Medium.Stateful.White isSelected={true} data-tid="foo" name="bar">
+            test
+          </Button.Medium.Stateful.White>
         )
         .toJSON()
       expect(tree).toMatchSnapshot()

--- a/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/src/components/Button/__snapshots__/Button.test.js.snap
@@ -23,3 +23,15 @@ exports[`Button default rendering Stateful isSelected 1`] = `
   test
 </button>
 `;
+
+exports[`Button default rendering Stateful isSelected White 1`] = `
+<button
+  aria-checked={true}
+  className="Button Medium Stateful White isSelected isSelected"
+  data-tid="foo"
+  name="bar"
+  type="button"
+>
+  test
+</button>
+`;

--- a/src/components/ButtonSelectGroup/ButtonSelectGroup.js
+++ b/src/components/ButtonSelectGroup/ButtonSelectGroup.js
@@ -18,6 +18,7 @@ import './ButtonGroup.scss'
  * @prop {string} props.label - Set's the caption of the group's label
  * @prop {boolean} [props.allCaps=false] - When set to `true`, the group's label will be displayed in all caps
  * @prop {string} [props.defaultValue] - Optionally sets a default value for the group. If set, the matching option will be set as `isSelected`
+ * @prop {string} [props.buttonStyle] - Optional value that sets the background color of all the buttons in the group (unselected state)
  * @prop {function} [props.onSelect] - Optional callback thats fires when an option is selected. returns an object containing the selected `value` and a boolean value `isAnswered`
  *
  * @example ```
@@ -35,10 +36,11 @@ import './ButtonGroup.scss'
  */
 export const ButtonSelectGroup = ({
   label,
-  allCaps = false,
   children,
   defaultValue,
   onSelect,
+  allCaps = false,
+  buttonStyle = 'default',
 }) => {
   const [selectedValue, setSelectedValue] = useState(defaultValue)
   const [isAnswered, setIsAnswered] = useState(false)
@@ -80,7 +82,7 @@ export const ButtonSelectGroup = ({
     const isSelected = value === selectedValue
     const onClick = onClickHandler(value, passedHandler)
 
-    return React.cloneElement(child, { ...child.props, isSelected, onClick })
+    return React.cloneElement(child, { ...child.props, isSelected, onClick, buttonStyle })
   })
 
   const labelId = `button-select-group-${uuidv4()}`
@@ -109,10 +111,12 @@ ButtonSelectGroup.propTypes = {
   label: PropTypes.string.isRequired,
   /** When set to `true`, the group's label will be displayed uppercase */
   allCaps: PropTypes.bool,
-  /** Optional callback thats fires when an option is selected. returns an object containing the selected `value` and a boolean value `isAnswered` */
-  onSelect: PropTypes.func,
   /** Optionally sets a default value for the group. If set, the matching option will be set as `isSelected` */
   defaultValue: PropTypes.string,
+  /** Optional value that sets the background color of all the buttons in the group (unselected state) */
+  buttonStyle: PropTypes.string,
+  /** Optional callback thats fires when an option is selected. returns an object containing the selected `value` and a boolean value `isAnswered` */
+  onSelect: PropTypes.func,
 }
 
 // Export the option button

--- a/src/components/ButtonSelectGroup/ButtonSelectGroup.md
+++ b/src/components/ButtonSelectGroup/ButtonSelectGroup.md
@@ -1,6 +1,6 @@
 ### Description
-`<ButtonSelectGroup />` renders a group of button that behaves similarly to a radio group
 
+`<ButtonSelectGroup />` renders a group of button that behaves similarly to a radio group
 
 ### Examples
 
@@ -44,8 +44,7 @@
 </ButtonSelectGroup>
 ```
 
-
-### Handling an `onClick` event on a specific `<Option/>` 
+### Handling an `onClick` event on a specific `<Option/>`
 
 ```jsx
 <ButtonSelectGroup
@@ -53,10 +52,61 @@
   label="Health"
   onSelect={({ value }) => console.log(value)}
 >
-  <ButtonSelectGroup.Option onClick={() => console.log('i was clicked!')} value="average">Average</ButtonSelectGroup.Option>
+  <ButtonSelectGroup.Option
+    onClick={() => console.log('i was clicked!')}
+    value="average"
+  >
+    Average
+  </ButtonSelectGroup.Option>
   <ButtonSelectGroup.Option value="great">Great</ButtonSelectGroup.Option>
   <ButtonSelectGroup.Option value="excellent">
     Exellent
   </ButtonSelectGroup.Option>
 </ButtonSelectGroup>
+```
+
+### Styling `<OptionButton />`
+
+`<OptionButtons />` can be styled by applying the `buttonStyle` property to the wrapping `<ButtonSelectGroup />`. The `buttonStyle` property expects to be passed a valid style enumeration option from the `OPTION_BUTTON_STYLES` `ENUM` (imported from the `BUTTON_SELECT_GROUP` package).
+
+There are currently two options: `WHITE` and `DEFAULT`. If `buttonStyle` is not passed, the button style is defaulted to `DEFAULT`.
+
+### White `buttonStyle`
+
+```jsx
+import { OPTION_BUTTON_STYLES } from './index.js'
+;<div style={{ background: '#f5f5f5', padding: '8px 16px' }}>
+  <ButtonSelectGroup
+    defaultValue="riddikulus"
+    label="Cast Spell"
+    buttonStyle={OPTION_BUTTON_STYLES.WHITE}
+  >
+    <ButtonSelectGroup.Option value="riddikulus">
+      Riddikulus
+    </ButtonSelectGroup.Option>
+    <ButtonSelectGroup.Option value=" expecto_patronum">
+      Expecto Patronum
+    </ButtonSelectGroup.Option>
+  </ButtonSelectGroup>
+</div>
+```
+
+### Default `buttonStyle`
+
+```jsx
+import { OPTION_BUTTON_STYLES } from './index.js'
+;<div style={{ background: '#f5f5f5', padding: '8px 16px' }}>
+  <ButtonSelectGroup
+    defaultValue="riddikulus"
+    label="Cast Spell"
+    buttonStyle={OPTION_BUTTON_STYLES.DEFAULT}
+  >
+    <ButtonSelectGroup.Option value="riddikulus">
+      Riddikulus
+    </ButtonSelectGroup.Option>
+    <ButtonSelectGroup.Option value=" expecto_patronum">
+      Expecto Patronum
+    </ButtonSelectGroup.Option>
+  </ButtonSelectGroup>
+</div>
 ```

--- a/src/components/ButtonSelectGroup/ButtonSelectGroup.test.js
+++ b/src/components/ButtonSelectGroup/ButtonSelectGroup.test.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import {OPTION_BUTTON_STYLES} from './OptionButton'
 import { ButtonSelectGroup } from './ButtonSelectGroup'
 import renderer from 'react-test-renderer'
 
@@ -7,10 +8,36 @@ jest.mock('uuid/v4', () => {
 })
 
 describe('ButtonSelectGroup', () => {
-  test('The ButtonSelectGroup renders', () => {
+  test('The ButtonSelectGroup renders (default button style, `buttonStyle` not passed)', () => {
     const tree = renderer
       .create(
         <ButtonSelectGroup label="options">
+          <ButtonSelectGroup.Option value="foo">foo</ButtonSelectGroup.Option>
+          <ButtonSelectGroup.Option value="bar">bar</ButtonSelectGroup.Option>
+        </ButtonSelectGroup>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('The ButtonSelectGroup renders (default button style, `buttonStyle` passed)', () => {
+    const tree = renderer
+      .create(
+        <ButtonSelectGroup buttonStyle={OPTION_BUTTON_STYLES.DEFAULT} label="options">
+          <ButtonSelectGroup.Option value="foo">foo</ButtonSelectGroup.Option>
+          <ButtonSelectGroup.Option value="bar">bar</ButtonSelectGroup.Option>
+        </ButtonSelectGroup>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('The ButtonSelectGroup renders (white button style)', () => {
+    const tree = renderer
+      .create(
+        <ButtonSelectGroup buttonStyle={OPTION_BUTTON_STYLES.WHITE} label="options">
           <ButtonSelectGroup.Option value="foo">foo</ButtonSelectGroup.Option>
           <ButtonSelectGroup.Option value="bar">bar</ButtonSelectGroup.Option>
         </ButtonSelectGroup>
@@ -66,7 +93,7 @@ describe('ButtonSelectGroup', () => {
     })
 
     const tree = renderer.create(
-      <ButtonSelectGroup defaultValue={optionValues[0]} onSelect={onSelectStub}>
+      <ButtonSelectGroup label="options" defaultValue={optionValues[0]} onSelect={onSelectStub}>
         {optionButtons}
       </ButtonSelectGroup>
     )
@@ -95,7 +122,7 @@ describe('ButtonSelectGroup', () => {
     const value = 'foo'
 
     const tree = renderer.create(
-      <ButtonSelectGroup onSelect={onSelectStub}>
+      <ButtonSelectGroup label="options" onSelect={onSelectStub}>
         <ButtonSelectGroup.Option value={value} onClick={onClickStub}>
           {value}
         </ButtonSelectGroup.Option>

--- a/src/components/ButtonSelectGroup/OptionButton.js
+++ b/src/components/ButtonSelectGroup/OptionButton.js
@@ -3,6 +3,11 @@ import PropTypes from 'prop-types'
 import uuidv4 from 'uuid/v4'
 import { Button } from '../Button'
 
+export const OPTION_BUTTON_STYLES = {
+  DEFAULT: 'default',
+  WHITE: 'white'
+}
+
 /**
  * Component renders an option button within a `<ButtonSelectGroup />`
  *
@@ -15,16 +20,28 @@ import { Button } from '../Button'
  *
  * @return {JSX.Element}
  */
-export const OptionButton = ({ children: label, isSelected, onClick }) => (
-  <Button.Medium.Stateful
-    ariaLabelId={`selection-option-${uuidv4()}`}
-    role="radio"
-    onClick={onClick}
-    isSelected={isSelected}
-  >
-    {label}
-  </Button.Medium.Stateful>
-)
+export const OptionButton = ({
+  children: label,
+  isSelected,
+  onClick,
+  buttonStyle,
+}) => {
+  const props = {
+    ariaLabelId: `selection-option-${uuidv4()}`,
+    role: 'radio',
+    onClick: onClick,
+    isSelected: isSelected,
+  }
+
+  switch (buttonStyle) {
+    case OPTION_BUTTON_STYLES.WHITE:
+      return <Button.Medium.Stateful.White {...props}>{label}</Button.Medium.Stateful.White>
+
+    case OPTION_BUTTON_STYLES.DEFAULT:
+    default:
+      return <Button.Medium.Stateful.Default {...props}>{label}</Button.Medium.Stateful.Default>
+  }
+}
 
 OptionButton.propTypes = {
   /** Set's the caption of the button's label */

--- a/src/components/ButtonSelectGroup/__snapshots__/ButtonSelectGroup.test.js.snap
+++ b/src/components/ButtonSelectGroup/__snapshots__/ButtonSelectGroup.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ButtonSelectGroup The ButtonSelectGroup renders 1`] = `
+exports[`ButtonSelectGroup The ButtonSelectGroup renders (default button style, \`buttonStyle\` not passed) 1`] = `
 <div
   aria-labelledby="button-select-group-1"
   className="button-select-group"
@@ -32,6 +32,96 @@ exports[`ButtonSelectGroup The ButtonSelectGroup renders 1`] = `
     </button>
     <button
       className="Button Medium Stateful"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        id="selection-option-1"
+      >
+        bar
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ButtonSelectGroup The ButtonSelectGroup renders (default button style, \`buttonStyle\` passed) 1`] = `
+<div
+  aria-labelledby="button-select-group-1"
+  className="button-select-group"
+  role="radiogroup"
+>
+  <span
+    className="Body Theinhardt Regular400 GrayPrimary"
+  >
+    <span
+      className="button-group-label"
+      id="button-select-group-1"
+    >
+      options
+    </span>
+  </span>
+  <div
+    className="button-group"
+  >
+    <button
+      className="Button Medium Stateful"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        id="selection-option-1"
+      >
+        foo
+      </span>
+    </button>
+    <button
+      className="Button Medium Stateful"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        id="selection-option-1"
+      >
+        bar
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ButtonSelectGroup The ButtonSelectGroup renders (white button style) 1`] = `
+<div
+  aria-labelledby="button-select-group-1"
+  className="button-select-group"
+  role="radiogroup"
+>
+  <span
+    className="Body Theinhardt Regular400 GrayPrimary"
+  >
+    <span
+      className="button-group-label"
+      id="button-select-group-1"
+    >
+      options
+    </span>
+  </span>
+  <div
+    className="button-group"
+  >
+    <button
+      className="Button Medium Stateful White"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        id="selection-option-1"
+      >
+        foo
+      </span>
+    </button>
+    <button
+      className="Button Medium Stateful White"
       onClick={[Function]}
       type="button"
     >

--- a/src/components/ButtonSelectGroup/index.js
+++ b/src/components/ButtonSelectGroup/index.js
@@ -1,1 +1,3 @@
+export { OPTION_BUTTON_STYLES } from './OptionButton.js';
+
 export { ButtonSelectGroup } from './ButtonSelectGroup.js';

--- a/src/components/design-system.css
+++ b/src/components/design-system.css
@@ -289,6 +289,9 @@ button:not([disabled]),
 .Button.Stateful.Medium {
   min-width: var(--ButtonMediumStatefulMinWidth);
 }
+.Button.Stateful.White {
+  background-color: var(--White);
+}
 .Button.Stateful:not([disabled]):hover {
   border-color: var(--GrayStrokeAndDisabled--translucent);
   background-color: var(--GrayLightHover--translucent);


### PR DESCRIPTION
## Description

Adding the ability to set the `<Options />` in a `<ButtonSelectGroup />` to `White`

### White Option Button

![image](https://user-images.githubusercontent.com/137689/64731047-47b87f80-d495-11e9-8a6e-9642cc131413.png)

### Default Option Button

![image](https://user-images.githubusercontent.com/137689/64731152-76cef100-d495-11e9-9313-18a2df4eed02.png)

## Changes
- Added the ability to style `<ButtonSelectGroup />` `<Option />` buttons through the use of a style `Enum`
- Added new test cases