### PR TITLE
Fix flash of alt text on SVG

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "license": "UNLICENSED",

--- a/src/components/Images/Images.js
+++ b/src/components/Images/Images.js
@@ -157,7 +157,7 @@ export const CloudinaryImage = ({
     const svgUrl = cld.url(filePath(publicId), baseSvgSettings)
     return (
       <img
-        data-src={svgUrl}
+        src={svgUrl}
         className={[styles.Svg, ...imageClasses].join(' ')}
         alt={alt}
       />


### PR DESCRIPTION
If there is no src in an image tag and dataSrc is used only, there will be a brief flash of text on rerenders. 