### PR TITLE
Text masked input

### DIFF
--- a/src/components/Inputs/ButtonSelectGroup/__snapshots__/ButtonSelectGroup.test.js.snap
+++ b/src/components/Inputs/ButtonSelectGroup/__snapshots__/ButtonSelectGroup.test.js.snap
@@ -7,7 +7,7 @@ exports[`ButtonSelectGroup The ButtonSelectGroup renders (default button style, 
   role="radiogroup"
 >
   <span
-    className="Caption Theinhardt Medium500 GrayPrimary AllCaps"
+    className="Caption Theinhardt Medium500 GrayPrimary"
     id="button-select-group-1"
   >
     options
@@ -56,7 +56,7 @@ exports[`ButtonSelectGroup The ButtonSelectGroup renders (default button style, 
   role="radiogroup"
 >
   <span
-    className="Caption Theinhardt Medium500 GrayPrimary AllCaps"
+    className="Caption Theinhardt Medium500 GrayPrimary"
     id="button-select-group-1"
   >
     options
@@ -105,7 +105,7 @@ exports[`ButtonSelectGroup The ButtonSelectGroup renders (white button style) 1`
   role="radiogroup"
 >
   <span
-    className="Caption Theinhardt Medium500 GrayPrimary AllCaps"
+    className="Caption Theinhardt Medium500 GrayPrimary"
     id="button-select-group-1"
   >
     options

--- a/src/components/Inputs/InputLabel.js
+++ b/src/components/Inputs/InputLabel.js
@@ -42,7 +42,7 @@ export function InputLabel({
       <Caption.Medium500
         element={element}
         color={COLORS.GRAY_PRIMARY}
-        allCaps={true} // WIP these should be consistent...
+        allCaps={allCaps}
         {...nameOrIdProps}
       >
         {labelCopy}

--- a/src/components/Inputs/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/Inputs/TextMaskedInput/TextMaskedInput.js
@@ -1,0 +1,103 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import MaskedInput from 'react-text-mask'
+import useErrorMessage from '../../../hooks/useErrorMessage.js'
+import useInputValidation from '../../../hooks/useInputValidation.js'
+import restrict from '../../../helpers/restrict.js'
+import { InputLabel } from '../InputLabel'
+import { cleanse } from '../../../validators/BirthdateInputValidator'
+
+import styles from '../TextInput/TextInput.module.scss'
+import errorStyles from '../Errors.module.scss'
+
+export const TextMaskedInput = (props) => {
+  const {
+    name,
+    labelCopy,
+    allCaps,
+    validator,
+    formChangeHandler,
+    ...restProps
+  } = props
+
+  const [getError, setError, validate] = useErrorMessage(validator)
+  const [value, setValue] = useState('')
+  const [touched, setTouched] = useState(false)
+  const [doValidation] = useInputValidation({validate, setError, formChangeHandler})
+
+  const onChange = (ev) => {
+    const val = event.target.value
+    const restrictedVal = restrict(val)
+    setValue(restrictedVal)
+
+    // Used to remove mask characters e.g. abc___ becomes just abc
+    const cleansed = cleanse(restrictedVal)
+
+    doValidation(cleansed, touched)
+  }
+
+  const onBlur = (ev) => {
+    // We set touched to change the react state, but it's async and
+    // processing still, so, we use a flag for doValidation
+    setTouched(true)
+    doValidation(ev.target.value, true)
+  }
+
+  const onPaste = (ev) => {
+    const val = ev.clipboardData.getData('text/plain')
+    const restrictedVal = restrict(val)
+    // Used to remove mask characters e.g. abc___ becomes just abc
+    const cleansed = cleanse(restrictedVal)
+    setValue(cleansed)
+  }
+
+  const getClasses = () => {
+    return !!getError() ?
+      `TextMaskedInput ${styles.TextInput} ${errorStyles.Error}` :
+      `TextMaskedInput ${styles.TextInput}`
+  }
+
+  return (
+    <>
+      <InputLabel name={name} labelCopy={labelCopy} allCaps={allCaps} />
+      <MaskedInput
+        mask={props.mask}
+        type={props.type}
+        data-tid={restProps['data-tid']}
+        guide={props.guide}
+        onBlur={onBlur}
+        onChange={onChange}
+        name={props.name}
+        className={getClasses()}
+        disabled={props.disabled}
+        keepCharPositions={props.keepCharPositions}
+      />
+      {getError()}
+    </>
+  )
+}
+
+TextMaskedInput.PUBLIC_PROPS = {
+  mask: PropTypes.array.isRequired,
+  guide: PropTypes.bool,
+  keepCharPositions: PropTypes.bool,
+  type: PropTypes.string.isRequired,
+  'data-tid': PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  allCaps: PropTypes.bool,
+  name: PropTypes.string.isRequired,
+  labelCopy: PropTypes.string.isRequired,
+  validator: PropTypes.func,
+}
+
+TextMaskedInput.propTypes = {
+  ...TextMaskedInput.PUBLIC_PROPS,
+}
+
+TextMaskedInput.defaultProps = {
+  guide: true,
+  keepCharPositions: true,
+  disabled: false,
+  allCaps: false,
+}
+

--- a/src/components/Inputs/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/Inputs/TextMaskedInput/TextMaskedInput.js
@@ -40,7 +40,9 @@ export const TextMaskedInput = (props) => {
     // We set touched to change the react state, but it's async and
     // processing still, so, we use a flag for doValidation
     setTouched(true)
-    doValidation(ev.target.value, true)
+    const val = ev.target.value
+    const cleansed = cleanse(val)
+    doValidation(cleansed, true)
   }
 
   const onPaste = (ev) => {
@@ -61,16 +63,17 @@ export const TextMaskedInput = (props) => {
     <>
       <InputLabel name={name} labelCopy={labelCopy} allCaps={allCaps} />
       <MaskedInput
-        mask={props.mask}
-        type={props.type}
+        mask={restProps.mask}
+        type={restProps.type}
         data-tid={restProps['data-tid']}
-        guide={props.guide}
+        guide={restProps.guide}
         onBlur={onBlur}
         onChange={onChange}
         name={props.name}
+        placeholder={restProps.placeholder}
         className={getClasses()}
-        disabled={props.disabled}
-        keepCharPositions={props.keepCharPositions}
+        disabled={restProps.disabled}
+        keepCharPositions={restProps.keepCharPositions}
       />
       {getError()}
     </>
@@ -78,6 +81,7 @@ export const TextMaskedInput = (props) => {
 }
 
 TextMaskedInput.PUBLIC_PROPS = {
+  placeholder: PropTypes.string,
   mask: PropTypes.array.isRequired,
   guide: PropTypes.bool,
   keepCharPositions: PropTypes.bool,
@@ -95,6 +99,7 @@ TextMaskedInput.propTypes = {
 }
 
 TextMaskedInput.defaultProps = {
+  placeholder: '',
   guide: true,
   keepCharPositions: true,
   disabled: false,

--- a/src/components/Inputs/TextMaskedInput/TextMaskedInput.md
+++ b/src/components/Inputs/TextMaskedInput/TextMaskedInput.md
@@ -1,27 +1,3 @@
-```jsx
-// formChangeHandler gets wired up automatically if using <Form /> component
-const formChangeHandlerStub = () => {}
-
-;<TextMaskedInput
-  mask={[/a/, /b/, /c/, /d/, /e/]}
-  guide={true}
-  keepCharPositions={true}
-  type='text'
-  allCaps={false}
-  formChangeHandler={formChangeHandlerStub}
-  name="le-masked"
-  labelCopy="Masked Input Example—only 'a' 'b' 'c' 'd' 'e' in that order allowed"
-  data-tid="the-masked-input"
-  validator={(x) => {
-    if (/a{1}b{1}c{1}d{1}e{1}/.test(x)) {
-      return ''
-    } else {
-      return "It's gotta be 'abcde'"
-    }
-  }}
-/>
-```
-
 Last 4 SSN Example
 
 ```jsx
@@ -38,5 +14,32 @@ const formChangeHandlerStub = () => {}
   labelCopy="Last 4 SSN Example"
   data-tid="last4-ssn-example"
   validator={(value) => value && value.length === 4 ? '' : 'Four digits required'}
+/>
+```
+
+Customize the map to your specific use case
+
+```jsx
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+
+;<TextMaskedInput
+  mask={[/a/, /b/, /c/, /d/, /e/]}
+  placeholder="abcde"
+  guide={true}
+  keepCharPositions={true}
+  type='text'
+  allCaps={false}
+  formChangeHandler={formChangeHandlerStub}
+  name="le-masked"
+  labelCopy="Masked Input Example—only 'a' 'b' 'c' 'd' 'e' in that order allowed"
+  data-tid="the-masked-input"
+  validator={(x) => {
+    if (/a{1}b{1}c{1}d{1}e{1}/.test(x)) {
+      return ''
+    } else {
+      return "It's gotta be 'abcde'"
+    }
+  }}
 />
 ```

--- a/src/components/Inputs/TextMaskedInput/TextMaskedInput.md
+++ b/src/components/Inputs/TextMaskedInput/TextMaskedInput.md
@@ -21,3 +21,24 @@ const formChangeHandlerStub = () => {}
   }}
 />
 ```
+
+Last 4 SSN Example
+
+```jsx
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+
+;<TextMaskedInput
+  mask={[/\d/, /\d/, /\d/, /\d/]}
+  guide={true}
+  keepCharPositions={true}
+  type='text'
+  formChangeHandler={formChangeHandlerStub}
+  name="last4-ssn"
+  labelCopy="Last 4 SSN Example"
+  data-tid="last4-ssn-example"
+  validator={(x) => {
+    return ''
+  }}
+/>
+```

--- a/src/components/Inputs/TextMaskedInput/TextMaskedInput.md
+++ b/src/components/Inputs/TextMaskedInput/TextMaskedInput.md
@@ -27,8 +27,8 @@ Last 4 SSN Example
 ```jsx
 // formChangeHandler gets wired up automatically if using <Form /> component
 const formChangeHandlerStub = () => {}
-
 ;<TextMaskedInput
+  placeholder="0000"
   mask={[/\d/, /\d/, /\d/, /\d/]}
   guide={true}
   keepCharPositions={true}
@@ -37,8 +37,6 @@ const formChangeHandlerStub = () => {}
   name="last4-ssn"
   labelCopy="Last 4 SSN Example"
   data-tid="last4-ssn-example"
-  validator={(x) => {
-    return ''
-  }}
+  validator={(value) => value && value.length === 4 ? '' : 'Four digits required'}
 />
 ```

--- a/src/components/Inputs/TextMaskedInput/TextMaskedInput.md
+++ b/src/components/Inputs/TextMaskedInput/TextMaskedInput.md
@@ -1,0 +1,23 @@
+```jsx
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+
+;<TextMaskedInput
+  mask={[/a/, /b/, /c/, /d/, /e/]}
+  guide={true}
+  keepCharPositions={true}
+  type='text'
+  allCaps={false}
+  formChangeHandler={formChangeHandlerStub}
+  name="le-masked"
+  labelCopy="Masked Input Example—only 'a' 'b' 'c' 'd' 'e' in that order allowed"
+  data-tid="the-masked-input"
+  validator={(x) => {
+    if (/a{1}b{1}c{1}d{1}e{1}/.test(x)) {
+      return ''
+    } else {
+      return "It's gotta be 'abcde'"
+    }
+  }}
+/>
+```

--- a/src/components/Inputs/TextMaskedInput/index.js
+++ b/src/components/Inputs/TextMaskedInput/index.js
@@ -1,1 +1,1 @@
-export { TextMakedInput } from './TextMaskedInput.js'
+export { TextMaskedInput } from './TextMaskedInput.js'

--- a/src/components/Inputs/TextMaskedInput/index.js
+++ b/src/components/Inputs/TextMaskedInput/index.js
@@ -1,0 +1,1 @@
+export { TextMakedInput } from './TextMaskedInput.js'

--- a/src/components/Inputs/ZipInput/ZipInput.js
+++ b/src/components/Inputs/ZipInput/ZipInput.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import MaskedInput from 'react-text-mask'
+import { TextMaskedInput } from '../TextMaskedInput'
 import useErrorMessage from '../../../hooks/useErrorMessage.js'
 import useInputValidation from '../../../hooks/useInputValidation.js'
 import { InputLabel } from '../InputLabel'
@@ -60,10 +60,11 @@ export const ZipInput = (props) => {
 
   return (
     <>
-      <InputLabel name={name} labelCopy={labelCopy} allCaps={allCaps} />
-      <MaskedInput
+      <TextMaskedInput
         mask={[/\d/, /\d/, /\d/, /\d/, /\d/]}
         type="tel"
+        labelCopy={labelCopy}
+        allCaps={allCaps}
         data-tid={restProps['data-tid']}
         guide={true}
         onBlur={onBlur}

--- a/src/components/Inputs/ZipInput/__snapshots__/ZipInput.test.js.snap
+++ b/src/components/Inputs/ZipInput/__snapshots__/ZipInput.test.js.snap
@@ -17,8 +17,9 @@ Array [
     }
   />,
   <input
-    className="ZipInput TextInput"
+    className="TextMaskedInput TextInput"
     data-tid="le-zip"
+    disabled={false}
     guide={true}
     keepCharPositions={true}
     mask={
@@ -33,8 +34,10 @@ Array [
     name="le-zip"
     onBlur={[Function]}
     onChange={[Function]}
+    placeholder=""
     type="tel"
   />,
+  "",
   "",
 ]
 `;


### PR DESCRIPTION
## should go in after https://github.com/getethos/ethos-design-system/pull/67 

**Description:**
- [Asana Task](https://app.asana.com/0/1137984670709817/1144545266811009/f)
- TextMaskedInput
    Creates a TextMaskedInput component primitive so we can build arbitrarily masked inputs.

Here's an example for Last 4 digits of SSN (this will replace [Last4SsnInput](https://github.com/getethos/ethos/pull/1361/files#diff-d14fb078b45fd1a5fdab5b30852be282R1):

![image](https://user-images.githubusercontent.com/142403/66710740-52379480-ed33-11e9-8c62-e0b48c80df22.png)

![image](https://user-images.githubusercontent.com/142403/66710745-624f7400-ed33-11e9-8c3a-140d669566ed.png)


Here's the other example I have:

![image](https://user-images.githubusercontent.com/142403/66710098-7e98e400-ed26-11e9-8fbc-3fb61cd70df1.png)


![image](https://user-images.githubusercontent.com/142403/66710102-8a84a600-ed26-11e9-9600-b70987e49143.png)

![image](https://user-images.githubusercontent.com/142403/66710106-a4be8400-ed26-11e9-91fe-04eeb828ce79.png)

Now also using this from ZipInput which is delegating to TextMaskedInput:

![image](https://user-images.githubusercontent.com/142403/66711027-bd379a00-ed38-11e9-90a3-afc5ae2e4b47.png)

![image](https://user-images.githubusercontent.com/142403/66711029-ca548900-ed38-11e9-9b99-9415fc9dfb20.png)
