### PR TITLE
[Don't merge] Dynamic form examples

### DIFF
--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -69,6 +69,8 @@ export function Form({ children, config }) {
     setFormErrorMessage,
     getFormIsValid,
     getFormInteractedWith,
+    resetFormState,
+    debugEntireFormState, // REMOVE
   ] = useFormState(initialValues)
 
   // Wrapper for default <form> submit function.
@@ -92,6 +94,18 @@ export function Form({ children, config }) {
     try {
       // Pass the form's values to whatever config.onSubmit wants to do
       await config.onSubmit(getFieldValues())
+
+      // If the appropriate config value is passed in,
+      // After form data has been used, reset it to the new default.
+      if (config.resetFormOnSubmit) {
+        alert(JSON.stringify(config.fields))
+        let newInitialValues = {}
+        Object.keys(config.fields).forEach((x) => {
+          newInitialValues[x] = `Initial invalid state for ${x}`
+        })
+
+        resetFormState(newInitialValues)
+      }
     } catch (e) {
       setFormErrorMessage(e.toString())
     }
@@ -154,7 +168,6 @@ export function Form({ children, config }) {
       // if multiple validators fail, their errors will be combined together.
       validator: doValidation,
 
-
       // data-tid is helpful for writing tests.
       // sometimes it's passed in, but if it isn't,
       // we will automatically generate one
@@ -186,6 +199,7 @@ export function Form({ children, config }) {
         getFormErrorMessage,
         getFormIsValid,
         getFormInteractedWith,
+        debugEntireFormState, // REMOVE
       })}
     </form>
   )

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -69,7 +69,6 @@ export function Form({ children, config }) {
     setFormErrorMessage,
     getFormIsValid,
     getFormInteractedWith,
-    resetFormState,
     debugEntireFormState, // REMOVE
   ] = useFormState(initialValues)
 
@@ -94,18 +93,6 @@ export function Form({ children, config }) {
     try {
       // Pass the form's values to whatever config.onSubmit wants to do
       await config.onSubmit(getFieldValues())
-
-      // If the appropriate config value is passed in,
-      // After form data has been used, reset it to the new default.
-      if (config.resetFormOnSubmit) {
-        alert(JSON.stringify(config.fields))
-        let newInitialValues = {}
-        Object.keys(config.fields).forEach((x) => {
-          newInitialValues[x] = `Initial invalid state for ${x}`
-        })
-
-        resetFormState(newInitialValues)
-      }
     } catch (e) {
       setFormErrorMessage(e.toString())
     }

--- a/src/components/Form/Form.md
+++ b/src/components/Form/Form.md
@@ -1,5 +1,5 @@
 ```jsx
-import validateTruthy from '../../validators/validateTruthy'
+import validateExists from '../../validators/validateExists'
 import validateMinMaxFactory from '../../validators/validateMinMax'
 import {
   TitleLarge,
@@ -49,7 +49,7 @@ const analyticsCustomEvent = (fieldName, fieldValue) => {
           return <TextInput {...props} />
         },
         validators: [
-          validateTruthy,
+          validateExists,
           validateCustom,
           validateMinMaxFactory.call(null, 5, 7),
         ],
@@ -63,7 +63,7 @@ const analyticsCustomEvent = (fieldName, fieldValue) => {
           return <TextInput {...props} />
         },
         validators: [
-          validateTruthy,
+          validateExists,
           validateCustom,
           validateMinMaxFactory.call(null, 3, 5),
         ],
@@ -138,7 +138,6 @@ const analyticsCustomEvent = (fieldName, fieldValue) => {
 _Note that we've set up the form submission to randomly fail or succeed—so, you're encouraged to resubmit until you've seen both!_
 
 ```jsx
-import validateTruthy from '../../validators/validateTruthy'
 import validateExists from '../../validators/validateExists'
 import dayjs from '../../helpers/getDayjs.js'
 import { validateMinMaxDateFactory } from '../../validators/BirthdateInputValidator'
@@ -229,7 +228,7 @@ const maxAge = 65
         // Note that Birthdate will only call these validators once it's own
         // internal validation passes e.g. there's a date string in valid format
         validators: [
-          validateTruthy,
+          validateExists,
           validateMinMaxDateFactory({
             minAge,
             maxAge,
@@ -355,9 +354,10 @@ const maxAge = 65
 ```
 
 ```jsx
-import validateTruthy from '../../validators/validateTruthy'
+import validateExists from '../../validators/validateExists'
 import {
   TitleLarge,
+  TitleSmall,
   TextInput,
   Spacer,
   Button,
@@ -374,15 +374,17 @@ import {
         component: (props, options) => {
           return <TextInput {...props} />
         },
-        validators: [validateTruthy],
-        labelCopy: 'Validator: `validateTruthy`',
+        validators: [validateExists],
+        labelCopy: 'Validator: `validateExists`',
         tid: 'example-data-tid',
       },
       noValidator: {
         component: (props, options) => {
           return <TextInput {...props} />
         },
-        labelCopy: 'No validators supplied',
+        labelCopy:
+          'No validators supplied, but you still have to focus and blur. ' +
+          'Functionally identical to the above component!',
         tid: 'example-data-tid',
       },
     },
@@ -398,74 +400,14 @@ import {
     return (
       <div>
         <TitleLarge.Serif.Book500>
-          Form with a field without a validator (Possibly bad)
+          Form with a field without a validator
         </TitleLarge.Serif.Book500>
 
         <Spacer.H16 />
 
-        {field('anything')}
-
-        <Spacer.H16 />
-
-        {field('noValidator')}
-
-        <Spacer.H16 />
-
-        <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
-          Submit
-        </Button.Medium.Black>
-      </div>
-    )
-  }}
-</Form>
-```
-
-```jsx
-import validateTruthy from '../../validators/validateTruthy'
-import {
-  TitleLarge,
-  TextInput,
-  Spacer,
-  Button,
-  InfoMessage,
-  ZipInput,
-} from '../index'
-;<Form
-  config={{
-    formName: 'Styleguidist example form',
-    autocompleteOff: true,
-    formId: '1',
-    fields: {
-      anything: {
-        component: (props, options) => {
-          return <TextInput {...props} />
-        },
-        validators: [validateTruthy],
-        labelCopy: 'Validator: `validateTruthy`',
-        tid: 'example-data-tid',
-      },
-      noValidator: {
-        component: (props, options) => {
-          return <TextInput {...props} />
-        },
-        labelCopy: 'No validators supplied',
-        tid: 'example-data-tid',
-      },
-    },
-    onSubmit: async (formData) => {
-      alert(
-        'form submission successful with values:' + JSON.stringify(formData)
-      )
-    },
-  }}
->
-  {(api) => {
-    const { field, getFormIsValid } = api
-    return (
-      <div>
-        <TitleLarge.Serif.Book500>
-          Form with a field without a validator (Possibly bad)
-        </TitleLarge.Serif.Book500>
+        <TitleSmall.Serif.Book500>
+          Is this the behavior we want?
+        </TitleSmall.Serif.Book500>
 
         <Spacer.H16 />
 
@@ -489,7 +431,7 @@ import {
 ```jsx
 import { useState } from 'react'
 import { TestFormWrapper } from './TestFormWrapper.js'
-import validateTruthy from '../../validators/validateTruthy'
+import validateExists from '../../validators/validateExists'
 import {
   TitleLarge,
   TitleSmall,

--- a/src/components/Form/Form.md
+++ b/src/components/Form/Form.md
@@ -37,157 +37,84 @@ const questionNames = ['one', 'two'] // same as keys in questionGroups
 
 ;<TestFormWrapper>
   {({ count, setCount }) => {
-    if (count === 0) {
-      return (
-        <Form
-          config={{
-            formName: 'Styleguidist example form',
-            autocompleteOff: true,
-            formId: '1',
-            autocompleteOff: true,
-            fields: questionGroups[0],
-            resetFormOnSubmit: true,
-            onSubmit: async (formData) => {
-              if (count === 0) {
-                // Go to the next set of questions
-                setCount(count + 1)
-              } else {
-                // Submit the form -- it will actually still have formData
-                // from the first set of questions, too
-                alert(
-                  'form submission successful with values:' +
-                    JSON.stringify(formData)
-                )
-              }
-            },
-          }}
-        >
-          {(api) => {
-            const {
-              field,
-              getFormIsValid,
-              debugEntireFormState, // REMOVE
-            } = api
-            return (
+    const form = (
+      <Form
+        config={{
+          formName: 'Styleguidist example form',
+          formId: '1',
+          autocompleteOff: true,
+          fields: questionGroups[count],
+          onSubmit: async (formData) => {
+            if (count === 0) {
+              // Go to the next set of questions
+              setCount(count + 1)
+            } else {
+              // Submit the form -- it will actually still have formData
+              // from the first set of questions, too
+              alert(
+                'form submission successful with values:' +
+                  JSON.stringify(formData)
+              )
+            }
+          },
+        }}
+      >
+        {(api) => {
+          const {
+            field,
+            getFormIsValid,
+            debugEntireFormState, // REMOVE
+          } = api
+          return (
+            <div>
+              <TitleLarge.Serif.Book500>
+                Form with dynamically changing questions. Form #{count}
+              </TitleLarge.Serif.Book500>
+
+              <Spacer.H16 />
+
+              {field(questionNames[count])}
+
+              <Spacer.H16 />
+
+              <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
+                Submit
+              </Button.Medium.Black>
               <div>
-                <TitleLarge.Serif.Book500>
-                  Form with dynamically changing questions. Form #{count}
-                </TitleLarge.Serif.Book500>
-
-                <Spacer.H16 />
-
-                {field(questionNames[count])}
-
-                <Spacer.H16 />
-
-                <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
-                  Submit
-                </Button.Medium.Black>
-                <div>
-                  <code>
-                    {' '}
-                    fieldErrorsState:{' '}
-                    {JSON.stringify(
-                      debugEntireFormState().fieldErrorsState
-                    )}{' '}
-                  </code>
-                </div>
-                <div>
-                  <code>
-                    {' '}
-                    fieldValuesState:{' '}
-                    {JSON.stringify(
-                      debugEntireFormState().fieldValuesState
-                    )}{' '}
-                  </code>
-                </div>
-                <div>
-                  <code>
-                    formErrorState:{' '}
-                    {JSON.stringify(debugEntireFormState().formErrorState)}{' '}
-                  </code>
-                </div>
+                <code>
+                  {' '}
+                  fieldErrorsState:{' '}
+                  {JSON.stringify(debugEntireFormState().fieldErrorsState)}{' '}
+                </code>
               </div>
-            )
-          }}
-        </Form>
-      )
-    } else {
-      return (
-        <Form
-          config={{
-            formName: 'Styleguidist example form',
-            autocompleteOff: true,
-            formId: '1',
-            autocompleteOff: true,
-            fields: questionGroups[1],
-            resetFormOnSubmit: true,
-            onSubmit: async (formData) => {
-              if (count === 0) {
-                // Go to the next set of questions
-                setCount(count + 1)
-              } else {
-                // Submit the form -- it will actually still have formData
-                // from the first set of questions, too
-                alert(
-                  'form submission successful with values:' +
-                    JSON.stringify(formData)
-                )
-              }
-            },
-          }}
-        >
-          {(api) => {
-            const {
-              field,
-              getFormIsValid,
-              debugEntireFormState, // REMOVE
-            } = api
-            return (
               <div>
-                <TitleLarge.Serif.Book500>
-                  Form with dynamically changing questions. Form #{count}
-                </TitleLarge.Serif.Book500>
-
-                <Spacer.H16 />
-
-                {field(questionNames[count])}
-
-                <Spacer.H16 />
-
-                <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
-                  Submit
-                </Button.Medium.Black>
-                <div>
-                  <code>
-                    {' '}
-                    fieldErrorsState:{' '}
-                    {JSON.stringify(
-                      debugEntireFormState().fieldErrorsState
-                    )}{' '}
-                  </code>
-                </div>
-                <div>
-                  <code>
-                    {' '}
-                    fieldValuesState:{' '}
-                    {JSON.stringify(
-                      debugEntireFormState().fieldValuesState
-                    )}{' '}
-                  </code>
-                </div>
-                <div>
-                  <code>
-                    formErrorState:{' '}
-                    {JSON.stringify(debugEntireFormState().formErrorState)}{' '}
-                  </code>
-                </div>
+                <code>
+                  {' '}
+                  fieldValuesState:{' '}
+                  {JSON.stringify(debugEntireFormState().fieldValuesState)}{' '}
+                </code>
               </div>
-            )
-          }}
-        </Form>
-      )
+              <div>
+                <code>
+                  formErrorState:{' '}
+                  {JSON.stringify(debugEntireFormState().formErrorState)}{' '}
+                </code>
+              </div>
+            </div>
+          )
+        }}
+      </Form>
+    )
+
+    switch (count) {
+      case 0:
+        return form
+      case 1:
+        return <div>{form}</div>
     }
+    if (count === 0) {
+      return <div>{form}</div>
+    } else if (count === 0) return
   }}
 </TestFormWrapper>
 ```

--- a/src/components/Form/Form.md
+++ b/src/components/Form/Form.md
@@ -1,11 +1,128 @@
 ```jsx
+import { TestFormWrapper } from './TestFormWrapper.js'
+import validateTruthy from '../../validators/validateTruthy'
+import {
+  TitleLarge,
+  TextInput,
+  Spacer,
+  Button,
+  InfoMessage,
+  ZipInput,
+} from '../index'
+
+const questionGroups = [
+  {
+    one: {
+      component: (props, options) => {
+        return <TextInput {...props} />
+      },
+      validators: [validateTruthy],
+      labelCopy: 'Validator: `validateTruthy`',
+      tid: 'example-data-tid',
+    },
+  },
+  {
+    two: {
+      component: (props, options) => {
+        return <TextInput {...props} />
+      },
+      labelCopy: 'No validators supplied',
+      tid: 'example-data-tid',
+    },
+  },
+]
+
+const questionNames = ['one', 'two'] // same as keys in questionGroups
+
+;<TestFormWrapper>
+  {({ count, setCount }) => (
+    <Form
+      config={{
+        formName: 'Styleguidist example form',
+        autocompleteOff: true,
+        formId: '1',
+        autocompleteOff: true,
+        fields: questionGroups[count],
+        resetFormOnSubmit: true,
+        onSubmit: async (formData) => {
+          if (count === 0) {
+            // Go to the next set of questions
+            setCount(count + 1)
+          } else {
+            // Submit the form -- it will actually still have formData
+            // from the first set of questions, too
+            alert(
+              'form submission successful with values:' +
+                JSON.stringify(formData)
+            )
+          }
+        },
+      }}
+    >
+      {(api) => {
+        const {
+          field,
+          getFormIsValid,
+          debugEntireFormState, // REMOVE
+        } = api
+        return (
+          <div>
+            <TitleLarge.Serif.Book500>
+              Form with dynamically changing questions. Form #{count}
+            </TitleLarge.Serif.Book500>
+
+            <Spacer.H16 />
+
+            {field(questionNames[count])}
+
+            <Spacer.H16 />
+
+            <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
+              Submit
+            </Button.Medium.Black>
+            <div>
+              <code>
+                {' '}
+                fieldErrorsState:{' '}
+                {JSON.stringify(debugEntireFormState().fieldErrorsState)}{' '}
+              </code>
+            </div>
+            <div>
+              <code>
+                {' '}
+                fieldValuesState:{' '}
+                {JSON.stringify(debugEntireFormState().fieldValuesState)}{' '}
+              </code>
+            </div>
+            <div>
+              <code>
+                formErrorState:{' '}
+                {JSON.stringify(debugEntireFormState().formErrorState)}{' '}
+              </code>
+            </div>
+          </div>
+        )
+      }}
+    </Form>
+  )}
+</TestFormWrapper>
+```
+
+```jsx
 import validateTruthy from '../../validators/validateTruthy'
 import validateMinMaxFactory from '../../validators/validateMinMax'
-import { TitleLarge, TextInput, Spacer, Button, InfoMessage, ZipInput } from '../index'
+import {
+  TitleLarge,
+  TextInput,
+  Spacer,
+  Button,
+  InfoMessage,
+  ZipInput,
+} from '../index'
 let count = 0
 
 const validateCustom = (x) => {
-  console.log("validateCustom got called...")
+  console.log('validateCustom got called...')
   return !!x ? '' : 'Validate custom error'
 }
 
@@ -14,7 +131,13 @@ const validateCustom = (x) => {
 // Note that it's the consumer's responsibility to keep a table
 // lookup or similar to prevent duplicate tracking of valid fields, etc.
 const analyticsCustomEvent = (fieldName, fieldValue) => {
-  console.log("analyticsCustomEvent got called--field name: ", fieldName, "fieldValue: ", fieldValue, "--means no validation errors, so we'd likely call something like sendAnalyticsEvent(fieldName, fieldValue)")
+  console.log(
+    'analyticsCustomEvent got called--field name: ',
+    fieldName,
+    'fieldValue: ',
+    fieldValue,
+    "--means no validation errors, so we'd likely call something like sendAnalyticsEvent(fieldName, fieldValue)"
+  )
 }
 
 ;<Form
@@ -25,19 +148,21 @@ const analyticsCustomEvent = (fieldName, fieldValue) => {
     fields: {
       zipCode: {
         component: (props, options) => {
-          return (
-            <ZipInput {...props} />
-          )
+          return <ZipInput {...props} />
         },
         validationSuccess: [analyticsCustomEvent],
-        name: "this-zip-input-example",
-        labelCopy: "What is your zip code?",
+        name: 'this-zip-input-example',
+        labelCopy: 'What is your zip code?',
       },
       evenNumText: {
         component: (props, options) => {
           return <TextInput {...props} />
         },
-        validators: [validateTruthy, validateCustom, validateMinMaxFactory.call(null, 5, 7)],
+        validators: [
+          validateTruthy,
+          validateCustom,
+          validateMinMaxFactory.call(null, 5, 7),
+        ],
         validationSuccess: [analyticsCustomEvent],
         labelCopy:
           "Validation happens after first blur ('touched')     Value's length is between 5 and 7 characters",
@@ -47,7 +172,11 @@ const analyticsCustomEvent = (fieldName, fieldValue) => {
         component: (props, options) => {
           return <TextInput {...props} />
         },
-        validators: [validateTruthy, validateCustom, validateMinMaxFactory.call(null, 3, 5)],
+        validators: [
+          validateTruthy,
+          validateCustom,
+          validateMinMaxFactory.call(null, 3, 5),
+        ],
         validationSuccess: [analyticsCustomEvent],
         labelCopy:
           "Validation happens after first blur ('touched')     Value's length is between 3 and 5 characters",
@@ -55,11 +184,12 @@ const analyticsCustomEvent = (fieldName, fieldValue) => {
     },
     onSubmit: async (formData) => {
       if (count++ % 2 === 0) {
-        throw new Error("API Issue (Try again,, it alternates success & failure)")
+        throw new Error(
+          'API Issue (Try again,, it alternates success & failure)'
+        )
       } else {
         alert(
-          'form submission successful with values:' +
-            JSON.stringify(formData)
+          'form submission successful with values:' + JSON.stringify(formData)
         )
       }
     },
@@ -81,7 +211,7 @@ const analyticsCustomEvent = (fieldName, fieldValue) => {
         {!!getFormInteractedWith() && (
           <>
             <InfoMessage.Alert.Success>
-              {"Form interacted with."}
+              {'Form interacted with.'}
             </InfoMessage.Alert.Success>
           </>
         )}
@@ -122,14 +252,21 @@ import validateTruthy from '../../validators/validateTruthy'
 import validateExists from '../../validators/validateExists'
 import dayjs from '../../helpers/getDayjs.js'
 import { validateMinMaxDateFactory } from '../../validators/BirthdateInputValidator'
-import { TitleLarge, TextInput, TextMaskedInput, Spacer, Button, InfoMessage } from '../index'
+import {
+  TitleLarge,
+  TextInput,
+  TextMaskedInput,
+  Spacer,
+  Button,
+  InfoMessage,
+} from '../index'
 import { ButtonSelectGroup } from '../Inputs/ButtonSelectGroup/ButtonSelectGroup'
 import { BirthdateInput } from '../Inputs/BirthdateInput/BirthdateInput'
 let count = 0
 
 function validateIllegal(x) {
-  console.log("validateIllegal: I got called...")
-  return x === 'illegal' ? 'That\'s an illegal option! Choose another.' : ''
+  console.log('validateIllegal: I got called...')
+  return x === 'illegal' ? "That's an illegal option! Choose another." : ''
 }
 
 // This will only be called by the form engine after a field is
@@ -137,7 +274,13 @@ function validateIllegal(x) {
 // Note that it's the consumer's responsibility to keep a table
 // lookup or similar to prevent duplicate tracking of valid fields, etc.
 const analyticsCustomEvent = (fieldName, fieldValue) => {
-  console.log("analyticsCustomEvent got called--field name: ", fieldName, "fieldValue: ", fieldValue, "--means no validation errors, so we'd likely call something like sendAnalyticsEvent(fieldName, fieldValue)")
+  console.log(
+    'analyticsCustomEvent got called--field name: ',
+    fieldName,
+    'fieldValue: ',
+    fieldValue,
+    "--means no validation errors, so we'd likely call something like sendAnalyticsEvent(fieldName, fieldValue)"
+  )
 }
 
 const getMinBirthdateLga = (maxAge) => {
@@ -216,29 +359,23 @@ const maxAge = 65
               mask={[/\d/, /\d/, /\d/, /\d/]}
               guide={true}
               keepCharPositions={true}
-              type='text'
+              type="text"
               name="last4-ssn"
               {...props}
             />
           )
         },
-        labelCopy: 'Last 4 digits of SSN' ,
+        labelCopy: 'Last 4 digits of SSN',
         tid: 'le-ssn',
         validators: [
-          (value) => (
-            value && value.length === 4
-              ? ''
-              : 'Four digits required'
-          )
+          (value) =>
+            value && value.length === 4 ? '' : 'Four digits required',
         ],
       },
       buttonGroup: {
         component: (props, options) => {
           return (
-            <ButtonSelectGroup
-              {...props}
-              intialValue="often"
-            >
+            <ButtonSelectGroup {...props} intialValue="often">
               {options.map((x, i) => (
                 <ButtonSelectGroup.Option value={x.value} key={i}>
                   {x.copy}
@@ -260,11 +397,12 @@ const maxAge = 65
     },
     onSubmit: async (formData) => {
       if (count++ % 2 === 0) {
-        throw new Error("API Issue (Try again,, it alternates success & failure)")
+        throw new Error(
+          'API Issue (Try again,, it alternates success & failure)'
+        )
       } else {
         alert(
-          'form submission successful with values:' +
-            JSON.stringify(formData)
+          'form submission successful with values:' + JSON.stringify(formData)
         )
       }
     },
@@ -288,7 +426,7 @@ const maxAge = 65
         {!!getFormInteractedWith() && (
           <>
             <InfoMessage.Alert.Success>
-              {"Form interacted with."}
+              {'Form interacted with.'}
             </InfoMessage.Alert.Success>
           </>
         )}
@@ -314,6 +452,72 @@ const maxAge = 65
         <Spacer.H16 />
 
         {field('booleanGroup')}
+
+        <Spacer.H16 />
+
+        <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
+          Submit
+        </Button.Medium.Black>
+      </div>
+    )
+  }}
+</Form>
+```
+
+```jsx
+import validateTruthy from '../../validators/validateTruthy'
+import {
+  TitleLarge,
+  TextInput,
+  Spacer,
+  Button,
+  InfoMessage,
+  ZipInput,
+} from '../index'
+;<Form
+  config={{
+    formName: 'Styleguidist example form',
+    autocompleteOff: true,
+    formId: '1',
+    fields: {
+      anything: {
+        component: (props, options) => {
+          return <TextInput {...props} />
+        },
+        validators: [validateTruthy],
+        labelCopy: 'Validator: `validateTruthy`',
+        tid: 'example-data-tid',
+      },
+      noValidator: {
+        component: (props, options) => {
+          return <TextInput {...props} />
+        },
+        labelCopy: 'No validators supplied',
+        tid: 'example-data-tid',
+      },
+    },
+    onSubmit: async (formData) => {
+      alert(
+        'form submission successful with values:' + JSON.stringify(formData)
+      )
+    },
+  }}
+>
+  {(api) => {
+    const { field, getFormIsValid } = api
+    return (
+      <div>
+        <TitleLarge.Serif.Book500>
+          Form with a field without a validator (Possibly bad)
+        </TitleLarge.Serif.Book500>
+
+        <Spacer.H16 />
+
+        {field('anything')}
+
+        <Spacer.H16 />
+
+        {field('noValidator')}
 
         <Spacer.H16 />
 

--- a/src/components/Form/Form.md
+++ b/src/components/Form/Form.md
@@ -16,8 +16,8 @@ const questionGroups = [
       component: (props, options) => {
         return <TextInput {...props} />
       },
-      validators: [validateTruthy],
-      labelCopy: 'Validator: `validateTruthy`',
+      validators: [(x) => (x === 'a' ? '' : 'Must be a')],
+      labelCopy: 'Validator: value must be "a"',
       tid: 'example-data-tid',
     },
   },
@@ -26,7 +26,8 @@ const questionGroups = [
       component: (props, options) => {
         return <TextInput {...props} />
       },
-      labelCopy: 'No validators supplied',
+      validators: [(x) => (x === 'a' ? '' : 'Must be a')],
+      labelCopy: 'Validator: value must be "a" again',
       tid: 'example-data-tid',
     },
   },
@@ -35,76 +36,159 @@ const questionGroups = [
 const questionNames = ['one', 'two'] // same as keys in questionGroups
 
 ;<TestFormWrapper>
-  {({ count, setCount }) => (
-    <Form
-      config={{
-        formName: 'Styleguidist example form',
-        autocompleteOff: true,
-        formId: '1',
-        autocompleteOff: true,
-        fields: questionGroups[count],
-        resetFormOnSubmit: true,
-        onSubmit: async (formData) => {
-          if (count === 0) {
-            // Go to the next set of questions
-            setCount(count + 1)
-          } else {
-            // Submit the form -- it will actually still have formData
-            // from the first set of questions, too
-            alert(
-              'form submission successful with values:' +
-                JSON.stringify(formData)
+  {({ count, setCount }) => {
+    if (count === 0) {
+      return (
+        <Form
+          config={{
+            formName: 'Styleguidist example form',
+            autocompleteOff: true,
+            formId: '1',
+            autocompleteOff: true,
+            fields: questionGroups[0],
+            resetFormOnSubmit: true,
+            onSubmit: async (formData) => {
+              if (count === 0) {
+                // Go to the next set of questions
+                setCount(count + 1)
+              } else {
+                // Submit the form -- it will actually still have formData
+                // from the first set of questions, too
+                alert(
+                  'form submission successful with values:' +
+                    JSON.stringify(formData)
+                )
+              }
+            },
+          }}
+        >
+          {(api) => {
+            const {
+              field,
+              getFormIsValid,
+              debugEntireFormState, // REMOVE
+            } = api
+            return (
+              <div>
+                <TitleLarge.Serif.Book500>
+                  Form with dynamically changing questions. Form #{count}
+                </TitleLarge.Serif.Book500>
+
+                <Spacer.H16 />
+
+                {field(questionNames[count])}
+
+                <Spacer.H16 />
+
+                <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
+                  Submit
+                </Button.Medium.Black>
+                <div>
+                  <code>
+                    {' '}
+                    fieldErrorsState:{' '}
+                    {JSON.stringify(
+                      debugEntireFormState().fieldErrorsState
+                    )}{' '}
+                  </code>
+                </div>
+                <div>
+                  <code>
+                    {' '}
+                    fieldValuesState:{' '}
+                    {JSON.stringify(
+                      debugEntireFormState().fieldValuesState
+                    )}{' '}
+                  </code>
+                </div>
+                <div>
+                  <code>
+                    formErrorState:{' '}
+                    {JSON.stringify(debugEntireFormState().formErrorState)}{' '}
+                  </code>
+                </div>
+              </div>
             )
-          }
-        },
-      }}
-    >
-      {(api) => {
-        const {
-          field,
-          getFormIsValid,
-          debugEntireFormState, // REMOVE
-        } = api
-        return (
-          <div>
-            <TitleLarge.Serif.Book500>
-              Form with dynamically changing questions. Form #{count}
-            </TitleLarge.Serif.Book500>
+          }}
+        </Form>
+      )
+    } else {
+      return (
+        <Form
+          config={{
+            formName: 'Styleguidist example form',
+            autocompleteOff: true,
+            formId: '1',
+            autocompleteOff: true,
+            fields: questionGroups[1],
+            resetFormOnSubmit: true,
+            onSubmit: async (formData) => {
+              if (count === 0) {
+                // Go to the next set of questions
+                setCount(count + 1)
+              } else {
+                // Submit the form -- it will actually still have formData
+                // from the first set of questions, too
+                alert(
+                  'form submission successful with values:' +
+                    JSON.stringify(formData)
+                )
+              }
+            },
+          }}
+        >
+          {(api) => {
+            const {
+              field,
+              getFormIsValid,
+              debugEntireFormState, // REMOVE
+            } = api
+            return (
+              <div>
+                <TitleLarge.Serif.Book500>
+                  Form with dynamically changing questions. Form #{count}
+                </TitleLarge.Serif.Book500>
 
-            <Spacer.H16 />
+                <Spacer.H16 />
 
-            {field(questionNames[count])}
+                {field(questionNames[count])}
 
-            <Spacer.H16 />
+                <Spacer.H16 />
 
-            <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
-              Submit
-            </Button.Medium.Black>
-            <div>
-              <code>
-                {' '}
-                fieldErrorsState:{' '}
-                {JSON.stringify(debugEntireFormState().fieldErrorsState)}{' '}
-              </code>
-            </div>
-            <div>
-              <code>
-                {' '}
-                fieldValuesState:{' '}
-                {JSON.stringify(debugEntireFormState().fieldValuesState)}{' '}
-              </code>
-            </div>
-            <div>
-              <code>
-                formErrorState:{' '}
-                {JSON.stringify(debugEntireFormState().formErrorState)}{' '}
-              </code>
-            </div>
-          </div>
-        )
-      }}
-    </Form>
-  )}
+                <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
+                  Submit
+                </Button.Medium.Black>
+                <div>
+                  <code>
+                    {' '}
+                    fieldErrorsState:{' '}
+                    {JSON.stringify(
+                      debugEntireFormState().fieldErrorsState
+                    )}{' '}
+                  </code>
+                </div>
+                <div>
+                  <code>
+                    {' '}
+                    fieldValuesState:{' '}
+                    {JSON.stringify(
+                      debugEntireFormState().fieldValuesState
+                    )}{' '}
+                  </code>
+                </div>
+                <div>
+                  <code>
+                    formErrorState:{' '}
+                    {JSON.stringify(debugEntireFormState().formErrorState)}{' '}
+                  </code>
+                </div>
+              </div>
+            )
+          }}
+        </Form>
+      )
+    }
+  }}
 </TestFormWrapper>
 ```
 

--- a/src/components/Form/Form.md
+++ b/src/components/Form/Form.md
@@ -1,125 +1,4 @@
 ```jsx
-import { TestFormWrapper } from './TestFormWrapper.js'
-import validateTruthy from '../../validators/validateTruthy'
-import {
-  TitleLarge,
-  TextInput,
-  Spacer,
-  Button,
-  InfoMessage,
-  ZipInput,
-} from '../index'
-
-const questionGroups = [
-  {
-    one: {
-      component: (props, options) => {
-        return <TextInput {...props} />
-      },
-      validators: [(x) => (x === 'a' ? '' : 'Must be a')],
-      labelCopy: 'Validator: value must be "a"',
-      tid: 'example-data-tid',
-    },
-  },
-  {
-    two: {
-      component: (props, options) => {
-        return <TextInput {...props} />
-      },
-      validators: [(x) => (x === 'a' ? '' : 'Must be a')],
-      labelCopy: 'Validator: value must be "a" again',
-      tid: 'example-data-tid',
-    },
-  },
-]
-
-const questionNames = ['one', 'two'] // same as keys in questionGroups
-
-;<TestFormWrapper>
-  {({ count, setCount }) => {
-    const form = (
-      <Form
-        config={{
-          formName: 'Styleguidist example form',
-          formId: '1',
-          autocompleteOff: true,
-          fields: questionGroups[count],
-          onSubmit: async (formData) => {
-            if (count === 0) {
-              // Go to the next set of questions
-              setCount(count + 1)
-            } else {
-              // Submit the form -- it will actually still have formData
-              // from the first set of questions, too
-              alert(
-                'form submission successful with values:' +
-                  JSON.stringify(formData)
-              )
-            }
-          },
-        }}
-      >
-        {(api) => {
-          const {
-            field,
-            getFormIsValid,
-            debugEntireFormState, // REMOVE
-          } = api
-          return (
-            <div>
-              <TitleLarge.Serif.Book500>
-                Form with dynamically changing questions. Form #{count}
-              </TitleLarge.Serif.Book500>
-
-              <Spacer.H16 />
-
-              {field(questionNames[count])}
-
-              <Spacer.H16 />
-
-              <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
-                Submit
-              </Button.Medium.Black>
-              <div>
-                <code>
-                  {' '}
-                  fieldErrorsState:{' '}
-                  {JSON.stringify(debugEntireFormState().fieldErrorsState)}{' '}
-                </code>
-              </div>
-              <div>
-                <code>
-                  {' '}
-                  fieldValuesState:{' '}
-                  {JSON.stringify(debugEntireFormState().fieldValuesState)}{' '}
-                </code>
-              </div>
-              <div>
-                <code>
-                  formErrorState:{' '}
-                  {JSON.stringify(debugEntireFormState().formErrorState)}{' '}
-                </code>
-              </div>
-            </div>
-          )
-        }}
-      </Form>
-    )
-
-    switch (count) {
-      case 0:
-        return form
-      case 1:
-        return <div>{form}</div>
-    }
-    if (count === 0) {
-      return <div>{form}</div>
-    } else if (count === 0) return
-  }}
-</TestFormWrapper>
-```
-
-```jsx
 import validateTruthy from '../../validators/validateTruthy'
 import validateMinMaxFactory from '../../validators/validateMinMax'
 import {
@@ -605,4 +484,178 @@ import {
     )
   }}
 </Form>
+```
+
+```jsx
+import { useState } from 'react'
+import { TestFormWrapper } from './TestFormWrapper.js'
+import validateTruthy from '../../validators/validateTruthy'
+import {
+  TitleLarge,
+  TitleSmall,
+  TextInput,
+  Spacer,
+  Button,
+  InfoMessage,
+  ZipInput,
+} from '../index'
+
+const questionGroups = [
+  {
+    one: {
+      component: (props, options) => {
+        return <TextInput {...props} />
+      },
+      validators: [(x) => (x === 'a' ? '' : 'Must be a')],
+      labelCopy: 'Validator: value must be "a"',
+      tid: 'example-data-tid',
+    },
+  },
+  {
+    two: {
+      component: (props, options) => {
+        return <TextInput {...props} />
+      },
+      validators: [(x) => (x === 'a' ? '' : 'Must be a')],
+      labelCopy: 'Same, must be a',
+      tid: 'example-data-tid',
+    },
+  },
+  {
+    three: {
+      component: (props, options) => {
+        return <TextInput {...props} />
+      },
+      validators: [(x) => (x === 'a' ? '' : 'Must be a')],
+      labelCopy: 'Same, must be a',
+      tid: 'example-data-tid',
+    },
+  },
+  {
+    four: {
+      component: (props, options) => {
+        return <TextInput {...props} />
+      },
+      validators: [(x) => (x === 'a' ? '' : 'Must be a')],
+      labelCopy: 'Same, must be a',
+      tid: 'example-data-tid',
+    },
+  },
+  {
+    five: {
+      component: (props, options) => {
+        return <TextInput {...props} />
+      },
+      validators: [(x) => (x === 'a' ? '' : 'Must be a')],
+      labelCopy: 'Same, must be a',
+      tid: 'example-data-tid',
+    },
+  },
+]
+
+const questionNames = ['one', 'two', 'three', 'four', 'five'] // same as keys in questionGroups
+
+;<TestFormWrapper>
+  {({ count, setCount }) => {
+    const [finalFormData, setFinalFormData] = useState({})
+    const form = (
+      <Form
+        config={{
+          formName: 'Styleguidist example form',
+          formId: '1',
+          autocompleteOff: true,
+          fields: questionGroups[count],
+          onSubmit: async (formData) => {
+            const spreaded = { ...finalFormData, ...formData }
+            if (count < questionGroups.length - 1) {
+              // Go to the next set of questions
+              setCount(count + 1)
+              setFinalFormData(spreaded)
+            } else {
+              // Submit the form -- it will actually still have formData
+              // from the first set of questions, too
+              alert(
+                'form submission successful with values:' +
+                  JSON.stringify(spreaded)
+              )
+            }
+          },
+        }}
+      >
+        {(api) => {
+          const {
+            field,
+            getFormIsValid,
+            debugEntireFormState, // REMOVE
+          } = api
+          return (
+            <div>
+              <TitleLarge.Serif.Book500>
+                Form with dynamically changing questions
+              </TitleLarge.Serif.Book500>
+              <Spacer.H16 />
+
+              <TitleSmall.Serif.Book500>Form #{count}</TitleSmall.Serif.Book500>
+
+              {count === questionGroups.length - 1 ? (
+                <>
+                  <Spacer.H16 />
+                  <TitleSmall.Serif.Book500>
+                    This is the final form!
+                  </TitleSmall.Serif.Book500>
+                </>
+              ) : null}
+
+              <Spacer.H16 />
+
+              {field(questionNames[count])}
+
+              <Spacer.H16 />
+
+              <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
+                Submit
+              </Button.Medium.Black>
+
+              <Spacer.H16 />
+              <TitleSmall.Serif.Book500>Debug section</TitleSmall.Serif.Book500>
+              <div>
+                <code>
+                  {' '}
+                  fieldErrorsState (from useFormState):{' '}
+                  {JSON.stringify(debugEntireFormState().fieldErrorsState)}{' '}
+                </code>
+              </div>
+              <div>
+                <code>
+                  {' '}
+                  fieldValuesState (from useFormState):{' '}
+                  {JSON.stringify(debugEntireFormState().fieldValuesState)}{' '}
+                </code>
+              </div>
+              <div>
+                <code>
+                  {' '}
+                  finalFormData (from the example hook here):{' '}
+                  {JSON.stringify(finalFormData)}{' '}
+                </code>
+              </div>
+            </div>
+          )
+        }}
+      </Form>
+    )
+
+    // Switch off so that the dom is different every time.
+    switch (count) {
+      case 0:
+      case 2:
+      case 4:
+        return form
+      case 1:
+      case 3:
+      default:
+        return <div>{form}</div>
+    }
+  }}
+</TestFormWrapper>
 ```

--- a/src/components/Form/Form.md
+++ b/src/components/Form/Form.md
@@ -645,7 +645,11 @@ const questionNames = ['one', 'two', 'three', 'four', 'five'] // same as keys in
       </Form>
     )
 
-    // Switch off so that the dom is different every time.
+    // This is how the dynamic form rerenders from scratch when submitted.
+    // We return the form on even form "pages," and wrap it in a div
+    // on odd "pages."
+    //
+    // This feels like a hack but it works
     switch (count) {
       case 0:
       case 2:

--- a/src/components/Form/TestFormWrapper.js
+++ b/src/components/Form/TestFormWrapper.js
@@ -1,0 +1,13 @@
+import React, { useState } from 'react'
+export function TestFormWrapper({ children }) {
+  const [count, setCount] = useState(0)
+
+  return (
+    <>
+      {children({
+        count,
+        setCount,
+      })}
+    </>
+  )
+}

--- a/src/hooks/useFormState.js
+++ b/src/hooks/useFormState.js
@@ -7,13 +7,6 @@ export function useFormState(initialState) {
   const [fieldValuesState, setFieldValuesState] = useState(initialState)
   const [formErrorState, setFormErrorState] = useState('')
 
-  // Wipes form state clean. Use when submitting a dynamic form to
-  // reset the formIsValid logic and such.
-  function resetFormState(newInitialState) {
-    setFieldErrorsState(newInitialState)
-    setFieldValuesState(newInitialState)
-  }
-
   // Returns a function that updates state for the field, tracked by fieldName
   function setFieldState(fieldName) {
     return (newValue, newError) => {
@@ -95,7 +88,6 @@ export function useFormState(initialState) {
     setFormErrorMessage,
     getFormIsValid,
     getFormInteractedWith,
-    resetFormState,
     debugEntireFormState,
   ]
 }

--- a/src/hooks/useFormState.js
+++ b/src/hooks/useFormState.js
@@ -7,6 +7,13 @@ export function useFormState(initialState) {
   const [fieldValuesState, setFieldValuesState] = useState(initialState)
   const [formErrorState, setFormErrorState] = useState('')
 
+  // Wipes form state clean. Use when submitting a dynamic form to
+  // reset the formIsValid logic and such.
+  function resetFormState(newInitialState) {
+    setFieldErrorsState(newInitialState)
+    setFieldValuesState(newInitialState)
+  }
+
   // Returns a function that updates state for the field, tracked by fieldName
   function setFieldState(fieldName) {
     return (newValue, newError) => {
@@ -64,6 +71,22 @@ export function useFormState(initialState) {
     return touched && !getFieldErrors()
   }
 
+  // Styleguideist doesn't work very well with debugger and seems to absorb
+  // console.logs. This may be useful in dev, but shouldn't get anywhere
+  // near production.
+  // Maybe use like this:
+  // <code>
+  //   {JSON.stringify(debugEntireFormState())}
+  // </code>
+
+  function debugEntireFormState() {
+    return {
+      fieldErrorsState,
+      fieldValuesState,
+      formErrorState,
+    }
+  }
+
   return [
     getFieldErrors,
     getFieldValues,
@@ -72,5 +95,7 @@ export function useFormState(initialState) {
     setFormErrorMessage,
     getFormIsValid,
     getFormInteractedWith,
+    resetFormState,
+    debugEntireFormState,
   ]
 }


### PR DESCRIPTION
**Description:**
- [Asana Task](https://app.asana.com/0/1138529592199337/1145045007570209)

### I don't know whether to merge these new examples, or to essentially consider them as feature requests. This PR is mostly to open up a discussion.

This PR highlights two aspects of forms which may or may not be ideal behavior (I don't really know for sure, rob is in a meeting)

1. We don't have a way to mark a `<Form>` field as optional yet, and providing `validateExists` as the validator for a textinput is identical to not providing a validator. Example: https://i.gyazo.com/68185318e55de85df27ee3163c95d0bb.mp4 I think for now this behavior may be fine, but this could serve as documentation of the behavior for now, and could be updated later to demonstrate a `<Form>` with an optional field. ([Asana link](https://app.asana.com/0/search/1145220031676457/1145029870042133/f))
2. There is a hacky way to provide dynamic questions which you can see [here](https://github.com/getethos/ethos-design-system/pull/80/files#diff-241aaafc3b8608d9c4863b8a8fe36caeR648). Example: https://i.gyazo.com/18657b3cf05ce28b4339d0589e9c1969.mp4 As I say in that comment, it feels like a hack but it works. I tried a lot of things, you can ask for more info if you want; this was the first thing i found that behaved like we wanted.

Unfortunately prettier created a pretty messy diff. To make it easier to understand, here's a list of the other things done in this PR:

* New component used to provide dynamic state to a `<Form>` component in Form.md. https://github.com/getethos/ethos-design-system/blob/fbf528fbdd87ba8f14cfd3f3c29a168eabbf6ad9/src/components/Form/TestFormWrapper.js
* New export in `hooks/useFormState.js`, "debugEntireFormState()," which is also just used in dev. I found it useful for tracking form state and displaying hidden state in styleguidist, because styleguidist doesn't like console logs or even debugger sometimes. https://github.com/getethos/ethos-design-system/pull/80/files#diff-241aaafc3b8608d9c4863b8a8fe36caeR620

**Referencing PR or Branch (e.g. in CMS or monorepo):**
- This was a bit of a research project brought on by https://github.com/getethos/ethos/pull/1378.