### PR TITLE
Case Sensitive File Fix

### DIFF
--- a/styleguide/content/color/color.scss
+++ b/styleguide/content/color/color.scss
@@ -1,4 +1,4 @@
-@import "../../src/components/colors.scss";
+@import '../../src/components/Colors.scss';
 
 .White {
   color: var(--White);


### PR DESCRIPTION
Import CSS File Case Sensitive fix

By default, MacOS does not have case sensitivity for files. And that was the reason I wasn't have been able to build this locally.

If you want a case sensitive volume: https://coderwall.com/p/mgi8ja/case-sensitive-git-in-mac-os-x-like-a-pro