### PR TITLE
hide becomes markHidden

### DIFF
--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -119,9 +119,10 @@ export function Form({ children, config }) {
     }
   }
 
-  function hide(fieldName) {
+  function markHidden(fieldName) {
     const fieldConfig = config.fields[fieldName]
     setFieldsHidden(fieldName, true)
+    return true
   }
 
   // Wrapper for all fields. Essentially, this translates the field definitions
@@ -241,7 +242,7 @@ export function Form({ children, config }) {
         these arguments passed to the children function. */}
       {children({
         field,
-        hide,
+        markHidden,
         getFieldErrors,
         getFieldValues,
         getFormErrorMessage,

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -122,6 +122,7 @@ export function Form({ children, config }) {
   function markHidden(fieldName) {
     const fieldConfig = config.fields[fieldName]
     setFieldsHidden(fieldName, true)
+    // allows for chaining with && if needed
     return true
   }
 

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -120,7 +120,6 @@ export function Form({ children, config }) {
   }
 
   function markHidden(fieldName) {
-    const fieldConfig = config.fields[fieldName]
     setFieldsHidden(fieldName, true)
     // allows for chaining with && if needed
     return true

--- a/src/components/Form/Form.md
+++ b/src/components/Form/Form.md
@@ -578,7 +578,7 @@ const analyticsCustomEvent = (fieldName, fieldValue) => {
 
 ### Hiding dynamic fields
 
-Dynamic fields & hidden fields—if you call `hide` when a dynamic field is hidden, it
+Dynamic fields & hidden fields—if you call `markHidden` when a dynamic field is hidden, it
 will not be considered in determining form validity. Further, if the hidden field has
 been previously interacted with, it's value will also be ignored.
 
@@ -649,7 +649,7 @@ import { ButtonSelectGroup } from '../Inputs/ButtonSelectGroup/ButtonSelectGroup
   {(api) => {
     const {
       field,
-      hide,
+      markHidden,
       getFieldErrors,
       getFieldValues,
       getFormErrorMessage,
@@ -673,7 +673,7 @@ import { ButtonSelectGroup } from '../Inputs/ButtonSelectGroup/ButtonSelectGroup
 
         {values.buttonGroup == 'toggle-1'
           ? field('buttonGroup2')
-          : hide('buttonGroup2')}
+          : markHidden('buttonGroup2')}
         <Spacer.H16 />
 
         <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
@@ -776,7 +776,7 @@ import { ButtonSelectGroup } from '../Inputs/ButtonSelectGroup/ButtonSelectGroup
   {(api) => {
     const {
       field,
-      hide,
+      markHidden,
       getFieldErrors,
       getFieldValues,
       getFormErrorMessage,
@@ -798,11 +798,11 @@ import { ButtonSelectGroup } from '../Inputs/ButtonSelectGroup/ButtonSelectGroup
         <Spacer.H16 />
         {values.buttonGroup === '1'
           ? field('buttonGroup2')
-          : hide('buttonGroup2') && hide('buttonGroup3')}
+          : markHidden('buttonGroup2') && markHidden('buttonGroup3')}
         <Spacer.H16 />
         {values.buttonGroup2 === '1'
           ? field('buttonGroup3')
-          : hide('buttonGroup3')}
+          : markHidden('buttonGroup3')}
         <Spacer.H16 />
         <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
           Submit

--- a/src/hooks/useFormState.js
+++ b/src/hooks/useFormState.js
@@ -10,7 +10,7 @@ export function useFormState(initialState) {
   const [formErrorState, setFormErrorState] = useState('')
 
   // No fields are considered hidden initially. Within the JSX, consumer can
-  // call hide('fieldName'), and from there we can update setFieldsHidden
+  // call markHidden('fieldName'), and from there we can update setFieldsHidden
   const initialHiddenState = {}
   Object.keys(initialState).map((key) => {
     initialHiddenState[key] = false


### PR DESCRIPTION
## This will require any consumers that use `hide` to refactor to use `markHidden`

**Description:**
- [Asana Task](https://app.asana.com/0/1136962714401929/1146709581895113/f)
-  hide becomes markHidden since we do not hide the thing but mark it as hidden thus do not consider when returning for values or validating fields for errors etc.



**Screenshots:**

This is a temporary page I created...but I marked buttonGroup 2 and 3 as hidden after clicking the 'Yo' button...the console.log shows that we only returned button 1 in the  form state collection

![image](https://user-images.githubusercontent.com/142403/67612059-33ce9180-f754-11e9-8c34-6f76027a2daf.png)
