### PR TITLE
useErrorMessage when no validator

### DIFF
--- a/src/hooks/useErrorMessage.js
+++ b/src/hooks/useErrorMessage.js
@@ -4,6 +4,15 @@ import { Spacer } from '../components'
 import { INIT_INVALID } from '../helpers/constants.js'
 
 const useErrorMessage = (validator) => {
+  // TODO: remove and require validator to be passed if useErrorMessage used
+  if (!validator) {
+    console.warn(
+      'useErrorMessage called without a validator—soon this will cause an error'
+    )
+  }
+  const noopValidator = () => ''
+  const resolvedValidator = validator ? validator : noopValidator
+
   const [displayError, setDisplayError] = useState('')
 
   const setError = (msg) => {
@@ -37,7 +46,7 @@ const useErrorMessage = (validator) => {
   }
 
   const validate = (thingToValidate) => {
-    return validator.call(null, thingToValidate)
+    return resolvedValidator.call(null, thingToValidate)
   }
 
   return [getError, setError, getFormattedError, validate]


### PR DESCRIPTION
**Description:**
- [Asana Task](https://app.asana.com/0/1136962714401929/1147477344968945/f)
- Fix useErrorMessage when no validator

Fix issue when consumer does not supply a validator to a component (it is not required), we inject a noop one so we don't error out calling undefined.

_We'll do a part II to this and [remove calls to useErrorMessage](https://app.asana.com/0/1136962714401929/1147477344968947/f) if the component hasn't been provided a `validator` or similar_
