### PR TITLE
Form.js PropTypes fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
 env:
   - NODE_ENV=ci
 script:
-  # - yarn lint
+  - yarn lint
   - yarn test
   - yarn e2e:ci
 after_success:

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import { useFormState } from '../../hooks/useFormState'
 import { INIT_INVALID } from '../../helpers/constants.js'
@@ -248,4 +249,9 @@ export function Form({ children, config }) {
       })}
     </form>
   )
+}
+
+Form.propTypes = {
+  children: PropTypes.func.isRequired,
+  config: PropTypes.object,
 }


### PR DESCRIPTION
# Should go in last of lint PRs. Uncomments `yarn lint` in travis.yml, so it'll need `master` merged in after those other PRs are in

**Description:**
- [Asana Task](https://app.asana.com/0/1136962714401929/1146342193058673/f)
- Fixes prop type warning Form.js