### PR TITLE
SCSS test successfully fails now 😅 also can pass -u to yarn test

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "stats": "node bin/generateStats.js --write",
     "styleguide": "yarn compile-css && styleguidist server",
     "styleguide:build": "yarn compile-css && styleguidist build",
-    "test": "jest && yarn test:scss",
+    "test": "yarn test:scss && jest",
     "test:coverage": "jest --collectCoverageFrom '[\"src/components/**/*.js\", \"src/hooks/**/*.js\"]' --coverage && open ./coverage/lcov-report/index.html",
     "test:debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand",
     "test:update": "jest --updateSnapshot",

--- a/scss-test.sh
+++ b/scss-test.sh
@@ -3,7 +3,7 @@
 if grep -r --include "*.module.scss" "//" . 
 then 
   printf "\nSCSS test failed. Please only use /* */ comment syntax in .module.scss files, never //.\n\n" 
-  exit 
+  exit 1
 else
   printf "SCSS test succeeded\n" 
 fi


### PR DESCRIPTION
Actually exits with error code, preventing monorepo webpack bugs. Rearranged test order so the faster thing happens first and also you can pass -u to yarn test.