### PR TITLE
[Prototype form component] Form I

### DIFF
--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -78,10 +78,6 @@ export function Form({ children, config, render }) {
 
     try {
       await config.onSubmit(getInputValues())
-      alert(
-        'form submission successful with values:' +
-          JSON.stringify(getInputValues())
-      )
     } catch (e) {
       setFormErrorMessage('Something bad happened: ' + e.toString())
     }

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { useFormState } from '../../hooks/useFormState'
+
+export function Form({ children, config, render }) {
+  const inputNames = Object.keys(config.inputs)
+
+  // Set up initial values
+  let initialValues = {}
+  inputNames.forEach((x) => {
+    initialValues[x] = null
+  })
+
+  // Hooks
+  const [
+    getInputErrors,
+    setErrorStateFactory,
+    getFormErrorMessage,
+    setFormErrorMessage,
+    getFormIsValid,
+  ] = useFormState(initialValues)
+
+  // Validates form, sets button to disabled if there's an error
+  function inputNamePropsTransformer(inputName) {
+    return {
+      name: inputName,
+      formErrorHandler: setErrorStateFactory(inputName),
+      validator: (input) =>
+        config.inputs[inputName].validators
+          .reduce((errors, validator) => errors.concat(validator(input)), [])
+          .filter((x) => !!x) // remove empty strings
+          .join(', '),
+      labelCopy: config.inputs[inputName].labelCopy,
+      ['data-tid']: [config.formName, config.formId, inputName].join('-'),
+    }
+  }
+
+  async function onSubmit(syntheticReactEvent) {
+    console.log('syntheticReactEvent', syntheticReactEvent)
+    syntheticReactEvent.preventDefault()
+
+    if (!getFormIsValid()) {
+      if (getInputErrors()) {
+        setFormErrorMessage(
+          'One of the inputs was invalid. Errors: ' + getInputErrors()
+        )
+      } else {
+        setFormErrorMessage("You haven't typed anything yet")
+      }
+      return
+    }
+
+    try {
+      await config.onSubmit(syntheticReactEvent)
+      alert('form submission successful')
+    } catch {
+      setFormErrorMessage('Form was invalid')
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit}>
+      {children(inputNamePropsTransformer, getInputErrors, getFormErrorMessage)}
+    </form>
+  )
+}

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -3,6 +3,28 @@ import PropTypes from 'prop-types'
 
 import { useFormState } from '../../hooks/useFormState'
 
+/**
+ * The `Form` component takes a `config` object, and uses the convention
+ * of providing a callback function that you can place your `children`
+ * JSX in. See corresponding markdown example for details.
+ *
+ * The callback provides the following _parameters_:
+ * `inputNamePropsTransformer`—takes `inputName` and:
+ * - Validates form
+ * - Sets button to disabled if there's an error
+ *
+ * `getInputErrors`—TBD
+ *
+ * `getFormErrorMessage`—Provides for "form level errors" e.g. for
+ * presenting API errors, or messaging that relates to the entire form.
+ * _Note that field level errors (or hints if you will) are handled via
+ * the `validators` at the field level._
+ *
+ * `getFormIsValid`—Call this to determine if the form is generally valid.
+ * Useful for determining whether to disable a submit button for example.
+ *
+ * @see See also: `src/hooks/useFormState.js`
+ */
 export function Form({ children, config, render }) {
   const inputNames = Object.keys(config.inputs)
 

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -9,7 +9,7 @@ export function Form({ children, config, render }) {
   // Set up initial values
   let initialValues = {}
   inputNames.forEach((x) => {
-    initialValues[x] = null
+    initialValues[x] = 'err' // by default inputs have "hidden" errors
   })
 
   // Hooks

--- a/src/components/Form/Form.md
+++ b/src/components/Form/Form.md
@@ -1,0 +1,42 @@
+```jsx
+import { TextInput, Spacer, Button, InfoMessage } from '../index'
+import validateMinMaxFactory from '../../validators/validateMinMax'
+;<Form
+  config={{
+    formName: 'Styleguidist example form',
+    formId: '1',
+    inputs: {
+      evenNumText: {
+        validators: [
+          validateMinMaxFactory(5, 7),
+          (x) =>
+            x.length % 2
+              ? 'Text does not have an even number of characters'
+              : '',
+        ],
+        labelCopy:
+          "Validation happens after first blur ('touched')     Value's length % 2 and is between 5 and 7 characters",
+      },
+    },
+    onSubmit: (formData) => {
+      console.log('passed in form worked!')
+    },
+  }}
+>
+  {(inputPropFactory, getInputErrors, getFormErrorMessage) => (
+    <div>
+      <TextInput {...inputPropFactory('evenNumText')} />
+
+      <Spacer.H16 />
+
+      {getFormErrorMessage() && (
+        <InfoMessage.Alert.Error>
+          {getFormErrorMessage()}
+        </InfoMessage.Alert.Error>
+      )}
+
+      <Button.Medium.Black type="submit">Submit</Button.Medium.Black>
+    </div>
+  )}
+</Form>
+```

--- a/src/components/Form/Form.md
+++ b/src/components/Form/Form.md
@@ -6,7 +6,7 @@ import validateMinMaxFactory from '../../validators/validateMinMax'
     formName: 'Styleguidist example form',
     formId: '1',
     inputs: {
-      evenNumText: {
+      evenNumTextInput: {
         validators: [
           validateMinMaxFactory(5, 7),
           (x) =>
@@ -18,14 +18,18 @@ import validateMinMaxFactory from '../../validators/validateMinMax'
           "Validation happens after first blur ('touched')     Value's length % 2 and is between 5 and 7 characters",
       },
     },
-    onSubmit: (formData) => {
-      console.log('passed in form worked!')
+    onSubmit: async (formData) => {
+      console.log('submitting with form data: ', formData)
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      if (!!(Math.floor(Math.random() * 10) % 2)) {
+        throw new Error("Oh no, the api is broken (try again, it's random)")
+      }
     },
   }}
 >
-  {(inputPropFactory, getInputErrors, getFormErrorMessage) => (
+  {(inputPropFactory, getInputErrors, getFormErrorMessage, getFormIsValid) => (
     <div>
-      <TextInput {...inputPropFactory('evenNumText')} />
+      <TextInput {...inputPropFactory('evenNumTextInput')} />
 
       <Spacer.H16 />
 
@@ -35,7 +39,9 @@ import validateMinMaxFactory from '../../validators/validateMinMax'
         </InfoMessage.Alert.Error>
       )}
 
-      <Button.Medium.Black type="submit">Submit</Button.Medium.Black>
+      <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
+        Submit
+      </Button.Medium.Black>
     </div>
   )}
 </Form>

--- a/src/components/Form/Form.md
+++ b/src/components/Form/Form.md
@@ -19,6 +19,18 @@ import validateTruthy from '../../validators/validateTruthy'
         labelCopy:
           "Validation happens after first blur ('touched')     Value's length % 2 and is between 5 and 7 characters",
       },
+      shorterEvenNumTextInput: {
+        validators: [
+          validateTruthy,
+          validateMinMaxFactory(3, 5),
+          (x) =>
+            x.length % 2
+              ? 'Text does not have an even number of characters'
+              : '',
+        ],
+        labelCopy:
+          "Validation happens after first blur ('touched')     Value's length % 2 and is between 3 and 5 characters",
+      },
     },
     onSubmit: async (formData) => {
       console.log('submitting with form data: ', formData)
@@ -32,6 +44,10 @@ import validateTruthy from '../../validators/validateTruthy'
   {(inputPropFactory, getInputErrors, getFormErrorMessage, getFormIsValid) => (
     <div>
       <TextInput {...inputPropFactory('evenNumTextInput')} />
+
+      <Spacer.H16 />
+
+      <TextInput {...inputPropFactory('shorterEvenNumTextInput')} />
 
       <Spacer.H16 />
 

--- a/src/components/Form/Form.md
+++ b/src/components/Form/Form.md
@@ -1,6 +1,7 @@
 ```jsx
 import { TextInput, Spacer, Button, InfoMessage } from '../index'
 import validateMinMaxFactory from '../../validators/validateMinMax'
+import validateTruthy from '../../validators/validateTruthy'
 ;<Form
   config={{
     formName: 'Styleguidist example form',
@@ -8,6 +9,7 @@ import validateMinMaxFactory from '../../validators/validateMinMax'
     inputs: {
       evenNumTextInput: {
         validators: [
+          validateTruthy,
           validateMinMaxFactory(5, 7),
           (x) =>
             x.length % 2

--- a/src/components/Inputs/TextInput/TextInput.js
+++ b/src/components/Inputs/TextInput/TextInput.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 
 import { InputLabel } from '../InputLabel'
 import useRequired from '../../../hooks/useRequired.js'
-import useMinMaxLength from '../../../hooks/useMinMaxLength.js'
 import useErrorMessage from '../../../hooks/useErrorMessage.js'
 import useInvalid from '../../../hooks/useInvalid.js'
 import restrict from '../../../helpers/restrict.js'
@@ -15,8 +14,6 @@ import restrict from '../../../helpers/restrict.js'
  *
  * @param  {String}   props.name        Input name and htmlFor prop for label
  * @param  {String}   props.labelCopy   User-visible text of label for input
- * @param  {Number}   props.minLength   Min number of characters allowed
- * @param  {Number}   props.maxLength   Max number of characters allowed 
  * @param  {Boolean}  props.allCaps     Whether to text-trasform: uppercase
  * @param  {Function} props.validator   Function for validating input
  * @param  {Boolean}  props.disabled  
@@ -28,10 +25,9 @@ let touched = false
 function PrivateTextInput({
   disabled,
   name,
-  minLength = 0,
-  maxLength = Number.MAX_SAFE_INTEGER,
   labelCopy,
   allCaps,
+  formErrorHandler,
   validator,
   ...rest
 }) {
@@ -39,8 +35,6 @@ function PrivateTextInput({
   const [includesRequired] = useRequired(['data-tid', 'name', 'labelCopy'])
   let allRelevantProps = Object.assign({}, rest, {
     name: name,
-    minLength: minLength,
-    maxLength: maxLength,
     labelCopy: labelCopy,
     allCaps: allCaps,
   })
@@ -54,26 +48,28 @@ function PrivateTextInput({
 
   // Set up validation hooks
   const [getError, setError, validate] = useErrorMessage(validator)
-  const [minMaxValidator] = useMinMaxLength(minLength, maxLength)
 
   const [value, setValue] = useState('')
 
-  const doValidation = (value) => {
-    const minMaxError = minMaxValidator(value)
-    if (minMaxError) {
-      setError(minMaxError)
-      return
+  const setErrorWrapper = (errorValue) => {
+    if (!!formErrorHandler) {
+      formErrorHandler(errorValue)
     }
+    setError(errorValue)
+  }
+
+  const doValidation = (value) => {
     const errMsg = validate(value)
     if (errMsg.length) {
-      setError(errMsg)
+      setErrorWrapper(errMsg)
     } else {
-      setError('')
+      setErrorWrapper('')
     }
   }
 
   const onBlur = (ev) => {
     touched = true
+    doValidation(value)
   }
 
   const onChange = (ev) => {
@@ -120,8 +116,6 @@ PrivateTextInput.PUBLIC_PROPS = {
   validator: PropTypes.func,
   onBlur: PropTypes.func,
   onFocus: PropTypes.func,
-  minLength: PropTypes.number,
-  maxLength: PropTypes.number,
 }
 
 PrivateTextInput.propTypes = {

--- a/src/components/Inputs/TextInput/TextInput.js
+++ b/src/components/Inputs/TextInput/TextInput.js
@@ -27,7 +27,7 @@ function PrivateTextInput({
   name,
   labelCopy,
   allCaps,
-  formErrorHandler,
+  formChangeHandler,
   validator,
   ...rest
 }) {
@@ -52,8 +52,8 @@ function PrivateTextInput({
   const [value, setValue] = useState('')
 
   const setErrorWrapper = (errorValue) => {
-    if (!!formErrorHandler) {
-      formErrorHandler(errorValue)
+    if (!!formChangeHandler) {
+      formChangeHandler(value, errorValue)
     }
     setError(errorValue)
   }

--- a/src/components/Inputs/TextInput/TextInput.md
+++ b/src/components/Inputs/TextInput/TextInput.md
@@ -1,13 +1,13 @@
 ```jsx
-<TextInput
+import validateMinMaxFactory from '../../../validators/validateMinMax'
+;<TextInput
   name="example"
-  minLength={5}
-  maxLength={20}
-  allCaps={true}
   labelCopy="Validation happens after first blur ('touched')—Value's length % 2"
   data-tid="the-text-input"
-  validator={(x) =>
-    x.length % 2 ? 'Text does not have an even number of characters' : ''
-  }
+  validator={(x) => {
+    const minMaxErr = validateMinMaxFactory(5, 20)(x)
+    if (!!minMaxErr) return minMaxErr
+    return x.length % 2 ? 'Text does not have an even number of characters' : ''
+  }}
 />
 ```

--- a/src/components/Inputs/TextInput/TextInput.md
+++ b/src/components/Inputs/TextInput/TextInput.md
@@ -1,10 +1,13 @@
 ```jsx
 import validateMinMaxFactory from '../../../validators/validateMinMax'
+import validateTruthy from '../../../validators/validateTruthy'
 ;<TextInput
   name="example"
   labelCopy="Validation happens after first blur ('touched')—Value's length % 2"
   data-tid="the-text-input"
   validator={(x) => {
+    const truthyErr = validateTruthy(x)
+    if (!!truthyErr) return truthyErr
     const minMaxErr = validateMinMaxFactory(5, 20)(x)
     if (!!minMaxErr) return minMaxErr
     return x.length % 2 ? 'Text does not have an even number of characters' : ''

--- a/src/hooks/useErrorMessage.test.js
+++ b/src/hooks/useErrorMessage.test.js
@@ -1,17 +1,26 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import useErrorMessage from './useErrorMessage.js'
-import testHook from './testHook.js';
+import testHook from './testHook.js'
 
 describe('useErrorMessage hook', () => {
   test('validate callback', () => {
-    const validatorMock = jest.fn().mockReturnValue('problemo');
+    const validatorMock = jest.fn().mockReturnValue('problemo')
     testHook(() => {
-      const [getError, setError, validate] = useErrorMessage(validatorMock)
-      validate('foo');
-      expect(validatorMock.mock.calls.length).toBe(1);
-      expect(validatorMock.mock.calls[0][0]).toBe('foo');
-      expect(validatorMock.mock.results[0].value).toBe('problemo');
+      const [, , validate] = useErrorMessage(validatorMock)
+      validate('foo')
+      expect(validatorMock.mock.calls.length).toBe(1)
+      expect(validatorMock.mock.calls[0][0]).toBe('foo')
+      expect(validatorMock.mock.results[0].value).toBe('problemo')
+    })
+  })
+
+  test('other hook methods exist', () => {
+    const validatorMock = jest.fn().mockReturnValue('problemo')
+    testHook(() => {
+      const [getError, setError] = useErrorMessage(validatorMock)
+      expect(typeof getError).toEqual('function')
+      expect(typeof setError).toEqual('function')
     })
   })
 })

--- a/src/hooks/useFormState.js
+++ b/src/hooks/useFormState.js
@@ -4,21 +4,37 @@ let touched = false
 
 export function useFormState(initialState) {
   const [inputErrorsState, setInputErrorsState] = useState(initialState)
+  const [inputValuesState, setInputValuesState] = useState(initialState)
   const [formErrorState, setFormErrorState] = useState('')
 
   // Returns a function that updates state for the input, tracked by inputName
-  function setErrorStateFactory(inputName) {
-    return (newValue) => {
+  function setStateFactory(inputName) {
+    return (newValue, newError) => {
       touched = true
+
+      // Reset form errors if they exist
       setFormErrorState('')
+
+      // Update values state
+      setInputValuesState((inputValuesState) => ({
+        ...inputValuesState,
+        [inputName]: newValue,
+      }))
+
+      // Update errors state
       setInputErrorsState((inputErrorsState) => ({
         ...inputErrorsState,
-        [inputName]: newValue,
+        [inputName]: newError,
       }))
     }
   }
 
-  // Checks if any inputs have errors; returns boolean
+  // Gets values of all fields, basically just used in form submission
+  function getInputValues() {
+    return inputValuesState
+  }
+
+  // Checks if any inputs have errors; returns concatenated string
   function getInputErrors() {
     return Object.values(inputErrorsState)
       .filter((x) => !!x)
@@ -38,15 +54,16 @@ export function useFormState(initialState) {
     setFormErrorState(msg)
   }
 
-  // Verify form has been touched and also has no errors
-
+  // Verify form has been touched and also has no errors;
+  // Used for determining whether a form is valid
   function getFormIsValid() {
-    return !touched && !!getInputErrors()
+    return touched && !getInputErrors()
   }
 
   return [
     getInputErrors,
-    setErrorStateFactory,
+    getInputValues,
+    setStateFactory,
     getFormErrorMessage,
     setFormErrorMessage,
     getFormIsValid,

--- a/src/hooks/useFormState.js
+++ b/src/hooks/useFormState.js
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+
+let touched = false
+
+export function useFormState(initialState) {
+  const [inputErrorsState, setInputErrorsState] = useState(initialState)
+  const [formErrorState, setFormErrorState] = useState('')
+
+  // Returns a function that updates state for the input, tracked by inputName
+  function setErrorStateFactory(inputName) {
+    return (newValue) => {
+      touched = true
+      setFormErrorState('')
+      setInputErrorsState((inputErrorsState) => ({
+        ...inputErrorsState,
+        [inputName]: newValue,
+      }))
+    }
+  }
+
+  // Checks if any inputs have errors; returns boolean
+  function getInputErrors() {
+    return Object.values(inputErrorsState)
+      .filter((x) => !!x)
+      .join(', ')
+  }
+
+  // Form level error handling has seemingly pointless wrappers,
+  // this is how useErrorMessage did it
+
+  // Gets form error, a string
+  function getFormErrorMessage() {
+    return formErrorState
+  }
+
+  // Sets the form error, a string
+  function setFormErrorMessage(msg) {
+    setFormErrorState(msg)
+  }
+
+  // Verify form has been touched and also has no errors
+
+  function getFormIsValid() {
+    return !touched && !!getInputErrors()
+  }
+
+  return [
+    getInputErrors,
+    setErrorStateFactory,
+    getFormErrorMessage,
+    setFormErrorMessage,
+    getFormIsValid,
+  ]
+}

--- a/src/validators/validateMinMax.js
+++ b/src/validators/validateMinMax.js
@@ -1,18 +1,16 @@
-import React from 'react'
-
-const useMinMaxLength = (
-  min,
-  max,
+const validateMinMaxFactory = (
+  min = 0,
+  max = Number.MAX_SAFE_INTEGER,
   message = `Must be between ${min} and ${max} characters`
 ) => {
-
-  const minMaxValidator = (value) => {
+  function validateMinMax(value) {
     const valueString = value ? String(value) : ''
     const isInvalidMin = valueString && valueString.length < min
     const isInvalidMax = valueString && valueString.length > max
     return isInvalidMin || isInvalidMax ? message : undefined
   }
-  return [minMaxValidator]
+
+  return validateMinMax
 }
 
-export default useMinMaxLength
+export default validateMinMaxFactory

--- a/src/validators/validateMinMax.test.js
+++ b/src/validators/validateMinMax.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import validateMinMaxFactory from './validateMinMax.js'
+
+describe('validateMinMax', () => {
+  test('zero to', () => {
+    expect(validateMinMaxFactory(0, 2)('1')).toBeUndefined()
+    expect(validateMinMaxFactory(0, 2)('12')).toBeUndefined()
+    expect(validateMinMaxFactory(0, 2)('123')).not.toBeUndefined()
+  })
+
+  test('greater then zero up to', () => {
+    expect(validateMinMaxFactory(2, 5)('1')).not.toBeUndefined()
+    expect(validateMinMaxFactory(2, 5)('12')).toBeUndefined()
+    expect(validateMinMaxFactory(2, 5)('12345')).toBeUndefined()
+    expect(validateMinMaxFactory(2, 5)('123456')).not.toBeUndefined()
+  })
+})

--- a/src/validators/validateTruthy.js
+++ b/src/validators/validateTruthy.js
@@ -1,0 +1,3 @@
+export default function validateTruthy(x) {
+  return !!x ? '' : 'Please provide input'
+}

--- a/src/validators/validateTruthy.test.js
+++ b/src/validators/validateTruthy.test.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import validateTruthy from './validateTruthy.js'
+
+describe('validateTruthy', () => {
+  test('validates truthy', () => {
+    expect(validateTruthy(true).length).toBe(0)
+    expect(validateTruthy(false).length).toBeTruthy()
+  })
+})


### PR DESCRIPTION
**For the quickest view of what this adds, pull this, run styleguide, and check out its page for Form.**

### Additions + changes: 
- Added `components/Form` and its hook, `hooks/useFormState`
  - Takes in `config` object which pretty much has all of the form info in it
  - Tracks state and any errors, wraps onsubmit, but lets inputs control their own state
  - Passes down form validity so the submit button can be disabled or enabled
  - Submit failure shows a form-level error
- Added `components/Form.md` with a working `config` prop
  - Has two inputs, both TextInputs, with different validation schemes
  - Submitting has a 50% chance to error out, handles errors and successes visibly for user
- Changed `hooks/useMinMaxLength` to go in a new folder, 'validators,' and changed name to `validateMinMax` (because it's not a hook)
- Add simple `validateTruthy` validator
- Some changes to TextInput 
  - min/max length validation is no longer baked into the component, fixing its behavior of handling errors and blurring differently from a passed-in validator
  - updated `components/inputs/TextInput.md` to have validateMinMax passed in
  - possible callback for registering errors (and lack of errors) in form wraps "setError" function, making sure that the visual error within an input is always up to date with the actual error status of the component. inputs still work fine if this isn't supplied!
    - Clicking submit before blurring component doesn't "trick" the form into submitting if it has errors

### Other changes I want to make after this but people may disagree:
- Make every `validator` prop on an input `validators` and have it take in an array of validators
- change "inputs" folder name to "fields," change all instances of "input" in new Form component to "field," because we need a word for "anything which counts as part of a form" (basically a different word which refers to both 'input' elements and 'select' elements