### PR TITLE
Prefill still requires touching fields

### DIFF
--- a/src/components/Form/FormPrefilled.js
+++ b/src/components/Form/FormPrefilled.js
@@ -1,0 +1,1 @@
+export function FormPrefilled() {}

--- a/src/components/Form/FormPrefilled.md
+++ b/src/components/Form/FormPrefilled.md
@@ -1,0 +1,249 @@
+## Prefilled forms
+
+This form starts completely _prefilled_. By this, we mean that each field has been configured
+with an `initializeValue` (and they all happen to be valid values so the submit button is
+enabled immediately).
+
+Note that a field the gets an `initialValue` will do two things:
+
+1. mark itself as "touched" (aka blurred)
+1. do validation—this results in the form state being updated per the validity of the `initialValue` passed in
+
+Try changing one of the `initialValue` values to something invalid e.g. for the zip switch
+it from `initialValue="94544"` to an invalid zip value of: `initialValue="9454"`. You should
+notice that the submit button has been disabled.
+
+```
+import createNumberMask from 'text-mask-addons/dist/createNumberMask'
+import dayjs from '../../helpers/getDayjs.js'
+import validateExists from '../../validators/validateExists'
+import validateMinMaxFactory from '../../validators/validateMinMax'
+import EmailFormatValidator from '../../validators/EmailValidator'
+import { validateMinMaxDateFactory } from '../../validators/BirthdateInputValidator'
+
+import {
+  TitleLarge,
+  Form,
+  TextInput,
+  TextMaskedInput,
+  Spacer,
+  EmailInput,
+  NumberInput,
+  CheckboxInput,
+  ZipInput,
+  BirthdateInput,
+  ButtonSelectGroup,
+  Button,
+  InfoMessage,
+} from '../index'
+
+const dollarMaskFunction = createNumberMask({
+  allowDecimal: false,
+  allowLeadingZeroes: false,
+  guide: false,
+  includeThousandsSeparator: true,
+  prefix: '$',
+})
+
+
+const getMinBirthdateLga = (maxAge) => {
+  // Max age determines the earliest (minimum) allowable birthdate
+  const minBirthdate = dayjs()
+    .subtract(maxAge, 'years')
+    .subtract(6, 'months')
+    .add(1, 'days')
+    .startOf('day')
+    .toDate()
+  return minBirthdate
+}
+
+const getMaxBirthdateLga = (minAge) => {
+  // Min age determines the latest (maximum) allowable birthdate
+  const maxBirthdate = dayjs()
+    .subtract(minAge, 'years')
+    .add(6, 'months')
+    .subtract(1, 'day')
+    .endOf('day')
+    .toDate()
+  return maxBirthdate
+}
+
+const minAge = 20
+const maxAge = 65
+
+;<Form
+  config={{
+    formName: 'Dynamic fields example form',
+    autocompleteOff: true,
+    formId: '1',
+    fields: {
+      dollar: {
+        component: (props, options) => {
+          return <NumberInput {...props} mask={dollarMaskFunction} initialValue="1234" />
+        },
+        name: "dollar-input-example",
+        labelCopy: "Enter a number (must be even to validate)",
+        tid: 'dollar-number-input',
+        validators: [(n) => {
+          if (n > Number.MAX_SAFE_INTEGER) {
+            return 'Number too large—you have exceeded JavaScript\s powers!!'
+          }
+          return n % 2 === 0 ? '' : 'Must be an even number'
+        }],
+      },
+      birthdate: {
+        component: (props, options) => {
+          return <BirthdateInput {...props} initialValue="09/12/1977" />
+        },
+        validators: [
+          validateExists,
+          validateMinMaxDateFactory({
+            minAge,
+            maxAge,
+            minBirthdate: getMinBirthdateLga(maxAge),
+            maxBirthdate: getMaxBirthdateLga(minAge),
+            dateFormat: 'mm/dd/yyyy',
+          }),
+        ],
+        labelCopy: 'Must be between 20 and 65 years old',
+      },
+      zipCode: {
+        component: (props, options) => {
+          return <ZipInput {...props} initialValue="94544" />
+        },
+        name: 'this-zip-input-example',
+        labelCopy: 'What is your zip code?',
+      },
+      email: {
+        component: (props, options) => {
+          return <EmailInput {...props} initialValue="fooby@ethoslife.com" placeholder="example@ethoslife.com" />
+        },
+        validators: [EmailFormatValidator],
+        name: 'the-email-input-example',
+        labelCopy: 'Your email',
+        tid: 'the-email-tid',
+      },
+      booleanGroup: {
+        component: (props, options) => (
+          <ButtonSelectGroup fullWidth={false} {...props} initialValue={false} >
+            {options.map((x) => (
+              <ButtonSelectGroup.Option value={x.value} key={x.id}>
+                {x.copy}
+              </ButtonSelectGroup.Option>
+            ))}
+          </ButtonSelectGroup>
+        ),
+        labelCopy: 'Booleans Are Tricky -- false should count as valid here',
+        validators: [validateExists],
+        options: [
+          { value: true, copy: 'True', id: 1 },
+          { value: false, copy: 'False', id: 2 },
+        ],
+        tid: 'booleanGroup-tid',
+      },
+      checkbox: {
+        component: (props, options) => {
+          return (
+            <CheckboxInput {...props} initialValue={true}>
+              I agree to the{' '}
+              <a href="/" target="_blank">
+                Agreement
+              </a>
+            </CheckboxInput>
+          )
+        },
+        name: "le-check-unchecked",
+        tid: "le-tid-unchecked",
+        validators: [(n) => {
+          // We only will accept the value of true!
+          if (n === true) {
+            return '' 
+          }
+          return 'You must agree to submit form'
+        }],
+      },
+      evenNumText: {
+        component: (props, options) => {
+          return <TextInput {...props} initialValue="abcdef" />
+        },
+        validators: [
+          validateExists,
+          validateMinMaxFactory.call(null, 5, 7),
+        ],
+        labelCopy:
+          "Validation happens after first form blur ('touched')--Value's length is between 5 and 7 characters",
+        tid: 'example-data-tid',
+      },
+    },
+    onSubmit: async (formData) => {
+      alert(
+        'form submission successful with values:' + JSON.stringify(formData)
+      )
+    },
+  }}
+>
+   {(api) => {
+    const {
+      field,
+      getFormErrorMessage,
+      getFormIsValid,
+      getFormInteractedWith,
+    } = api
+    return (
+      <div>
+        <TitleLarge.Serif.Book500>Example Form</TitleLarge.Serif.Book500>
+
+        <Spacer.H16 />
+
+        {!!getFormInteractedWith() && (
+          <>
+            <InfoMessage.Alert.Success>
+              {'Form interacted with.'}
+            </InfoMessage.Alert.Success>
+          </>
+        )}
+
+        {getFormErrorMessage() && (
+          <>
+            <InfoMessage.Alert.Error>
+              {getFormErrorMessage()}
+            </InfoMessage.Alert.Error>
+          </>
+        )}
+
+        {field('evenNumText')}
+
+        <Spacer.H16 />
+
+        {field('dollar')}
+        
+        <Spacer.H16 />
+
+        {field('email')}
+
+        <Spacer.H16 />
+
+        {field('zipCode')}
+
+        <Spacer.H16 />
+
+        {field('birthdate')}
+
+        <Spacer.H16 />
+
+        {field('booleanGroup')}
+        
+        <Spacer.H16 />
+
+        {field('checkbox')}
+
+        <Spacer.H16 />
+
+        <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
+          Submit
+        </Button.Medium.Black>
+      </div>
+    )
+  }}
+</Form>
+```

--- a/src/components/Inputs/BirthdateInput/BirthdateInput.js
+++ b/src/components/Inputs/BirthdateInput/BirthdateInput.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { TextMaskedInput } from '../TextMaskedInput'
 import createAutoCorrectedDatePipe from 'text-mask-addons/dist/createAutoCorrectedDatePipe'
@@ -39,7 +39,7 @@ const PrivateBirthdateInput = (props) => {
     validator
   )
   const val = currentValue || initialValue
-  const [touched, setTouched] = useState(false)
+  const [touched, setTouched] = useState(initialValue ? true : false)
   const [value, setValue] = useState(val || '')
 
   const callErrorHandlers = (value, handlerFn) => {
@@ -69,6 +69,15 @@ const PrivateBirthdateInput = (props) => {
     }
   }
 
+  // Initial Value aka prefilled—are considered "touched", but must prevalidate
+  // which will in turn update the internal form state as to their validity
+  useEffect(() => {
+    if (!!formChangeHandler && initialValue) {
+      console.log('BirthdateInput useEffect -- calling doValidation')
+      doValidation(initialValue, true)
+    }
+  }, [])
+
   const [doValidation] = useInputValidation({
     validate,
     setError,
@@ -77,9 +86,9 @@ const PrivateBirthdateInput = (props) => {
   })
 
   const getClasses = () => {
-    return !!getError(currentError, touched) ?
-      `BirthdateInput ${styles.TextInput} ${errorStyles.Error}` :
-      `BirthdateInput ${styles.TextInput}`
+    return !!getError(currentError, touched)
+      ? `BirthdateInput ${styles.TextInput} ${errorStyles.Error}`
+      : `BirthdateInput ${styles.TextInput}`
   }
 
   return (

--- a/src/components/Inputs/CheckboxInput/CheckboxInput.js
+++ b/src/components/Inputs/CheckboxInput/CheckboxInput.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { COLORS } from '../../Colors.js'
 import { Body } from '../../Type/Body.js'
@@ -37,7 +37,7 @@ export const CheckboxInput = ({
   ...rest
 }) => {
   const initialChecked = currentValue || initialValue || false
-  const [touched, setTouched] = useState(initialChecked)
+  const [touched, setTouched] = useState(initialValue ? true : false)
   const [isChecked, setIsChecked] = useState(initialChecked)
   const [getError, setError, getFormattedError, validate] = useErrorMessage(
     validator
@@ -47,6 +47,15 @@ export const CheckboxInput = ({
     setError,
     formChangeHandler,
   })
+
+  // Initial Value aka prefilled—are considered "touched", but must prevalidate
+  // which will in turn update the internal form state as to their validity
+  useEffect(() => {
+    if (!!formChangeHandler && initialValue) {
+      console.log('CheckboxInput useEffect -- calling doValidation')
+      doValidation(initialValue, true)
+    }
+  }, [])
 
   const onChange = (ev) => {
     // It feels like a checkbox isn't something you blur off of, so I'm electing to

--- a/src/components/Inputs/TextAreaInput/TextAreaInput.js
+++ b/src/components/Inputs/TextAreaInput/TextAreaInput.js
@@ -57,7 +57,7 @@ function PrivateTextAreaInput({
 
   const [value, setValue] = useState(currentValue || initialValue || '')
 
-  const [touched, setTouched] = useState(false)
+  const [touched, setTouched] = useState(initialValue ? true : false)
 
   const [doValidation] = useInputValidation({
     validate,
@@ -83,6 +83,15 @@ function PrivateTextAreaInput({
       setFieldTouched(true)
     }
   }
+
+  // Initial Value aka prefilled—are considered "touched", but must prevalidate
+  // which will in turn update the internal form state as to their validity
+  useEffect(() => {
+    if (!!formChangeHandler && initialValue) {
+      console.log('TextAreaInput useEffect -- calling doValidation')
+      doValidation(initialValue, '')
+    }
+  }, [])
 
   const onBlur = (ev) => {
     setAllTouched()

--- a/src/components/Inputs/TextAreaInput/TextAreaInput.js
+++ b/src/components/Inputs/TextAreaInput/TextAreaInput.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 
 import { InputLabel } from '../InputLabel'

--- a/src/components/Inputs/TextInput/TextInput.js
+++ b/src/components/Inputs/TextInput/TextInput.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 
 import { InputLabel } from '../InputLabel'
@@ -57,7 +57,7 @@ function PrivateTextInput({
 
   const [value, setValue] = useState(currentValue || initialValue || '')
 
-  const [touched, setTouched] = useState(false)
+  const [touched, setTouched] = useState(initialValue ? true : false)
 
   const [doValidation] = useInputValidation({
     validate,
@@ -83,6 +83,15 @@ function PrivateTextInput({
       setFieldTouched(true)
     }
   }
+
+  // Initial Value aka prefilled—are considered "touched", but must prevalidate
+  // which will in turn update the internal form state as to their validity
+  useEffect(() => {
+    if (!!formChangeHandler && initialValue) {
+      console.log('TextInput useEffect -- calling doValidation')
+      doValidation(initialValue, true)
+    }
+  }, [])
 
   const onBlur = (ev) => {
     setAllTouched()

--- a/src/components/Inputs/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/Inputs/TextMaskedInput/TextMaskedInput.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import MaskedInput from 'react-text-mask'
 import useErrorMessage from '../../../hooks/useErrorMessage.js'
@@ -35,7 +35,9 @@ export const TextMaskedInput = (props) => {
   )
   const val = currentValue || initialValue
   const [value, setValue] = useState(val || '')
-  const [internalTouched, internalSetTouched] = useState(false)
+  const [internalTouched, internalSetTouched] = useState(
+    initialValue ? true : false
+  )
   const whichTouched = getTouched ? getTouched : internalTouched
   const whichSetTouched = setTouched ? setTouched : internalSetTouched
   const [internalDoValidation] = useInputValidation({
@@ -63,6 +65,16 @@ export const TextMaskedInput = (props) => {
     }
   }
 
+  // Initial Value aka prefilled—are considered "touched", but must prevalidate
+  // which will in turn update the internal form state as to their validity
+  useEffect(() => {
+    if (!!formChangeHandler && initialValue) {
+      console.log('TextMaskedInput useEffect -- calling formChangeHandler')
+      const cleansed = cleanse(initialValue)
+      whichDoValidation(cleansed, true)
+    }
+  }, [])
+
   const onBlur = (ev) => {
     // We set touched to change the react state, but it's async and
     // processing still, so, we use a flag for doValidation
@@ -81,9 +93,9 @@ export const TextMaskedInput = (props) => {
   }
 
   const getClasses = () => {
-    return !!getError(currentError, whichTouched) ?
-      `TextMaskedInput ${styles.TextInput} ${errorStyles.Error}` :
-      `TextMaskedInput ${styles.TextInput}`
+    return !!getError(currentError, whichTouched)
+      ? `TextMaskedInput ${styles.TextInput} ${errorStyles.Error}`
+      : `TextMaskedInput ${styles.TextInput}`
   }
 
   const getMaskedInputByType = (mask) => {

--- a/src/components/Inputs/ZipInput/ZipInput.js
+++ b/src/components/Inputs/ZipInput/ZipInput.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { TextMaskedInput } from '../TextMaskedInput'
 import useErrorMessage from '../../../hooks/useErrorMessage.js'
@@ -26,7 +26,7 @@ export const ZipInput = (props) => {
     validator
   )
   const val = currentValue || initialValue
-  const [touched, setTouched] = useState(false)
+  const [touched, setTouched] = useState(initialValue ? true : false)
   const [value, setValue] = useState(val || '')
 
   // This has to come before useInputValidation setup below
@@ -45,6 +45,13 @@ export const ZipInput = (props) => {
     }
   }
 
+  useEffect(() => {
+    if (!!formChangeHandler && initialValue) {
+      console.log('ZipInput useEffect -- calling doValidation')
+      formChangeHandler(initialValue, '')
+    }
+  }, [])
+
   const [doValidation] = useInputValidation({
     validate,
     setError,
@@ -53,9 +60,9 @@ export const ZipInput = (props) => {
   })
 
   const getClasses = () => {
-    return !!getError(currentError, touched) ?
-      `ZipInput ${styles.TextInput} ${errorStyles.Error}` :
-      `ZipInput ${styles.TextInput}`
+    return !!getError(currentError, touched)
+      ? `ZipInput ${styles.TextInput} ${errorStyles.Error}`
+      : `ZipInput ${styles.TextInput}`
   }
 
   return (


### PR DESCRIPTION
**Description:**
- [Asana Task](https://app.asana.com/0/1136962714401929/1146473861245233/f)
- Questions Page - Continue disabled with all inputs prefilled

Essentially, `initialValue` for a given field will now result:

1. field is considered _touched_
2. the field's validation will get called. This means the form state is a aware of the field's validity

If the initial values are valid values and all for fields are using this, the `buttonIsValid()` will return true and thus the submit button will show as enabled.

**Screenshots:**

![image](https://user-images.githubusercontent.com/142403/67621343-0b7e7b80-f7c4-11e9-90cd-0263781db3c3.png)

** Notes: **

To verify interact with http://localhost:9008/#/Components/FormPrefilled and try manually setting the `initialValue` for the fields to invalid values and watch that the submit button gets disabled.
