### PR TITLE
Add aria-hidden, tests to Spacer (a11y fix)

### DIFF
--- a/src/components/Inputs/BirthdateInput/__snapshots__/BirthdateInput.test.js.snap
+++ b/src/components/Inputs/BirthdateInput/__snapshots__/BirthdateInput.test.js.snap
@@ -9,6 +9,7 @@ Array [
     What is your birthdate?
   </label>,
   <div
+    aria-hidden={true}
     className="Spacer"
     style={
       Object {

--- a/src/components/Inputs/ButtonSelectGroup/__snapshots__/ButtonSelectGroup.test.js.snap
+++ b/src/components/Inputs/ButtonSelectGroup/__snapshots__/ButtonSelectGroup.test.js.snap
@@ -14,6 +14,7 @@ Array [
       options
     </span>
     <div
+      aria-hidden={true}
       className="Spacer"
       style={
         Object {
@@ -66,6 +67,7 @@ Array [
       options
     </span>
     <div
+      aria-hidden={true}
       className="Spacer"
       style={
         Object {
@@ -118,6 +120,7 @@ Array [
       options
     </span>
     <div
+      aria-hidden={true}
       className="Spacer"
       style={
         Object {

--- a/src/components/Inputs/EmailInput/__snapshots__/EmailInput.test.js.snap
+++ b/src/components/Inputs/EmailInput/__snapshots__/EmailInput.test.js.snap
@@ -9,6 +9,7 @@ Array [
     Your email
   </label>,
   <div
+    aria-hidden={true}
     className="Spacer"
     style={
       Object {

--- a/src/components/Inputs/NumberInput/__snapshots__/NumberInput.test.js.snap
+++ b/src/components/Inputs/NumberInput/__snapshots__/NumberInput.test.js.snap
@@ -9,6 +9,7 @@ Array [
     Enter a number (must be even to validate)
   </label>,
   <div
+    aria-hidden={true}
     className="Spacer"
     style={
       Object {

--- a/src/components/Inputs/PasswordInput/__snapshots__/PasswordInput.test.js.snap
+++ b/src/components/Inputs/PasswordInput/__snapshots__/PasswordInput.test.js.snap
@@ -9,6 +9,7 @@ Array [
     Password
   </label>,
   <div
+    aria-hidden={true}
     className="Spacer"
     style={
       Object {

--- a/src/components/Inputs/TextAreaInput/__snapshots__/TextAreaInput.test.js.snap
+++ b/src/components/Inputs/TextAreaInput/__snapshots__/TextAreaInput.test.js.snap
@@ -9,6 +9,7 @@ Array [
     The label
   </label>,
   <div
+    aria-hidden={true}
     className="Spacer"
     style={
       Object {

--- a/src/components/Inputs/TextInput/__snapshots__/TextInput.test.js.snap
+++ b/src/components/Inputs/TextInput/__snapshots__/TextInput.test.js.snap
@@ -9,6 +9,7 @@ Array [
     The label
   </label>,
   <div
+    aria-hidden={true}
     className="Spacer"
     style={
       Object {

--- a/src/components/Inputs/ZipInput/__snapshots__/ZipInput.test.js.snap
+++ b/src/components/Inputs/ZipInput/__snapshots__/ZipInput.test.js.snap
@@ -9,6 +9,7 @@ Array [
     What is your zip code?
   </label>,
   <div
+    aria-hidden={true}
     className="Spacer"
     style={
       Object {

--- a/src/components/Spacer/Spacer.js
+++ b/src/components/Spacer/Spacer.js
@@ -20,7 +20,7 @@ function Space({ height, width, flexGrow, ...rest }) {
   if (validWidth) style.width = validWidth
   if (validHeight) style.height = validHeight
 
-  return <div className="Spacer" style={style} />
+  return <div className="Spacer" style={style} aria-hidden />
 }
 
 Space.HEIGHTS = {

--- a/src/components/Spacer/Spacer.test.js
+++ b/src/components/Spacer/Spacer.test.js
@@ -3,6 +3,100 @@ import { Spacer } from './Spacer.js'
 import renderer from 'react-test-renderer'
 
 describe('Spacer', () => {
+  describe('matches snapshot', () => {
+    test('Spacer.H80', () => {
+      expect(deepSnapshot(<Spacer.H80 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.H72', () => {
+      expect(deepSnapshot(<Spacer.H72 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.H64', () => {
+      expect(deepSnapshot(<Spacer.H64 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.H56', () => {
+      expect(deepSnapshot(<Spacer.H56 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.H48', () => {
+      expect(deepSnapshot(<Spacer.H48 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.H40', () => {
+      expect(deepSnapshot(<Spacer.H40 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.H32', () => {
+      expect(deepSnapshot(<Spacer.H32 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.H24', () => {
+      expect(deepSnapshot(<Spacer.H24 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.H16', () => {
+      expect(deepSnapshot(<Spacer.H16 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.H8', () => {
+      expect(deepSnapshot(<Spacer.H8 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.H4', () => {
+      expect(deepSnapshot(<Spacer.H4 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.W80', () => {
+      expect(deepSnapshot(<Spacer.W80 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.W72', () => {
+      expect(deepSnapshot(<Spacer.W72 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.W64', () => {
+      expect(deepSnapshot(<Spacer.W64 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.W64', () => {
+      expect(deepSnapshot(<Spacer.W64 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.W56', () => {
+      expect(deepSnapshot(<Spacer.W56 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.W48', () => {
+      expect(deepSnapshot(<Spacer.W48 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.W40', () => {
+      expect(deepSnapshot(<Spacer.W40 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.W32', () => {
+      expect(deepSnapshot(<Spacer.W32 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.W24', () => {
+      expect(deepSnapshot(<Spacer.W24 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.W16', () => {
+      expect(deepSnapshot(<Spacer.W16 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.W8', () => {
+      expect(deepSnapshot(<Spacer.W8 />)).toMatchSnapshot()
+    })
+
+    test('Spacer.W4', () => {
+      expect(deepSnapshot(<Spacer.W4 />)).toMatchSnapshot()
+    })
+  })
+
   describe('API', () => {
     test('Spacer exports properly', () => {
       expect(Spacer).toBeDefined()
@@ -32,3 +126,7 @@ describe('Spacer', () => {
     })
   })
 })
+
+export function deepSnapshot(jsx) {
+  return renderer.create(jsx).toJSON()
+}

--- a/src/components/Spacer/__snapshots__/Spacer.test.js.snap
+++ b/src/components/Spacer/__snapshots__/Spacer.test.js.snap
@@ -1,0 +1,277 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Spacer matches snapshot Spacer.H4 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "height": 4,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.H8 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "height": 8,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.H16 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "height": 16,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.H24 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "height": 24,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.H32 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "height": 32,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.H40 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "height": 40,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.H48 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "height": 48,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.H56 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "height": 56,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.H64 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "height": 64,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.H72 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "height": 72,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.H80 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "height": 80,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.W4 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "width": 4,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.W8 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "width": 8,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.W16 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "width": 16,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.W24 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "width": 24,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.W32 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "width": 32,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.W40 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "width": 40,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.W48 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "width": 48,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.W56 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "width": 56,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.W64 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "width": 64,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.W64 2`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "width": 64,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.W72 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "width": 72,
+    }
+  }
+/>
+`;
+
+exports[`Spacer matches snapshot Spacer.W80 1`] = `
+<div
+  aria-hidden={true}
+  className="Spacer"
+  style={
+    Object {
+      "width": 80,
+    }
+  }
+/>
+`;


### PR DESCRIPTION
**Description:**
- [Asana Task](https://app.asana.com/0/1128987846241693/1117917027835300)
- Ideally we do spacing in CSS. To the extent that we use HTML we should be adding aria-hidden to hide the nonsemantic tags from screen readers.
- I added this elsewhere and realized we should add it here. It's a one-liner + tests.