### PR TITLE
another all caps false that should be true

### DIFF
--- a/src/components/Inputs/ButtonSelectGroup/ButtonSelectGroup.js
+++ b/src/components/Inputs/ButtonSelectGroup/ButtonSelectGroup.js
@@ -43,7 +43,7 @@ export const ButtonSelectGroup = ({
   onSelect,
   formChangeHandler,
   name = `button-select-group-${uuidv4()}`,
-  allCaps = false,
+  allCaps = true,
   buttonStyle = 'default',
   validator,
   ...rest

--- a/src/components/Inputs/ButtonSelectGroup/__snapshots__/ButtonSelectGroup.test.js.snap
+++ b/src/components/Inputs/ButtonSelectGroup/__snapshots__/ButtonSelectGroup.test.js.snap
@@ -8,7 +8,7 @@ Array [
     role="radiogroup"
   >
     <span
-      className="Caption Theinhardt Medium500 GrayPrimary"
+      className="Caption Theinhardt Medium500 GrayPrimary AllCaps"
       id="button-select-group-1"
     >
       options
@@ -60,7 +60,7 @@ Array [
     role="radiogroup"
   >
     <span
-      className="Caption Theinhardt Medium500 GrayPrimary"
+      className="Caption Theinhardt Medium500 GrayPrimary AllCaps"
       id="button-select-group-1"
     >
       options
@@ -112,7 +112,7 @@ Array [
     role="radiogroup"
   >
     <span
-      className="Caption Theinhardt Medium500 GrayPrimary"
+      className="Caption Theinhardt Medium500 GrayPrimary AllCaps"
       id="button-select-group-1"
     >
       options


### PR DESCRIPTION
We found one more case of incorrect `allCaps` being `false`. This is for: https://github.com/getethos/cms/pull/1958
