### PR TITLE
Converts TextInput to use CSS Modules and removes from the compiled d…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.5-c",
+  "version": "1.1.5-d",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "license": "UNLICENSED",

--- a/src/components/Inputs/BirthdateInput/BirthdateInput.js
+++ b/src/components/Inputs/BirthdateInput/BirthdateInput.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import MaskedInput from 'react-text-mask'
 import createAutoCorrectedDatePipe from 'text-mask-addons/dist/createAutoCorrectedDatePipe'
 import { InputLabel } from '../InputLabel'
+import styles from '../TextInput/TextInput.module.scss'
+import errorStyles from '../Errors.module.scss'
 
 import dayjs from '../../../helpers/getDayjs.js'
 import useErrorMessage from '../../../hooks/useErrorMessage.js'
@@ -87,17 +89,19 @@ const PrivateBirthdateInput = (props) => {
     doValidation(ev.target.value, touched)
   }
 
+  const getClasses = () => {
+    return !!getError() ?
+      `BirthdateInput ${styles.TextInput} ${errorStyles.Error}` :
+      `BirthdateInput ${styles.TextInput}`
+  }
+
   return (
     <>
       <InputLabel name={name} labelCopy={labelCopy} allCaps={allCaps} />
       <MaskedInput
         mask={dateMaskByFormat[dateFormat]}
         pipe={autoCorrectedDatePipe}
-        className={
-          !!getError()
-            ? 'BirthdateInput TextInput Error'
-            : 'BirthdateInput TextInput'
-        }
+        className={getClasses()}
         type="tel"
         data-tid={restProps['data-tid']}
         guide={true}

--- a/src/components/Inputs/Errors.module.scss
+++ b/src/components/Inputs/Errors.module.scss
@@ -1,5 +1,3 @@
-// TODO -- convert this to Errors.module.scss
-
 .Error {
   border-color: var(--BrandSunburn);
   border-width: 1px;

--- a/src/components/Inputs/Errors.scss
+++ b/src/components/Inputs/Errors.scss
@@ -1,3 +1,5 @@
+// TODO -- convert this to Errors.module.scss
+
 .Error {
   border-color: var(--BrandSunburn);
   border-width: 1px;

--- a/src/components/Inputs/TextInput/TextInput.js
+++ b/src/components/Inputs/TextInput/TextInput.js
@@ -7,6 +7,10 @@ import useErrorMessage from '../../../hooks/useErrorMessage.js'
 import useInvalid from '../../../hooks/useInvalid.js'
 import restrict from '../../../helpers/restrict.js'
 
+// TODO -- pull in errors as CSS Modules too
+//import errorStyles from '../Inputs/Errors.module.scss
+import styles from './TextInput.module.scss'
+
 /* @getethos/design-system/TextInput.js
 
 /**
@@ -96,12 +100,17 @@ function PrivateTextInput({
     setValue(restrictedVal)
   }
 
+  const getClasses = () => {
+    // TODO -- use something like ${errorStyles.Error}
+    return !!getError() ? `${styles.TextInput} Error` : `${styles.TextInput}`
+  }
+
   return (
     <>
       <InputLabel name={name} labelCopy={labelCopy} />
       <input
         type="text"
-        className={!!getError() ? 'TextInput Error' : 'TextInput'}
+        className={getClasses()}
         disabled={disabled}
         name={name}
         onPaste={onPaste}

--- a/src/components/Inputs/TextInput/TextInput.js
+++ b/src/components/Inputs/TextInput/TextInput.js
@@ -7,9 +7,8 @@ import useErrorMessage from '../../../hooks/useErrorMessage.js'
 import useInvalid from '../../../hooks/useInvalid.js'
 import restrict from '../../../helpers/restrict.js'
 
-// TODO -- pull in errors as CSS Modules too
-//import errorStyles from '../Inputs/Errors.module.scss
 import styles from './TextInput.module.scss'
+import errorStyles from '../Errors.module.scss'
 
 /* @getethos/design-system/TextInput.js
 
@@ -101,8 +100,7 @@ function PrivateTextInput({
   }
 
   const getClasses = () => {
-    // TODO -- use something like ${errorStyles.Error}
-    return !!getError() ? `${styles.TextInput} Error` : `${styles.TextInput}`
+    return !!getError() ? `${styles.TextInput} ${errorStyles.Error}` : `${styles.TextInput}`
   }
 
   return (

--- a/src/components/Inputs/TextInput/TextInput.md
+++ b/src/components/Inputs/TextInput/TextInput.md
@@ -1,10 +1,14 @@
 ```jsx
 import validateMinMaxFactory from '../../../validators/validateMinMax'
 import validateTruthy from '../../../validators/validateTruthy'
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+
 ;<TextInput
   name="example"
   labelCopy="Validation happens after first blur ('touched')—Value's length % 2"
   data-tid="the-text-input"
+  formChangeHandler={formChangeHandlerStub}
   validator={(x) => {
     const truthyErr = validateTruthy(x)
     if (!!truthyErr) return truthyErr

--- a/src/components/Inputs/TextInput/TextInput.module.scss
+++ b/src/components/Inputs/TextInput/TextInput.module.scss
@@ -1,3 +1,9 @@
+// TODO -- these are currently come in via globals but we'll need
+// them here once we continue to strip 'em out of design-system.css
+// @import "../Colors.scss";
+// @import "../Type/Type.scss";
+// @import '../Spacer/Spacer.scss';
+
 .TextInput {
   // Same as Type.scss Body. Should we use a mixin?
   $font-size: 19;
@@ -11,8 +17,7 @@
   border-style: solid;
   border-width: 1px;
   border-color: var(--GrayStrokeAndDisabled--translucent);
-  // TODO: Is there a better way to achieve this?
-  padding: 17px 16px 13px;
+  padding: 17px var(--Space-16) 13px;
   color: var(--GrayPrimary--opaque);
   border-radius: 0;
   transition: border-color 250ms ease;

--- a/src/components/Inputs/ZipInput/ZipInput.js
+++ b/src/components/Inputs/ZipInput/ZipInput.js
@@ -4,6 +4,8 @@ import MaskedInput from 'react-text-mask'
 import useErrorMessage from '../../../hooks/useErrorMessage.js'
 import { InputLabel } from '../InputLabel'
 import zipInputValidator from '../../../validators/ZipInputValidator'
+import styles from '../TextInput/TextInput.module.scss'
+import errorStyles from '../Errors.module.scss'
 
 export const ZipInput = (props) => {
   const {
@@ -63,6 +65,13 @@ export const ZipInput = (props) => {
     doValidation(ev.target.value, touched)
   }
 
+
+  const getClasses = () => {
+    return !!getError() ?
+      `ZipInput ${styles.TextInput} ${errorStyles.Error}` :
+      `ZipInput ${styles.TextInput}`
+  }
+
   return (
     <>
       <InputLabel name={name} labelCopy={labelCopy} allCaps={allCaps} />
@@ -74,9 +83,7 @@ export const ZipInput = (props) => {
         onBlur={onBlur}
         onChange={onChange}
         name={props.name}
-        className={
-          !!getError() ? 'ZipInput TextInput Error' : 'ZipInput TextInput'
-        }
+        className={getClasses()}
         keepCharPositions={true}
       />
       {getError()}

--- a/src/components/design-system.css
+++ b/src/components/design-system.css
@@ -1231,10 +1231,3 @@ a,
 .flex-shrink-0 {
   flex-shrink: 0;
 }
-
-.Error,
-.Error:focus {
-  border-color: var(--BrandSunburn);
-  border-width: 1px;
-  border-style: solid;
-}

--- a/src/components/design-system.css
+++ b/src/components/design-system.css
@@ -1232,43 +1232,6 @@ a,
   flex-shrink: 0;
 }
 
-.TextInput {
-  font-size: 19px;
-  line-height: 1.26316;
-  width: 100%;
-  font-family: var(--Theinhardt-font-stack);
-  box-sizing: border-box;
-  background-color: var(--White);
-  border-style: solid;
-  border-width: 1px;
-  border-color: var(--GrayStrokeAndDisabled--translucent);
-  padding: 17px 16px 13px;
-  color: var(--GrayPrimary--opaque);
-  border-radius: 0;
-  transition: border-color 250ms ease;
-  outline: 0;
-  margin: 0;
-}
-
-.TextInput:hover {
-  background-color: var(--GrayLightHover--translucent);
-}
-
-.TextInput:focus {
-  border-color: var(--GrayPrimary--opaque);
-  background-color: var(--White);
-}
-
-.TextInput::placeholder {
-  color: var(--GrayStrokeAndDisabled--opaque);
-}
-
-.TextInput:disabled {
-  color: var(--White);
-  background-color: var(--GrayStrokeAndDisabled--translucent);
-  border-color: transparent;
-}
-
 .Error,
 .Error:focus {
   border-color: var(--BrandSunburn);

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -17,5 +17,4 @@
 @import './UniversalNavbar/TransformingBurgerButton/TransformingBurgerButton.scss';
 @import './UniversalNavbar/globals-for-cms.scss';
 
-@import './Inputs/TextInput/TextInput';
 @import './Inputs/Errors';

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -16,5 +16,3 @@
 @import './UniversalNavbar/UniversalNavbar.scss';
 @import './UniversalNavbar/TransformingBurgerButton/TransformingBurgerButton.scss';
 @import './UniversalNavbar/globals-for-cms.scss';
-
-@import './Inputs/Errors';


### PR DESCRIPTION
…esign-system.css

**Description:**
- [Asana Task](https://app.asana.com/0/1137984670709817/1143741730422930/f)
- Convert TextInput to use CSS Modules. BirthdateInput and ZipInput utilize TextInput's CSS, so those too become CSS Modules compatible as well indirectly 🙌 
- Converts Error.scss to Error.module.scss--it too is only used by TextInput for inline field hint errors


**Referencing PR or Branch (e.g. in CMS or monorepo):**
- 


**Screenshots:**

![image](https://user-images.githubusercontent.com/142403/66627461-a9f9c280-ebb0-11e9-8423-3562ba6c6a45.png)


![image](https://user-images.githubusercontent.com/142403/66627486-b41bc100-ebb0-11e9-9aab-1ba36d3433b7.png)

![image](https://user-images.githubusercontent.com/142403/66627499-bc73fc00-ebb0-11e9-9faf-1af9846ff069.png)
