### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "license": "UNLICENSED",


### PR DESCRIPTION
I believe on the `react-select-port` stuff I recently merged, I may have inadvertantly pushed more commits after the version bump because I'm not seeing the entirety of stuff e.g. exporting from index.js when I pull in from monorepo. This is just to ensure I have the tip of that work