### PR TITLE
Downgrading

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,9 +79,6 @@
     "webpack": "^4.39.3",
     "webpack-dev-server": "^3.8.0"
   },
-  "engines": {
-    "node": "^10.16.3"
-  },
   "husky": {
     "hooks": {
       "pre-push": "yarn test"


### PR DESCRIPTION
**Description:**
The node engine requirement would require monorepo et al to upgrade node. It seems like eslint runs fine with 10.6 so this PR downgrades to match what we have across our stack.


**Referencing PR or Branch (e.g. in CMS or monorepo):**
- https://github.com/getethos/ethos-design-system/pull/104/files


`yarn lint` runs fine. We have a lot to fix apparently, but that should be done on a follow up branch I think since it's not blocking our consumers as the node engine thing IS.