### PR TITLE
Move Link to CSS modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.7-b",
+  "version": "1.1.8-RC1",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "license": "UNLICENSED",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.8-RC1",
+  "version": "1.1.8",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "license": "UNLICENSED",

--- a/src/components/Type/Link.js
+++ b/src/components/Type/Link.js
@@ -8,7 +8,6 @@ export const Link = {
   STYLE_VARIANTS: {
     INHERIT: 'Inherit',
     STANDARD: 'Standard',
-    NAVLINK: 'Navlink',
   },
   styles,
 }

--- a/src/components/Type/Link.js
+++ b/src/components/Type/Link.js
@@ -1,12 +1,14 @@
 import { Type, TypeFoundry } from './Type.js'
 
+import styles from './Link.module.scss'
+
 // Links – WIP. For now let's just export CSS classes and be otherwise agnostic.
+
 export const Link = {
-  CLASS_NAME: 'Link',
   STYLE_VARIANTS: {
     INHERIT: 'Inherit',
     STANDARD: 'Standard',
     NAVLINK: 'Navlink',
-    HAMBURGER_MENU: 'HamburgerMenu',
   },
+  styles,
 }

--- a/src/components/Type/Link.module.scss
+++ b/src/components/Type/Link.module.scss
@@ -10,9 +10,9 @@
 
 // Style variants
 
-&.Standard {
+.Standard {
 }
 
-&.Inherit {
+.Inherit {
   color: inherit;
 }

--- a/src/components/Type/Link.module.scss
+++ b/src/components/Type/Link.module.scss
@@ -6,25 +6,13 @@
   &:hover {
     text-decoration: none;
   }
+}
 
-  // Style variants
+// Style variants
 
-  &.Standard {
-  }
+&.Standard {
+}
 
-  &.Inherit {
-    color: inherit;
-  }
-
-  &.Navlink {
-    color: var(--GrayPrimary--translucent);
-    text-decoration: none;
-    padding: var(--Space-4) 0;
-    border-bottom: 2px solid transparent;
-
-    &:active,
-    &:hover {
-      border-bottom-color: var(--GrayPrimary--translucent);
-    }
-  }
+&.Inherit {
+  color: inherit;
 }

--- a/src/components/Type/Link.module.scss
+++ b/src/components/Type/Link.module.scss
@@ -1,0 +1,30 @@
+.Link {
+  color: var(--GrayPrimary--translucent);
+
+  &,
+  &:active,
+  &:hover {
+    text-decoration: none;
+  }
+
+  // Style variants
+
+  &.Standard {
+  }
+
+  &.Inherit {
+    color: inherit;
+  }
+
+  &.Navlink {
+    color: var(--GrayPrimary--translucent);
+    text-decoration: none;
+    padding: var(--Space-4) 0;
+    border-bottom: 2px solid transparent;
+
+    &:active,
+    &:hover {
+      border-bottom-color: var(--GrayPrimary--translucent);
+    }
+  }
+}

--- a/src/components/Type/Type.scss
+++ b/src/components/Type/Type.scss
@@ -31,37 +31,12 @@ strong {
 // the complications from JS routers with <Link>s that are not standard <a>s.
 // See also ./Type.module.scss.
 
-a,
-.Link {
+a {
   &,
   &:active,
   &:hover {
     text-decoration: none;
   }
 
-  & {
-    color: var(--GrayPrimary--translucent);
-  }
-}
-
-.Link {
-  &.Inherit {
-    color: inherit;
-  }
-
-  &.Navlink {
-    color: var(--GrayPrimary--translucent);
-    text-decoration: none;
-    padding: var(--Space-4) 0;
-    border-bottom: 2px solid transparent;
-
-    // transition: var(--transition-default);
-    // transition-property: none;
-
-    &:active,
-    &:hover {
-      // &[aria-current='page'] // if we need to underline the current page later
-      border-bottom-color: var(--GrayPrimary--translucent);
-    }
-  }
+  color: var(--GrayPrimary--translucent);
 }

--- a/src/components/design-system.css
+++ b/src/components/design-system.css
@@ -229,33 +229,13 @@ strong {
   font-weight: 500;
 }
 
+a {
+  color: var(--GrayPrimary--translucent);
+}
 a,
 a:active,
-a:hover,
-.Link,
-.Link:active,
-.Link:hover {
+a:hover {
   text-decoration: none;
-}
-
-a,
-.Link {
-  color: var(--GrayPrimary--translucent);
-}
-
-.Link.Inherit {
-  color: inherit;
-}
-
-.Link.Navlink {
-  color: var(--GrayPrimary--translucent);
-  text-decoration: none;
-  padding: var(--Space-4) 0;
-  border-bottom: 2px solid transparent;
-}
-.Link.Navlink:active,
-.Link.Navlink:hover {
-  border-bottom-color: var(--GrayPrimary--translucent);
 }
 
 /**

--- a/stats.json
+++ b/stats.json
@@ -1,7 +1,7 @@
 {
-  "cssBytes": 6885,
-  "cssRules": 52,
+  "cssBytes": 6549,
+  "cssRules": 49,
   "cssTypeSelectors": 33,
-  "cssClassSelectors": 40,
+  "cssClassSelectors": 28,
   "cssMediaQueries": 1
 }


### PR DESCRIPTION
**Description:**
- [Asana Task](https://app.asana.com/0/1136962714401929/1143741730422930)
- Removes Link-related globals from the CSS bundle (which shrinks 5%).
- No major issues found in CMS yet so I think this is good for final CR.
- Gonna do one last quick round of CMS QA and then I'll be ready to merge.

**Referencing PR or Branch (e.g. in CMS or monorepo):**
- https://github.com/getethos/cms/pull/1997


**Screenshots:**
- See https://github.com/getethos/cms/pull/1997.