### PR TITLE
Add colors for arrowicons in buttons, and expand styleguide demos

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -123,10 +123,7 @@ const ArrowIconInline = (shouldFlip) => {
         shouldFlip ? styles.backArrowIconInline : styles.arrowIconInline
       }
     >
-      <path
-        d="M7.00016 0.333374L5.82516 1.50837L10.4752 6.16671H0.333496V7.83337H10.4752L5.82516 12.4917L7.00016 13.6667L13.6668 7.00004L7.00016 0.333374Z"
-        fill="white"
-      />
+      <path d="M7.00016 0.333374L5.82516 1.50837L10.4752 6.16671H0.333496V7.83337H10.4752L5.82516 12.4917L7.00016 13.6667L13.6668 7.00004L7.00016 0.333374Z" />
     </svg>
   )
 }

--- a/src/components/Button/Button.md
+++ b/src/components/Button/Button.md
@@ -1,13 +1,11 @@
 Set of Design-approved public buttons.
 
-```jsx
-<Button.Medium.Black>Button.Medium.Black</Button.Medium.Black>
-```
+---
+
+## Color + border styles
 
 ```jsx
-<Button.Medium.Black fullWidth>
-  Button.Medium.Black fullWidth
-</Button.Medium.Black>
+<Button.Medium.Black>Button.Medium.Black</Button.Medium.Black>
 ```
 
 ```jsx
@@ -17,9 +15,16 @@ Set of Design-approved public buttons.
 ```
 
 ```jsx
-<Button.Medium.WhiteOutline>
-  Button.Medium.WhiteOutline
-</Button.Medium.WhiteOutline>
+<div style={{ backgroundColor: 'var(--BrandForest)', padding: 20 }}>
+  <strong style={{ color: 'white' }}>
+    Background supplied so the button is visible.
+  </strong>
+  <br />
+  <br />
+  <Button.Medium.WhiteOutline>
+    Button.Medium.WhiteOutline
+  </Button.Medium.WhiteOutline>
+</div>
 ```
 
 ```jsx
@@ -35,14 +40,28 @@ Set of Design-approved public buttons.
 ```
 
 ```jsx
-<Button.Medium.Black arrowIcon>
-  Button.Medium.Black with arrowIcon
+<Button.Unstyled>Button.Unstyled</Button.Unstyled>
+```
+
+---
+
+## Fullwidth prop
+
+```jsx
+<Button.Medium.Black fullWidth>
+  Button.Medium.Black fullWidth
 </Button.Medium.Black>
 ```
 
+---
+
+## Arrow icons
+
+#### Forward + back
+
 ```jsx
-<Button.Medium.Black fullWidth arrowIcon>
-  Button.Medium.Black + fullWidth + arrowIcon
+<Button.Medium.Black arrowIcon>
+  Button.Medium.Black with arrowIcon
 </Button.Medium.Black>
 ```
 
@@ -52,17 +71,49 @@ Set of Design-approved public buttons.
 </Button.Medium.Black>
 ```
 
+#### Fullwidth
+
+```jsx
+<Button.Medium.Black fullWidth arrowIcon>
+  Button.Medium.Black + fullWidth + arrowIcon
+</Button.Medium.Black>
+```
+
 ```jsx
 <Button.Medium.Black fullWidth backArrowIcon>
   Button.Medium.Black + fullWidth + backArrowIcon
 </Button.Medium.Black>
 ```
 
+#### Colors + colors when hovered
+
 ```jsx
-<Button.Unstyled>Button.Unstyled</Button.Unstyled>
+<Button.Medium.Stateful.Default arrowIcon>
+  Button.Medium.Stateful.Default + arrowIcon
+</Button.Medium.Stateful.Default>
 ```
 
-<strong>The following are only for use in indicated places</strong>
+```jsx
+<Button.Medium.BlackOutline arrowIcon>
+  Button.Medium.BlackOutline + arrowIcon
+</Button.Medium.BlackOutline>
+```
+
+```jsx
+<Button.Unstyled arrowIcon>
+  Button.Unstyled + arrowIcon (different margin on arrow)
+</Button.Unstyled>
+```
+
+```jsx
+<Button.Unstyled backArrowIcon>Button.Unstyled + backArrowIcon</Button.Unstyled>
+```
+
+---
+
+## Do not use
+
+#### The following are only for use in indicated places
 
 PLEASE ONLY USE IN UniversalNavbar! In fact, have a look at
 UniversalNavbar component to see this in use.

--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -23,7 +23,7 @@ button,
   border: 1px solid transparent;
   font-family: var(--Theinhardt-font-stack);
   color: var(--GrayPrimary--translucent);
-  path: {
+  path {
     fill: var(--GrayPrimary--translucent);
   }
 

--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -23,6 +23,9 @@ button,
   border: 1px solid transparent;
   font-family: var(--Theinhardt-font-stack);
   color: var(--GrayPrimary--translucent);
+  path: {
+    fill: var(--GrayPrimary--translucent);
+  }
 
   transition: var(--transition-default);
   transition-property: background-color, border-color, color;
@@ -86,11 +89,21 @@ button,
   background: none;
   border: none;
   padding: 0;
+  .arrowIconInline {
+    margin-top: 1px;
+  }
+
+  .backArrowIconInline {
+    margin-top: 1px;
+  }
 }
 
 .Button.Black {
   background-color: var(--GrayPrimary--translucent);
   color: var(--White);
+  path {
+    fill: var(--White);
+  }
   @include light-on-dark-font-smoothing;
 
   &:not([disabled]) {
@@ -107,6 +120,9 @@ button,
     border-color: var(--Transparent--white);
     background-color: var(--GrayStrokeAndDisabled--translucent);
     color: var(--White);
+    path {
+      fill: var(--White);
+    }
   }
 }
 
@@ -114,18 +130,27 @@ button,
   border-color: var(--GrayPrimary--opaque);
   background-color: var(--Transparent--white);
   color: var(--GrayPrimary--opaque);
+  path {
+    fill: var(--GrayPrimary--opaque);
+  }
 
   &:not([disabled]) {
     &:hover {
       border-color: var(--GrayDarkHover--translucent);
       background-color: var(--GrayDarkHover--translucent);
       color: var(--White);
+      path {
+        fill: var(--White);
+      }
     }
 
     &:active {
       border-color: var(--GrayDarkHover--translucent);
       background-color: var(--GrayDarkHover--translucent);
       color: var(--White);
+      path {
+        fill: var(--White);
+      }
     }
   }
 
@@ -133,6 +158,9 @@ button,
     border-color: var(--Transparent--white);
     background-color: var(--GrayStrokeAndDisabled--translucent);
     color: var(--White);
+    path {
+      fill: var(--White);
+    }
   }
 }
 
@@ -140,18 +168,27 @@ button,
   border-color: var(--White);
   background-color: var(--Transparent--white);
   color: var(--White);
+  path {
+    fill: var(--White);
+  }
 
   &:not([disabled]) {
     &:hover {
       border-color: var(--White);
       background-color: var(--White);
       color: var(--GrayPrimary--translucent);
+      path {
+        fill: var(--GrayPrimary--translucent);
+      }
     }
 
     &:active {
       border-color: var(--White);
       background-color: var(--White);
       color: var(--GrayPrimary--translucent);
+      path {
+        fill: var(--GrayPrimary--translucent);
+      }
     }
   }
 
@@ -159,6 +196,9 @@ button,
     border-color: var(--Transparent--white);
     background-color: var(--GrayStrokeAndDisabled--translucent);
     color: var(--White);
+    path {
+      fill: var(--White);
+    }
   }
 }
 
@@ -194,17 +234,26 @@ button,
     border-color: var(--BrandForest);
     background-color: var(--BrandForest);
     color: var(--White);
+    path {
+      fill: var(--White);
+    }
   }
 
   border-color: var(--GrayStrokeAndDisabled--translucent);
   background-color: var(--Transparent--white);
   color: var(--GrayPrimary--translucent);
+  path {
+    fill: var(--GrayPrimary--translucent);
+  }
 
   &:not([disabled]) {
     &:hover {
       border-color: var(--GrayStrokeAndDisabled--translucent);
       background-color: var(--GrayLightHover--translucent);
       color: var(--GrayPrimary--translucent);
+      path {
+        fill: var(--GrayPrimary--translucent);
+      }
     }
 
     /* Bugfix: Need this one to have more specificity then ^ hover */
@@ -221,6 +270,9 @@ button,
     border-color: var(--Transparent--white);
     background-color: var(--GrayStrokeAndDisabled--translucent);
     color: var(--White);
+    path {
+      fill: var(--White);
+    }
   }
 
   /*


### PR DESCRIPTION
Added scss rules so that the icons are the same color as the test in their button; also added some more examples and structure to the button.md styleguide page.

Old version where all arrow icons are white:
![x](https://i.gyazo.com/7c81467e49dd9de7369582c2bcb2e059.png)

New: 
![x](https://i.gyazo.com/9abd0790f4c44063b3a7b44fbccb3a2d.png)