### PR TITLE
Fix EDS composes / css modules when consumed by monorepo

### DIFF
--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -1,16 +1,18 @@
-// @import "../Animation.scss";
-// @import "../Colors.scss";
-// @import "../Type/Type.scss";
-// @import '../Spacer/Spacer.scss';
+/*
+@import "../Animation.scss";
+@import "../Colors.scss";
+@import "../Type/Type.scss";
+@import '../Spacer/Spacer.scss';
+*/
 @import '../Media/Media.scss';
 
-// This is currently a one-off implementation for UniversalNavbar
+/* This is currently a one-off implementation for UniversalNavbar */
 @import './Button.small.shame.scss';
 
 /* @getethos/design-system/Button.scss
    ========================================================================== */
 
-// Defaults
+/* Defaults */
 
 :root {
   --ButtonMediumStatefulMinWidth: 156px;
@@ -30,7 +32,7 @@ button,
   }
 }
 
-// Dimensions
+/* Dimensions */
 
 .Button.Medium {
   $font-size: 19;
@@ -65,10 +67,11 @@ button,
     padding-left: 48px;
   }
 }
-// Styles
+/* Styles */
 
 @mixin light-on-dark-font-smoothing {
-  -webkit-font-smoothing: antialiased; // stackoverflow.com/a/17927764
+  /* stackoverflow.com/a/17927764 */
+  -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
@@ -152,8 +155,8 @@ button,
   }
 }
 
-// Purposely very specific name WhiteCTA as this is currently
-// only used on the CMS hero for the CTA 'Check my price' button
+/* Purposely very specific name WhiteCTA as this is currently */
+/* only used on the CMS hero for the CTA 'Check my price' button */
 .Button.WhiteCTA {
   background: var(--White);
   padding: var(--Space-16) var(--Space-32);
@@ -179,8 +182,8 @@ button,
   }
 
   @mixin button-stateful-is-active-or-selected {
-    // These are used in both the HTML "active" state (mid-click), as well as
-    // the custom "is selected" state (this button is in the "on" state).
+    /* These are used in both the HTML "active" state (mid-click), as well as */
+    /* the custom "is selected" state (this button is in the "on" state). */
     border-color: var(--BrandForest);
     background-color: var(--BrandForest);
     color: var(--White);
@@ -197,7 +200,7 @@ button,
       color: var(--GrayPrimary--translucent);
     }
 
-    // Bugfix: Need this one to have more specificity then ^ hover
+    /* Bugfix: Need this one to have more specificity then ^ hover */
     &.isSelected {
       @include button-stateful-is-active-or-selected;
     }
@@ -213,10 +216,12 @@ button,
     color: var(--White);
   }
 
-  // This class will be applied with the button is in the "selected" state, e.g.
-  // after the user clicks it, or if they have previously selected this value.
-  // Note thatthese styles should appear even if the button is disabled, though
-  // this probably only makes sense for `.isSelected` (not `:active`).
+  /*
+  This class will be applied with the button is in the "selected" state, e.g.
+  after the user clicks it, or if they have previously selected this value.
+  Note thatthese styles should appear even if the button is disabled, though
+  this probably only makes sense for `.isSelected` (not `:active`).
+  */
   &.isSelected {
     @include button-stateful-is-active-or-selected;
   }

--- a/src/components/Inputs/ButtonSelectGroup/ButtonGroup.module.scss
+++ b/src/components/Inputs/ButtonSelectGroup/ButtonGroup.module.scss
@@ -1,5 +1,7 @@
-// Button.Stateful is no longer available w/CSS Modules but
-// it's always such a button if you look at component JSX
+/*
+Button.Stateful is no longer available w/CSS Modules but
+it's always such a button if you look at component JSX
+*/
 .buttonGroup:not(.column) > button {
   margin-right: var(--Space-8);
 }
@@ -8,7 +10,7 @@
   margin-bottom: var(--Space-8);
 }
 
-// fullWidth is default.
+/* fullWidth is default. */
 .buttonGroup.fullWidth {
   display: flex;
   flex-direction: row;

--- a/src/components/Inputs/CheckboxInput/CheckboxInput.module.scss
+++ b/src/components/Inputs/CheckboxInput/CheckboxInput.module.scss
@@ -30,7 +30,7 @@
   opacity: 0;
 }
 
-// State
+/* State */
 .CheckboxInput:not(:checked) ~ .Facade {
   &:hover {
     background-color: var(--GrayLightHover--translucent);

--- a/src/components/Inputs/Errors.module.scss
+++ b/src/components/Inputs/Errors.module.scss
@@ -4,7 +4,7 @@
   border-style: solid;
 }
 
-// To beat out things like .TextInput:focus
+/* To beat out things like .TextInput:focus */
 .Error:focus {
   @extend .Error;
 }

--- a/src/components/Inputs/TextInput/TextInput.module.scss
+++ b/src/components/Inputs/TextInput/TextInput.module.scss
@@ -1,11 +1,12 @@
-// TODO -- these are currently come in via globals but we'll need
-// them here once we continue to strip 'em out of design-system.css
-// @import "../Colors.scss";
-// @import "../Type/Type.scss";
-// @import '../Spacer/Spacer.scss';
+/* TODO -- these are currently come in via globals but we'll need
+   them here once we continue to strip 'em out of design-system.css
+@import "../Colors.scss";
+@import "../Type/Type.scss";
+@import '../Spacer/Spacer.scss';
+*/
 
 .TextInput {
-  // Same as Type.scss Body. Should we use a mixin?
+  /* Same as Type.scss Body. Should we use a mixin? */
   $font-size: 19;
   $line-height: 24;
   font-size: $font-size * 1px;
@@ -35,7 +36,7 @@
 }
 
 .TextInput::placeholder {
-  // It's $gray-64 / #a3a3a3 in ethos, but going to try to limit # of grays
+  /* It's $gray-64 / #a3a3a3 in ethos, but going to try to limit # of grays */
   color: var(--GrayStrokeAndDisabled--opaque);
 }
 

--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -1,8 +1,8 @@
 @import '../Media/Media.scss';
 
 .Layout {
-  // The concept of a top-level reusable "Layout" component may be an antipattern.
-  // Let's be slow to add more styles here.
+  /* The concept of a top-level reusable "Layout" component may be an antipattern. */
+  /* Let's be slow to add more styles here. */
   width: 100%;
   overflow-x: hidden;
 }

--- a/src/components/RadioButtons/RadioButtons.module.scss
+++ b/src/components/RadioButtons/RadioButtons.module.scss
@@ -1,9 +1,9 @@
-// A single radio button with a styled façade and a text label.
+/* A single radio button with a styled façade and a text label. */
 .RadioButton {
-  // Get the text on the same line:
+  /* Get the text on the same line: */
   display: flex;
 
-  // This wraps the radio button/façade in order to set proper whitespace.
+  /* This wraps the radio button/façade in order to set proper whitespace. */
   span {
     height: var(--Space-24);
     width: var(--Space-24);
@@ -17,24 +17,24 @@
     padding: 3px;
   }
 
-  // This is the actual HTML radio button. Hidden so we can style more freely.
+  /* This is the actual HTML radio button. Hidden so we can style more freely. */
   input {
     visibility: hidden;
     position: absolute;
   }
 
-  // This is a façade styled to the design spec.
+  /* This is a façade styled to the design spec. */
   aside {
     height: 18px;
     width: 18px;
     border-radius: 50%;
-    pointer-events: none; // pass click events to the real HTML radio button
+    pointer-events: none; /* pass click events to the real HTML radio button */
 
     transition: var(--transition-default);
     transition-property: background-color, border-width, border-color;
   }
 
-  // These ~ selectors let us style the façade according to the input state.
+  /* These ~ selectors let us style the façade according to the input state. */
   input:hover ~ aside {
     background-color: var(--GrayLightHover--translucent);
   }
@@ -48,17 +48,19 @@
     background-color: var(--White);
   }
 
-  // The vertical position of the text, given our current fonts/etc., needs to
-  // be optically tuned to resemble the spec (`align-items:` isn't enough).
-  // TODO: This currently seems to diverge between main and frontend-docs :/
+  /*
+  The vertical position of the text, given our current fonts/etc., needs to
+  be optically tuned to resemble the spec (`align-items:` isn't enough).
+  TODO: This currently seems to diverge between main and frontend-docs :/
+  */
   > div:last-child {
     position: relative;
-    top: 0.15em; // optical
+    top: 0.15em; /* optical */
   }
 }
 
 .RadioButtonGroup {
-  // unset fieldset styles
+  /* unset fieldset styles */
   border: none;
   padding: 0;
   margin: 0;

--- a/src/components/Type/Link.module.scss
+++ b/src/components/Type/Link.module.scss
@@ -8,7 +8,7 @@
   }
 }
 
-// Style variants
+/* Style variants */
 
 .Standard {
 }

--- a/src/components/Type/Type.module.scss
+++ b/src/components/Type/Type.module.scss
@@ -8,8 +8,7 @@
   font-family: var(--Cambon-font-stack);
 }
 
-// Type utilities (colors, weights, alignment)
-
+/* Type utilities (colors, weights, alignment) */
 .Caption,
 .Footnote,
 .Body,
@@ -18,7 +17,7 @@
 .TitleLarge,
 .TitleXLarge,
 .TitleXXLarge {
-  // Brand colors
+  /* Brand colors */
 
   &.BrandForest {
     color: var(--BrandForest);
@@ -27,7 +26,7 @@
     color: var(--BrandSalamander);
   }
 
-  // Grayscales
+  /* Grayscales */
 
   &.GrayPrimary {
     color: var(--GrayPrimary--translucent);
@@ -45,7 +44,7 @@
     color: var(--White);
   }
 
-  // Misc.
+  /* Misc. */
 
   &.Centered {
     text-align: center;
@@ -73,7 +72,7 @@
   font-weight: 600;
 }
 
-// Subtypes
+/* Subtypes */
 
 .Caption {
   @include for-phone-only {
@@ -375,10 +374,11 @@ h6,
   }
 }
 
-// TODO: come up with a comprehensive plan for links and link styles. This is
-// complicated by the number of design features we may need to support, plus
-// the complications from JS routers with <Link>s that are not standard <a>s.
-// See also ./Type.scss.
+/* TODO: come up with a comprehensive plan for links and link styles. This is
+   complicated by the number of design features we may need to support, plus
+   the complications from JS routers with <Link>s that are not standard <a>s.
+   See also ./Type.scss.
+*/
 
 .Caption,
 .Footnote,

--- a/src/components/UniversalNavbar/TransformingBurgerButton/TransformingBurgerButton.module.scss
+++ b/src/components/UniversalNavbar/TransformingBurgerButton/TransformingBurgerButton.module.scss
@@ -1,6 +1,6 @@
-// TODO once we remove Colors.scss from design-system.css we'll need to import
-// @import "../Colors.scss";
-
+/* TODO once we remove Colors.scss from design-system.css we'll need to import
+@import "../Colors.scss";
+*/
 .iconWrapper {
   display: flex;
   flex-direction: column;
@@ -11,7 +11,7 @@
 }
 
 .showMobileMenu {
-  // .icon adds an extra level of specificity needed in CSS Modules land
+  /* .icon adds an extra level of specificity needed in CSS Modules land */
   .icon {
     i {
       background: transparent;


### PR DESCRIPTION
**Description:**
- [Asana Task](https://app.asana.com/0/1136962714401929/1146699554558697/f)
- Fix EDS composes / css modules when consumed by monorepo

Note I elected to only convert comments in .module.scss files since those will be the only ones we do `composes: ` from. It's weird that .scss files get evaluated by postcss-loader before css-loader, but everywhere on the web recommends this ordering.

tried from monorepo pointed here for all envs:

- [x] yarn start --environment stage --verbose main
- [x] yarn start --environment production --verbose main
- [x] yarn start --environment dev --verbose main

**Referencing PR or Branch (e.g. in CMS or monorepo):**
- https://github.com/getethos/ethos/pull/1451


**Screenshots:**
