### PR TITLE
Remove unused variables in hooks causing linting warnings

### DIFF
--- a/src/hooks/useFormState.js
+++ b/src/hooks/useFormState.js
@@ -15,7 +15,6 @@ export function useFormState(initialState) {
   Object.keys(initialState).map((key) => {
     initialHiddenState[key] = false
   })
-  const [fieldsHiddenState, setFieldsHiddenState] = useState(initialHiddenState)
 
   // Returns a function that updates state for the field, tracked by fieldName
   function setFieldState(fieldName) {

--- a/src/hooks/useFormState.test.js
+++ b/src/hooks/useFormState.test.js
@@ -12,11 +12,11 @@ describe('useFormState hook', () => {
         getFieldErrors,
         getFieldValues,
         ,
-        getFormErrorMessage,
+        ,
         ,
         getFormIsValid,
         ,
-        setFieldsHidden,
+        ,
       ] = useFormState(initialState)
       expect(getFieldErrorsString()).toEqual('')
       expect(getFieldErrors()).toEqual(initialState)
@@ -35,11 +35,11 @@ describe('useFormState hook', () => {
         getFieldErrors,
         getFieldValues,
         ,
-        getFormErrorMessage,
+        ,
         ,
         getFormIsValid,
         ,
-        setFieldsHidden,
+        ,
       ] = useFormState(initialState)
       expect(getFieldErrorsString()).toEqual('error1, error2')
       expect(getFieldErrors()).toEqual(initialState)
@@ -58,7 +58,7 @@ describe('useFormState hook', () => {
         getFieldErrors,
         getFieldValues,
         ,
-        getFormErrorMessage,
+        ,
         ,
         getFormIsValid,
         ,

--- a/src/hooks/useRequired.js
+++ b/src/hooks/useRequired.js
@@ -2,7 +2,6 @@ const useRequired = (requiredProps) => {
   const includesRequired = (actualProps) => {
     const missingProps = []
     const keys = Object.keys(actualProps)
-    const vals = Object.values(actualProps)
 
     // prop's missing, or, it's there but its value undefined or null
     requiredProps.forEach((prop) => {


### PR DESCRIPTION
**Description:**
- [Asana Task](https://app.asana.com/0/1136962714401929/1146342193058673/f)
-     Remove unused variables in hooks causing linting warnings


Gets us down to 
✖ 55 problems (0 errors, 55 warnings)