### PR TITLE
ButtonSelectGroup now has a fullWidth prop, defaults to true

### DIFF
--- a/src/components/Inputs/ButtonSelectGroup/ButtonGroup.module.scss
+++ b/src/components/Inputs/ButtonSelectGroup/ButtonGroup.module.scss
@@ -1,14 +1,18 @@
-.buttonGroup {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-evenly;
-}
-
 // Button.Stateful is no longer available w/CSS Modules but
 // it's always such a button if you look at component JSX
 .buttonGroup > button {
-  width: 100%;
   margin-right: var(--Space-8);
+}
+
+// fullWidth is default.
+.buttonGroup.fullWidth {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  width: 100%;
+  & > button {
+    width: 100%;
+  }
 }
 
 .buttonGroup > button:last-child {

--- a/src/components/Inputs/ButtonSelectGroup/ButtonSelectGroup.js
+++ b/src/components/Inputs/ButtonSelectGroup/ButtonSelectGroup.js
@@ -46,6 +46,7 @@ export const ButtonSelectGroup = ({
   allCaps = false,
   buttonStyle = 'default',
   validator,
+  fullWidth = true,
   ...rest
 }) => {
   const [selectedValue, setSelectedValue] = useState(initialValue)
@@ -107,6 +108,9 @@ export const ButtonSelectGroup = ({
     })
   })
 
+  const optionsContainerClassNames = [styles.buttonGroup]
+  if (fullWidth) optionsContainerClassNames.push(styles.fullWidth)
+
   // Use id to connect label and this pseudo-input because of aria-labelledby
   return (
     <>
@@ -122,7 +126,7 @@ export const ButtonSelectGroup = ({
           labelCopy={labelCopy}
           allCaps={allCaps}
         />
-        <div className={styles.buttonGroup}>{options}</div>
+        <div className={optionsContainerClassNames.join(' ')}>{options}</div>
       </div>
       {getError()}
     </>
@@ -147,6 +151,8 @@ ButtonSelectGroup.propTypes = {
   /** Optional data-tid used as a unique id for targeting test selectors */
   'data-tid': PropTypes.string,
   validator: PropTypes.func,
+  /** Optional, makes the group width 100%. Defaults to true */
+  fullWidth: PropTypes.bool,
 }
 
 // Export the option button

--- a/src/components/Inputs/ButtonSelectGroup/ButtonSelectGroup.md
+++ b/src/components/Inputs/ButtonSelectGroup/ButtonSelectGroup.md
@@ -110,3 +110,15 @@ import { OPTION_BUTTON_STYLES } from './index.js'
   </ButtonSelectGroup>
 </div>
 ```
+
+### Group when `fullWidth` is false
+
+```jsx
+<ButtonSelectGroup fullWidth={false} labelCopy="Health">
+  <ButtonSelectGroup.Option value="average">Average</ButtonSelectGroup.Option>
+  <ButtonSelectGroup.Option value="great">Great</ButtonSelectGroup.Option>
+  <ButtonSelectGroup.Option value="excellent">
+    Exellent
+  </ButtonSelectGroup.Option>
+</ButtonSelectGroup>
+```

--- a/src/components/Inputs/ButtonSelectGroup/__snapshots__/ButtonSelectGroup.test.js.snap
+++ b/src/components/Inputs/ButtonSelectGroup/__snapshots__/ButtonSelectGroup.test.js.snap
@@ -22,7 +22,7 @@ Array [
       }
     />
     <div
-      className="buttonGroup"
+      className="buttonGroup fullWidth"
     >
       <button
         className="Button Medium Stateful"
@@ -74,7 +74,7 @@ Array [
       }
     />
     <div
-      className="buttonGroup"
+      className="buttonGroup fullWidth"
     >
       <button
         className="Button Medium Stateful"
@@ -126,7 +126,7 @@ Array [
       }
     />
     <div
-      className="buttonGroup"
+      className="buttonGroup fullWidth"
     >
       <button
         className="Button Medium Stateful White"


### PR DESCRIPTION
Needed for unum forms

![x](https://i.gyazo.com/c2e4239f0c509550b6170d122b2a81e1.png)

Defaults to true so existing button groups should be unaffected. 