### PR TITLE
Was throwing when we use a boolean value even though it can now handl…

### DIFF
--- a/src/components/Inputs/ButtonSelectGroup/ButtonSelectGroup.js
+++ b/src/components/Inputs/ButtonSelectGroup/ButtonSelectGroup.js
@@ -153,7 +153,7 @@ ButtonSelectGroup.propTypes = {
   /** When set to `true`, the group's label will be displayed uppercase */
   allCaps: PropTypes.bool,
   /** Optionally sets a default value for the group. If set, the matching option will be set as `isSelected` */
-  initialValue: PropTypes.string,
+  initialValue: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   /** Optional value that sets the background color of all the buttons in the group (unselected state) */
   buttonStyle: PropTypes.string,
   /** Optional callback thats fires when an option is selected. returns an object containing the selected `value` and a boolean value `isAnswered` */


### PR DESCRIPTION
…e it

**Description:**
- [Asana Task]()
- 


**Referencing PR or Branch (e.g. in CMS or monorepo):**
- 


**Screenshots:**
