### PR TITLE
Update UniversalNavbar to accept logoHref parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "license": "UNLICENSED",

--- a/src/components/UniversalNavbar/UniversalNavbar.js
+++ b/src/components/UniversalNavbar/UniversalNavbar.js
@@ -28,7 +28,7 @@ NavLink.propTypes = {
 
 const LINKS = {
   // These are used e.g. in the logo and CTA button:
-  INDEX: { href: '/' },
+  INDEX: { href: '/index' },
   TERM: { href: '/term' },
 
   // These are used in the navigation links proper:

--- a/src/components/UniversalNavbar/UniversalNavbar.js
+++ b/src/components/UniversalNavbar/UniversalNavbar.js
@@ -28,7 +28,7 @@ NavLink.propTypes = {
 
 const LINKS = {
   // These are used e.g. in the logo and CTA button:
-  INDEX: { href: '/index' },
+  INDEX: { href: '/' },
   TERM: { href: '/term' },
 
   // These are used in the navigation links proper:
@@ -67,7 +67,12 @@ class UniversalNavbar extends React.Component {
   }
 
   render() {
-    const { LinkComponent, hideMobileCta, hideDesktopCta } = this.props
+    const {
+      LinkComponent,
+      hideMobileCta,
+      hideDesktopCta,
+      logoHref,
+    } = this.props
 
     const getAnEstimate = (showWhenScrolled) => (
       <a
@@ -121,7 +126,7 @@ class UniversalNavbar extends React.Component {
                   showMobileMenu ? styles.mobileMenu : styles.hideMobileMenu
                 }
               >
-                <NavLink href={LINKS.INDEX.href} LinkComponent={LinkComponent}>
+                <NavLink href={logoHref} LinkComponent={LinkComponent}>
                   {LogoWhite({ className: styles.logo })}
                 </NavLink>
                 <Spacer.H56 />
@@ -159,10 +164,7 @@ class UniversalNavbar extends React.Component {
               <div className={styles.tabletAndUpContainer}>
                 {/* Desktop menu items to the left */}
                 <div className={`${styles.flex} ${styles.itemsCenter}`}>
-                  <NavLink
-                    href={LINKS.INDEX.href}
-                    LinkComponent={LinkComponent}
-                  >
+                  <NavLink href={logoHref} LinkComponent={LinkComponent}>
                     {LogoNotAnimated({ className: styles.logo })}
                   </NavLink>
                   {renderDesktopLink(LINKS.NAVLINKS[0])}
@@ -201,11 +203,14 @@ UniversalNavbar.propTypes = {
   trackCtaClick: PropTypes.func,
   /** agnotistic Reach and React Router Link */
   LinkComponent: PropTypes.object,
+  /** Href for the logo */
+  logoHref: PropTypes.string,
 }
 
 UniversalNavbar.defaultProps = {
   hideMobileCta: false,
   hideDesktopCta: false,
+  logoHref: LINKS.INDEX.href,
   trackCtaClick: () => {},
 }
 

--- a/src/components/UniversalNavbar/UniversalNavbar.md
+++ b/src/components/UniversalNavbar/UniversalNavbar.md
@@ -1,5 +1,5 @@
 This element has a fixed position at the top of the screen which you can see here. Also, it behaves very differently on mobile.
 
 ```jsx
-<UniversalNavbar />
+<UniversalNavbar logoHref={'http://test.com'} />
 ```

--- a/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
+++ b/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
@@ -39,7 +39,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           className="hideMobileMenu"
         >
           <NavLink
-            href="/index"
+            href="/"
           >
             <svg
               className="logo"
@@ -139,7 +139,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           </div>
         </div>
         <NavLink
-          href="/index"
+          href="/"
         >
           <FancyAnimatedLogo />
         </NavLink>
@@ -163,7 +163,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
             className="flex itemsCenter"
           >
             <NavLink
-              href="/index"
+              href="/"
             >
               <svg
                 className="logo"

--- a/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
+++ b/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
@@ -39,7 +39,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           className="hideMobileMenu"
         >
           <NavLink
-            href="/"
+            href="/index"
           >
             <svg
               className="logo"
@@ -139,7 +139,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           </div>
         </div>
         <NavLink
-          href="/"
+          href="/index"
         >
           <FancyAnimatedLogo />
         </NavLink>
@@ -163,7 +163,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
             className="flex itemsCenter"
           >
             <NavLink
-              href="/"
+              href="/index"
             >
               <svg
                 className="logo"


### PR DESCRIPTION
**Description:**
- Because the `UniversalNavbar` is used in the monorepo (`app.ethoslife.com`) and the CMS (`ethoslife.com`), having the logo route to `/` sends the user to different pages, depending on whether you're in the main app or CMS.
- This allows for passing in a parameter, `logoHref` to the component, so that we can send a user directly to `https://ethoslife.com/` rather than `href='/'`