### PR TITLE
Fixes warnings on children being an object

### DIFF
--- a/src/components/Inputs/ButtonSelectGroup/ButtonSelectGroup.js
+++ b/src/components/Inputs/ButtonSelectGroup/ButtonSelectGroup.js
@@ -149,7 +149,7 @@ export const ButtonSelectGroup = ({
 }
 
 ButtonSelectGroup.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.instanceOf(OptionButton)).isRequired,
+  children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
   /** Set's the caption of the group's label */
   labelCopy: PropTypes.string.isRequired,
   /** Name of the field, provided a uuid if not supplied. */

--- a/src/components/Inputs/ButtonSelectGroup/OptionButton.js
+++ b/src/components/Inputs/ButtonSelectGroup/OptionButton.js
@@ -52,6 +52,7 @@ export const OptionButton = ({
 }
 
 OptionButton.propTypes = {
+  children: PropTypes.string.isRequired,
   buttonStyle: PropTypes.oneOf(Object.values(OPTION_BUTTON_STYLES)),
   /** Set's the caption of the button's label */
   label: PropTypes.string,


### PR DESCRIPTION
Fixes warnings after https://github.com/getethos/ethos-design-system/pull/137 

I suppose this is a more lenient fix but was the only one that made the proptype errors go away. From logging things out from tests and console in chrome, it seems like sometimes it's an array but others it's an object. 

This also adds children prop type to OptionButton which seems related