### PR TITLE
Remove required and add default for image alt

### DIFF
--- a/src/components/Images/Images.js
+++ b/src/components/Images/Images.js
@@ -186,13 +186,14 @@ CloudinaryImage.PUBLIC_PROPS = {
   height: PropTypes.array,
   width: PropTypes.array,
   className: PropTypes.string,
-  alt: PropTypes.string.isRequired,
+  alt: PropTypes.string,
   publicId: PropTypes.string.isRequired,
   crop: PropTypes.oneOf(Object.values(CloudinaryImage.CROP_METHODS)),
 }
 
 CloudinaryImage.defaultProps = {
   crop: CloudinaryImage.CROP_METHODS.FILL,
+  alt: '',
 }
 
 CloudinaryImage.propTypes = CloudinaryImage.PUBLIC_PROPS


### PR DESCRIPTION
* Having alt as required was causing build issues when editors would make changes if they didn't have an alt. We can handle setting of alts as required on the CMS side and having it required in the DS is making things unnecessarily complicated.