### PR TITLE
SCSS test to prevent comment style which breaks monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "stats": "node bin/generateStats.js --write",
     "styleguide": "yarn compile-css && styleguidist server",
     "styleguide:build": "yarn compile-css && styleguidist build",
-    "test": "jest",
+    "test": "jest && yarn test:scss",
     "test:coverage": "jest --collectCoverageFrom '[\"src/components/**/*.js\", \"src/hooks/**/*.js\"]' --coverage && open ./coverage/lcov-report/index.html",
     "test:debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand",
-    "test:update": "jest --updateSnapshot"
+    "test:update": "jest --updateSnapshot",
+    "test:scss": "./scss-test.sh"
   },
   "jest": {
     "verbose": true,

--- a/scss-test.sh
+++ b/scss-test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash 
+
+if grep -r --include "*.module.scss" "//" . 
+then 
+  printf "\nSCSS test failed. Please only use /* */ comment syntax in .module.scss files, never //.\n\n" 
+  exit 
+else
+  printf "SCSS test succeeded\n" 
+fi


### PR DESCRIPTION
Prevent monorepo breaking in stage/prod environments due to postcss dying on `//` comment syntax in `.module.scss` files. Followup to https://github.com/getethos/ethos-design-system/pull/116