### PR TITLE
Cap lint problems

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,12 @@ module.exports = {
     'plugin:prettier/recommended',
   ],
 
+  rules: {
+    // TODO: (1) fix these warnings, (2) remove --max-warnings in package.json.
+    'no-unused-vars': 'warn',
+    'react/prop-types': 'warn',
+  },
+
   // https://eslint.org/docs/user-guide/configuring#specifying-parser
   // This is necessary for various ES language features we use.
   parser: 'babel-eslint',

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: node_js
+
 install:
   - yarn
+
 script:
+  - yarn lint
   - yarn test
+
 after_success:
   - yarn build

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "e2e:ci": "CYPRESS_SUPPORT=y yarn run build && start-server-and-test styleguide http://localhost:9008 cy:open",
     "e2e:dev": "CYPRESS_SUPPORT=y start-server-and-test styleguide http://localhost:9008 cy:open",
     "format": "prettier --write \"src/components/**/*.*css\"",
-    "lint": "eslint src",
+    "lint": "eslint src --max-warnings 82",
     "prerelease": "yarn test && yarn build",
     "spotcheck": "yarn compile-css && echo \"\n*****\n* View the spotcheck at http://localhost:8080/spotcheck.html\n*****\n\" && webpack-dev-server ",
     "stats": "node bin/generateStats.js --write",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "e2e:ci": "CYPRESS_SUPPORT=y yarn run build && start-server-and-test styleguide http://localhost:9008 cy:open",
     "e2e:dev": "CYPRESS_SUPPORT=y start-server-and-test styleguide http://localhost:9008 cy:open",
     "format": "prettier --write \"src/components/**/*.*css\"",
-    "lint": "eslint src --max-warnings 82",
+    "lint": "eslint src --max-warnings 81",
     "prerelease": "yarn test && yarn build",
     "spotcheck": "yarn compile-css && echo \"\n*****\n* View the spotcheck at http://localhost:8080/spotcheck.html\n*****\n\" && webpack-dev-server ",
     "stats": "node bin/generateStats.js --write",

--- a/src/components/Spacer/Spacer.test.js
+++ b/src/components/Spacer/Spacer.test.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import renderer from 'react-test-renderer'
 import { Spacer } from './Spacer.js'
 
 describe('Spacer', () => {

--- a/src/components/Spacer/Spacer.test.js
+++ b/src/components/Spacer/Spacer.test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { Spacer } from './Spacer.js'
 
 describe('Spacer', () => {
@@ -58,10 +59,6 @@ describe('Spacer', () => {
       expect(deepSnapshot(<Spacer.W64 />)).toMatchSnapshot()
     })
 
-    test('Spacer.W64', () => {
-      expect(deepSnapshot(<Spacer.W64 />)).toMatchSnapshot()
-    })
-
     test('Spacer.W56', () => {
       expect(deepSnapshot(<Spacer.W56 />)).toMatchSnapshot()
     })
@@ -92,35 +89,6 @@ describe('Spacer', () => {
 
     test('Spacer.W4', () => {
       expect(deepSnapshot(<Spacer.W4 />)).toMatchSnapshot()
-    })
-  })
-
-  describe('API', () => {
-    test('Spacer exports properly', () => {
-      expect(Spacer).toBeDefined()
-      expect(Spacer.H80).toBeDefined()
-      expect(Spacer.H72).toBeDefined()
-      expect(Spacer.H64).toBeDefined()
-      expect(Spacer.H56).toBeDefined()
-      expect(Spacer.H48).toBeDefined()
-      expect(Spacer.H40).toBeDefined()
-      expect(Spacer.H32).toBeDefined()
-      expect(Spacer.H24).toBeDefined()
-      expect(Spacer.H16).toBeDefined()
-      expect(Spacer.H8).toBeDefined()
-      expect(Spacer.H4).toBeDefined()
-      expect(Spacer.W80).toBeDefined()
-      expect(Spacer.W72).toBeDefined()
-      expect(Spacer.W64).toBeDefined()
-      expect(Spacer.W64).toBeDefined()
-      expect(Spacer.W56).toBeDefined()
-      expect(Spacer.W48).toBeDefined()
-      expect(Spacer.W40).toBeDefined()
-      expect(Spacer.W32).toBeDefined()
-      expect(Spacer.W24).toBeDefined()
-      expect(Spacer.W16).toBeDefined()
-      expect(Spacer.W8).toBeDefined()
-      expect(Spacer.W4).toBeDefined()
     })
   })
 })

--- a/src/components/Spacer/__snapshots__/Spacer.test.js.snap
+++ b/src/components/Spacer/__snapshots__/Spacer.test.js.snap
@@ -240,18 +240,6 @@ exports[`Spacer matches snapshot Spacer.W64 1`] = `
 />
 `;
 
-exports[`Spacer matches snapshot Spacer.W64 2`] = `
-<div
-  aria-hidden={true}
-  className="Spacer"
-  style={
-    Object {
-      "width": 64,
-    }
-  }
-/>
-`;
-
 exports[`Spacer matches snapshot Spacer.W72 1`] = `
 <div
   aria-hidden={true}


### PR DESCRIPTION
**Description:**
- [Round 1](https://github.com/getethos/ethos-design-system/pull/126), [Round 2](https://github.com/getethos/ethos-design-system/pull/128)  
- This should prevent further lint errors by failing locally and in CI if you add more.
- The basic idea is, we have 82 issues, and if that goes up, the build fails. Later we reduce 82 to 0.
- TLDR: this doesn't fix everything we could possibly fix, but it prevents things from worsening.

**Notes:**

- The biggest source of remaining lint problems (30%) is propTypes in Form.js.
- The rest are propTypes elsewhere and `no-unused-vars`.
- The docs for --max-warnings: https://eslint.org/docs/user-guide/command-line-interface#exit-codes

**Screenshots:**

Here is what it looks like when you add a new lint problem (unused variable `foo`):

<img width="688" alt="Capture d’écran 2019-10-30 à 16 14 19" src="https://user-images.githubusercontent.com/49569137/67906028-8d5a0600-fb30-11e9-8faa-4667fa62e317.png">