### PR TITLE
Unum form touch issue

### DIFF
--- a/src/components/Inputs/BirthdateInput/BirthdateInput.js
+++ b/src/components/Inputs/BirthdateInput/BirthdateInput.js
@@ -37,7 +37,7 @@ const PrivateBirthdateInput = (props) => {
   const autoCorrectedDatePipe = createAutoCorrectedDatePipe('mm/dd/yyyy')
   const [getError, setError, getFormattedError, validate] = useErrorMessage(validator)
   const val = currentValue || initialValue
-  const [touched, setTouched] = useState(val ? true : false)
+  const [touched, setTouched] = useState(false)
   const [value, setValue] = useState(val || '')
 
   const callErrorHandlers = (value, handlerFn) => {
@@ -96,8 +96,10 @@ const PrivateBirthdateInput = (props) => {
         currentError={currentError}
         formTouched={formTouched}
         setFieldTouched={restProps.setFieldTouched}
+        getTouched={touched}
+        setTouched={setTouched}
       />
-      {getError(currentError, formTouched)}
+      {getError(currentError, touched)}
     </>
   )
 }

--- a/src/components/Inputs/BirthdateInput/BirthdateInput.js
+++ b/src/components/Inputs/BirthdateInput/BirthdateInput.js
@@ -70,7 +70,7 @@ const PrivateBirthdateInput = (props) => {
   const [doValidation] = useInputValidation({validate, setError, formChangeHandler, callErrorHandlers})
 
   const getClasses = () => {
-    return !!getError() ?
+    return !!getError(currentError, touched) ?
       `BirthdateInput ${styles.TextInput} ${errorStyles.Error}` :
       `BirthdateInput ${styles.TextInput}`
   }

--- a/src/components/Inputs/CheckboxInput/CheckboxInput.js
+++ b/src/components/Inputs/CheckboxInput/CheckboxInput.js
@@ -60,7 +60,7 @@ export const CheckboxInput = ({
   }
 
   const getClasses = () => {
-    return !!getError() ? `${styles.CheckboxInput} ${errorStyles.Error}` : `${styles.CheckboxInput}`
+    return !!getError(currentError, touched) ? `${styles.CheckboxInput} ${errorStyles.Error}` : `${styles.CheckboxInput}`
   }
 
   const id = name

--- a/src/components/Inputs/CheckboxInput/CheckboxInput.js
+++ b/src/components/Inputs/CheckboxInput/CheckboxInput.js
@@ -43,6 +43,8 @@ export const CheckboxInput = ({
   const [doValidation] = useInputValidation({validate, setError, formChangeHandler})
 
   const onChange = (ev) => {
+    // It feels like a checkbox isn't something you blur off of, so I'm electing to 
+    // call a checkbox touched when you check it
     if (!touched) setTouched(true)
     const val = ev.target.type === 'checkbox' ? ev.target.checked : ev.target.value;
     doValidation(val, touched)

--- a/src/components/Inputs/NumberInput/NumberInput.md
+++ b/src/components/Inputs/NumberInput/NumberInput.md
@@ -11,6 +11,9 @@ const formChangeHandlerStub = () => {}
   placeholder='number input'
   formChangeHandler={formChangeHandlerStub}
   validator={(n) => {
+    if (n > Number.MAX_SAFE_INTEGER) {
+      return 'Number too large—you have exceeded JavaScript\s powers!!'
+    }
     return n % 2 === 0 ? '' : 'Must be an even number'
   }}
 />

--- a/src/components/Inputs/TextInput/TextInput.js
+++ b/src/components/Inputs/TextInput/TextInput.js
@@ -55,7 +55,7 @@ function PrivateTextInput({
 
   const [value, setValue] = useState(currentValue || initialValue || '')
 
-  const [touched, setTouched] = useState(initialValue ? true : false)
+  const [touched, setTouched] = useState(false)
 
   const [doValidation] = useInputValidation({validate, setError, formChangeHandler})
 
@@ -90,7 +90,7 @@ function PrivateTextInput({
   }
 
   const getClasses = () => {
-    return !!getError() ? `${styles.TextInput} ${errorStyles.Error}` : `${styles.TextInput}`
+    return !!getError(currentError, touched) ? `${styles.TextInput} ${errorStyles.Error}` : `${styles.TextInput}`
   }
 
   return (
@@ -108,7 +108,7 @@ function PrivateTextInput({
         value={value}
         data-tid={rest['data-tid']}
       />
-      {getError(currentError, formTouched)}
+      {getError(currentError, touched)}
     </>
   )
 }

--- a/src/components/Inputs/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/Inputs/TextMaskedInput/TextMaskedInput.js
@@ -18,6 +18,8 @@ export const TextMaskedInput = (props) => {
     labelCopy,
     allCaps,
     validator,
+    getTouched,
+    setTouched,
     formChangeHandler,
     initialValue,
     currentValue,
@@ -31,10 +33,10 @@ export const TextMaskedInput = (props) => {
   const [getError, setError, getFormattedError, validate] = useErrorMessage(validator)
   const val = currentValue || initialValue
   const [value, setValue] = useState(val || '')
-  const [touched, setTouched] = useState(val ? true : false)
+  const [internalTouched, internalSetTouched] = useState( false)
+  const whichTouched = getTouched ? getTouched : internalTouched
+  const whichSetTouched = setTouched ? setTouched : internalSetTouched
   const [internalDoValidation] = useInputValidation({validate, setError, formChangeHandler})
-
-  // Prioritizes props.doValidation but falls back to our internal implementation
   const whichDoValidation = doValidation ? doValidation : internalDoValidation
 
   const onChange = (ev) => {
@@ -45,11 +47,11 @@ export const TextMaskedInput = (props) => {
     // Used to remove mask characters e.g. abc___ becomes just abc
     const cleansed = cleanse(restrictedVal)
 
-    whichDoValidation(cleansed, touched)
+    whichDoValidation(cleansed, whichTouched)
   }
 
   const setAllTouched = () => {
-    setTouched(true)
+    whichSetTouched(true)
     if (!!setFieldTouched) {
       setFieldTouched(true)
     }
@@ -73,7 +75,7 @@ export const TextMaskedInput = (props) => {
   }
 
   const getClasses = () => {
-    return !!getError() ?
+    return !!getError(currentError, whichTouched) ?
       `TextMaskedInput ${styles.TextInput} ${errorStyles.Error}` :
       `TextMaskedInput ${styles.TextInput}`
   }
@@ -122,7 +124,7 @@ export const TextMaskedInput = (props) => {
     <>
       <InputLabel name={name} labelCopy={labelCopy} allCaps={allCaps} />
       {getMaskedInputByType(mask)}
-      {!doValidation && getError(currentError, formTouched)} 
+      {!doValidation && getError(currentError, whichTouched)} 
     </>
   )
 }
@@ -143,6 +145,8 @@ TextMaskedInput.PUBLIC_PROPS = {
   name: PropTypes.string.isRequired,
   labelCopy: PropTypes.string.isRequired,
   validator: PropTypes.func,
+  setTouched: PropTypes.func,
+  getTouched: PropTypes.func,
 }
 
 TextMaskedInput.propTypes = {

--- a/src/components/Inputs/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/Inputs/TextMaskedInput/TextMaskedInput.js
@@ -146,7 +146,7 @@ TextMaskedInput.PUBLIC_PROPS = {
   labelCopy: PropTypes.string.isRequired,
   validator: PropTypes.func,
   setTouched: PropTypes.func,
-  getTouched: PropTypes.func,
+  getTouched: PropTypes.bool,
 }
 
 TextMaskedInput.propTypes = {

--- a/src/components/Inputs/ZipInput/ZipInput.js
+++ b/src/components/Inputs/ZipInput/ZipInput.js
@@ -24,7 +24,7 @@ export const ZipInput = (props) => {
 
   const [getError, setError, getFormattedError, validate] = useErrorMessage(validator)
   const val = currentValue || initialValue
-  const [touched, setTouched] = useState(val ? true : false)
+  const [touched, setTouched] = useState(false)
   const [value, setValue] = useState(val || '')
 
   // This has to come before useInputValidation setup below
@@ -71,8 +71,10 @@ export const ZipInput = (props) => {
         currentError={currentError}
         formTouched={formTouched}
         setFieldTouched={restProps.setFieldTouched}
+        getTouched={touched}
+        setTouched={setTouched}
       />
-      {getError(currentError, formTouched)}
+      {getError(currentError, touched)}
     </>
   )
 }

--- a/src/components/Inputs/ZipInput/ZipInput.js
+++ b/src/components/Inputs/ZipInput/ZipInput.js
@@ -46,7 +46,7 @@ export const ZipInput = (props) => {
   const [doValidation] = useInputValidation({validate, setError, formChangeHandler, callErrorHandlers})
 
   const getClasses = () => {
-    return !!getError() ?
+    return !!getError(currentError, touched) ?
       `ZipInput ${styles.TextInput} ${errorStyles.Error}` :
       `ZipInput ${styles.TextInput}`
   }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -19,7 +19,7 @@ export {
 export { UniversalNavbar } from './UniversalNavbar/UniversalNavbar'
 export { ButtonSelectGroup } from './Inputs/ButtonSelectGroup/ButtonSelectGroup'
 export { NumberInput } from './Inputs/NumberInput/NumberInput'
-export { OPTION_BUTTON_STYLES } from './Inputs//ButtonSelectGroup/OptionButton'
+export { OPTION_BUTTON_STYLES } from './Inputs/ButtonSelectGroup/OptionButton'
 
 export {
   Body,

--- a/src/hooks/useErrorMessage.js
+++ b/src/hooks/useErrorMessage.js
@@ -10,14 +10,15 @@ const useErrorMessage = (validator) => {
     setDisplayError(msg)
   }
 
-  const getError = (currentError, formTouched) => {
+  const getError = (currentError, fieldTouched) => {
+    console.log('getError--currentError: ', currentError, ' fieldTouched: ', fieldTouched, 'displayError: ', displayError)
     if (displayError) {
       return getFormattedError(displayError)
     } else {
       // If we don't have a display error we still have to account for the
       // the form state's currentError. For example, the user toggles a field
       // off then back on...this will cause a rerender with no display error
-      if (currentError && formTouched && currentError !== INIT_INVALID) {
+      if (currentError && fieldTouched && currentError !== INIT_INVALID) {
         return getFormattedError(currentError)
       }
     }

--- a/src/hooks/useErrorMessage.js
+++ b/src/hooks/useErrorMessage.js
@@ -11,7 +11,6 @@ const useErrorMessage = (validator) => {
   }
 
   const getError = (currentError, fieldTouched) => {
-    console.log('getError--currentError: ', currentError, ' fieldTouched: ', fieldTouched, 'displayError: ', displayError)
     if (displayError) {
       return getFormattedError(displayError)
     } else {


### PR DESCRIPTION
**Description:**
- [Asana Task](https://app.asana.com/0/1136962714401929/1145702600849513/f)
- Form touch refactor

___

## Rationale

Looks like "field touch" or, field blur is what should determine whether field level error messages are displayed or not. 

## Research

If you look at this vanilla Formik example, we can see the default is field touch:
https://jasonwatmore.com/post/2019/04/10/react-formik-form-validation-example

Here’s an example from Jared himself (the author), and his description implies how Formik defaults to touch-based error message visibility:

> A Formik form where errors are shown while the user types (**instead of showing after blur event**). Submission is also prevented if there are any errors.

Note his example requires the application developer to override the default functionality. It also feels like the form is "yelling":

https://codesandbox.io/s/jn00j0prpv

Hence my decision to go back to field touch :)
