### PR TITLE
Columns v0

### DIFF
--- a/src/components/Colors.js
+++ b/src/components/Colors.js
@@ -12,5 +12,10 @@ export const COLORS = {
   GRAY_STROKE_AND_DISABLED: 'GrayStrokeAndDisabled',
   WHITE: 'White',
 
+  // Background colors
+  BRAND_DUCKEGG: 'BrandDuckegg',
+  BRAND_MOSS: 'BrandMoss',
+  BRAND_BUTTERCUP: 'BrandButtercup',
+
   // Miscellany
 }

--- a/src/components/Layout/Columns/ColumnWrapper.js
+++ b/src/components/Layout/Columns/ColumnWrapper.js
@@ -1,0 +1,8 @@
+import React from 'react'
+// import PropTypes from 'prop-types'
+
+import styles from './Columns.module.scss'
+
+export function ColumnWrapper({ children }) {
+  return <div className={styles.twoColumnLayout}>{children}</div>
+}

--- a/src/components/Layout/Columns/ColumnWrapper.js
+++ b/src/components/Layout/Columns/ColumnWrapper.js
@@ -4,6 +4,10 @@ import React from 'react'
 import styles from './Columns.module.scss'
 
 export default function ColumnWrapper({ children, divider }) {
+  if (React.Children.count(children) !== 2) {
+    throw new Error('ColumnWrapper can only be used with exactly two columns.')
+  }
+
   const classNames = [styles.twoColumnLayout]
   if (divider) {
     classNames.push(styles.dividerLine)

--- a/src/components/Layout/Columns/ColumnWrapper.js
+++ b/src/components/Layout/Columns/ColumnWrapper.js
@@ -3,6 +3,10 @@ import React from 'react'
 
 import styles from './Columns.module.scss'
 
-export function ColumnWrapper({ children }) {
-  return <div className={styles.twoColumnLayout}>{children}</div>
+export default function ColumnWrapper({ children, divider }) {
+  const classNames = [styles.twoColumnLayout]
+  if (divider) {
+    classNames.push(styles.dividerLine)
+  }
+  return <div className={classNames.join(' ')}>{children}</div>
 }

--- a/src/components/Layout/Columns/Columns.js
+++ b/src/components/Layout/Columns/Columns.js
@@ -1,0 +1,8 @@
+import React from 'react'
+// import PropTypes from 'prop-types'
+
+import styles from './Columns.module.scss'
+
+export function ColumnSmall({ children }) {
+  return <div className={styles.columnSmall}>{children}</div>
+}

--- a/src/components/Layout/Columns/Columns.js
+++ b/src/components/Layout/Columns/Columns.js
@@ -3,6 +3,38 @@ import React from 'react'
 
 import styles from './Columns.module.scss'
 
-export function ColumnSmall({ children }) {
-  return <div className={styles.columnSmall}>{children}</div>
+function ColumnSmall({ children }) {
+  return (
+    <div className={styles.columnWrapper}>
+      <div className={styles.columnSmall}>{children}</div>
+    </div>
+  )
 }
+
+function ColumnMedium({ children, alignRight }) {
+  const classNames = [styles.columnMedium]
+  if (alignRight) {
+    classNames.push(styles.alignRight)
+  }
+  return (
+    <div className={styles.columnWrapper}>
+      <div className={classNames.join(' ')}>{children}</div>
+    </div>
+  )
+}
+
+function ColumnLarge({ children }) {
+  return (
+    <div className={styles.columnWrapper}>
+      <div className={styles.columnLarge}>{children}</div>
+    </div>
+  )
+}
+
+const Column = {
+  Small: ColumnSmall,
+  Medium: ColumnMedium,
+  Large: ColumnLarge,
+}
+
+export default Column

--- a/src/components/Layout/Columns/Columns.md
+++ b/src/components/Layout/Columns/Columns.md
@@ -1,0 +1,93 @@
+```jsx
+import { Spacer, Body, TitleSmall, Layout } from '../../index'
+
+const { HorizontallyPaddedContainer, ColumnWrapper, Column } = Layout
+
+const absoluteFullScreenSize = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100vw',
+  zIndex: 5,
+  boxShadow: 'inset 0 0 10px #000000',
+  backgroundColor: 'white',
+}
+
+const plentyOfText =
+  ' ' +
+  Array(400)
+    .fill('.')
+    .join('')
+
+const baseStyles = {
+  padding: 20,
+  border: '1px solid #ddd',
+  overflowWrap: 'break-word',
+}
+
+const sm = {
+  ...baseStyles,
+}
+
+const med = {
+  ...baseStyles,
+}
+
+const lg = {
+  backgroundColor: 'var(--BrandForest)',
+  color: 'white',
+  ...baseStyles,
+}
+
+const linkProps = {
+  style: {
+    color: 'burgundy',
+    cursor: 'pointer',
+  },
+  target: '_blank',
+}
+
+const spacer = <div style={{ height: 16 }} />
+
+;<div style={absoluteFullScreenSize}>
+  <HorizontallyPaddedContainer>
+    <br />
+    <TitleSmall.Sans.Medium500>Story module</TitleSmall.Sans.Medium500>
+    <Body.Regular400>Two medium columns and divider.</Body.Regular400>
+    <a
+      href="https://www.figma.com/file/BqpC4jxtI91RlTR4v9sIUZ6t/CMS-Playground?node-id=2815%3A2908"
+      {...linkProps}
+    >
+      Figma link
+    </a>
+    {spacer}
+    <ColumnWrapper divider>
+      <Column.Medium>
+        <div style={med}>(Column.Medium) Story module {plentyOfText}</div>
+      </Column.Medium>
+      <Column.Medium alignRight>
+        <div style={med}>(Column.Medium) Story module right{plentyOfText}</div>
+      </Column.Medium>
+    </ColumnWrapper>
+    <br />
+    <br />
+    <ColumnWrapper>
+      <Column.Medium>
+        <div style={med}>
+          (Column.Medium)
+          {plentyOfText}
+        </div>
+      </Column.Medium>
+      <Column.Large>
+        <div style={lg}>
+          (Column Large, full 50% width)
+          {[plentyOfText, plentyOfText, plentyOfText, plentyOfText]
+            .join('')
+            .replace(/ /g, '')}
+        </div>
+      </Column.Large>
+    </ColumnWrapper>
+    <br />
+  </HorizontallyPaddedContainer>
+</div>
+```

--- a/src/components/Layout/Columns/Columns.md
+++ b/src/components/Layout/Columns/Columns.md
@@ -1,93 +1,276 @@
+### Click show/hide button in upper right to view demos with corresponding cms module titles and figma links.
+
 ```jsx
-import { Spacer, Body, TitleSmall, Layout } from '../../index'
+import {
+  Button,
+  TitleXLarge,
+  TitleMedium,
+  Body,
+  TitleSmall,
+  Layout,
+} from '../../index'
 
 const { HorizontallyPaddedContainer, ColumnWrapper, Column } = Layout
 
-const absoluteFullScreenSize = {
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  width: '100vw',
-  zIndex: 5,
-  boxShadow: 'inset 0 0 10px #000000',
-  backgroundColor: 'white',
-}
+// Recommended: set this to true when developing with hot-reload.
+const showDemosOnPageLoad = false
 
+/**
+ *  Some filler/placeholder/DRY variables, just to try and keep the demo clean.
+ */
+
+// String of 400 periods.
 const plentyOfText =
   ' ' +
   Array(400)
     .fill('.')
     .join('')
 
-const baseStyles = {
-  padding: 20,
+// Lightweight bounding box to demonstrate spacing of divs.
+const textWrapper = {
+  padding: 0,
   border: '1px solid #ddd',
   overflowWrap: 'break-word',
 }
 
-const sm = {
-  ...baseStyles,
-}
-
-const med = {
-  ...baseStyles,
-}
-
-const lg = {
-  backgroundColor: 'var(--BrandForest)',
-  color: 'white',
-  ...baseStyles,
-}
-
-const linkProps = {
-  style: {
-    color: 'burgundy',
-    cursor: 'pointer',
-  },
-  target: '_blank',
-}
-
+// Throwaway elements for spacing.
 const spacer = <div style={{ height: 16 }} />
+const bigSpacer = <div style={{ height: 40 }} />
 
-;<div style={absoluteFullScreenSize}>
-  <HorizontallyPaddedContainer>
-    <br />
-    <TitleSmall.Sans.Medium500>Story module</TitleSmall.Sans.Medium500>
-    <Body.Regular400>Two medium columns and divider.</Body.Regular400>
+// Placeholder for big hero images.
+const imagePlaceholder = (text) => (
+  <div
+    style={{
+      backgroundColor: 'var(--BrandForest)',
+      color: 'white',
+      textAlign: 'center',
+    }}
+  >
+    {bigSpacer}
+    {bigSpacer}
+    {bigSpacer}
+    Image should go here
+    {bigSpacer}
+    {text}
+    {bigSpacer}
+    {bigSpacer}
+    {bigSpacer}
+  </div>
+)
+
+// Just to DRY out the example modules.
+let exampleDemoCounter = 0
+const moduleExample = ({ title, description, figmaUrl, jsx, skipSpacer }) => (
+  <>
+    {spacer}
+    <TitleSmall.Sans.Medium500>
+      {++exampleDemoCounter}. "{title}" module
+    </TitleSmall.Sans.Medium500>
+    <Body.Regular400>{description}</Body.Regular400>
+    {spacer}
     <a
-      href="https://www.figma.com/file/BqpC4jxtI91RlTR4v9sIUZ6t/CMS-Playground?node-id=2815%3A2908"
-      {...linkProps}
+      href={figmaUrl}
+      style={{
+        color: '#8C001A',
+        cursor: 'pointer',
+      }}
+      target="_blank"
     >
       Figma link
     </a>
     {spacer}
-    <ColumnWrapper divider>
-      <Column.Medium>
-        <div style={med}>(Column.Medium) Story module {plentyOfText}</div>
-      </Column.Medium>
-      <Column.Medium alignRight>
-        <div style={med}>(Column.Medium) Story module right{plentyOfText}</div>
-      </Column.Medium>
-    </ColumnWrapper>
-    <br />
-    <br />
-    <ColumnWrapper>
-      <Column.Medium>
-        <div style={med}>
-          (Column.Medium)
-          {plentyOfText}
-        </div>
-      </Column.Medium>
-      <Column.Large>
-        <div style={lg}>
-          (Column Large, full 50% width)
-          {[plentyOfText, plentyOfText, plentyOfText, plentyOfText]
-            .join('')
-            .replace(/ /g, '')}
-        </div>
-      </Column.Large>
-    </ColumnWrapper>
-    <br />
-  </HorizontallyPaddedContainer>
+    {jsx}
+    {bigSpacer}
+    {!skipSpacer && (
+      <>
+        <div
+          style={{
+            width: 'calc(100% - 160px)',
+            marginLeft: 80,
+            borderTop: '1px solid #ddd',
+          }}
+        />
+        {bigSpacer}
+      </>
+    )}
+  </>
+)
+
+// Button to show/hide the demo; this demo is meant for elements which are
+// screen-wide, and it needs to take up the entire width of the screen, but
+// it's so big it blocks all the text of the page.
+const showHideButton = (
+  <button
+    id="help"
+    style={{
+      position: 'fixed',
+      zIndex: 50,
+      top: 10,
+      right: 10,
+      backgroundColor: 'hotpink',
+    }}
+    onClick={() => {
+      const x = document.querySelector('#columns-wrapper')
+      x.style.display = !!x.style.display ? '' : 'none'
+    }}
+  >
+    Show/hide
+  </button>
+)
+
+;<div>
+  {showHideButton}
+  <div
+    id="columns-wrapper"
+    style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100vw',
+      zIndex: 5,
+      boxShadow: 'inset 0 0 10px #000000',
+      backgroundColor: 'white',
+      display: showDemosOnPageLoad ? '' : 'none',
+    }}
+  >
+    <HorizontallyPaddedContainer>
+      {bigSpacer}
+      <TitleXLarge.Sans.Regular400>Columns demos</TitleXLarge.Sans.Regular400>
+      {moduleExample({
+        title: 'Story',
+        description: 'Two medium columns, second is alignRight, and divider',
+        figmaUrl:
+          'https://www.figma.com/file/BqpC4jxtI91RlTR4v9sIUZ6t/CMS-Playground?node-id=2815%3A2908',
+        jsx: (
+          <ColumnWrapper divider>
+            <Column.Medium>
+              <div style={textWrapper}>(Column.Medium){plentyOfText}</div>
+            </Column.Medium>
+            <Column.Medium alignRight>
+              <div style={textWrapper}>(Column.Medium){plentyOfText}</div>
+            </Column.Medium>
+          </ColumnWrapper>
+        ),
+      })}
+
+      {moduleExample({
+        title: 'Highlight',
+        description: 'Two medium columns, second is alignRight',
+        figmaUrl:
+          'https://www.figma.com/file/BqpC4jxtI91RlTR4v9sIUZ6t/CMS-Playground?node-id=2815%3A2411',
+        jsx: (
+          <ColumnWrapper>
+            <Column.Medium>
+              <div style={textWrapper}>(Column.Medium){plentyOfText}</div>
+            </Column.Medium>
+            <Column.Medium alignRight>
+              {imagePlaceholder('(Column.Medium)')}
+            </Column.Medium>
+          </ColumnWrapper>
+        ),
+      })}
+
+      {moduleExample({
+        title: 'Header Homepage',
+        description: 'Small column + large column with hero image',
+        figmaUrl:
+          'https://www.figma.com/file/BqpC4jxtI91RlTR4v9sIUZ6t/CMS-Playground?node-id=2408%3A4566',
+        jsx: (
+          <ColumnWrapper>
+            <Column.Small>
+              <div style={textWrapper}>
+                (Column.Medium)
+                {plentyOfText}
+              </div>
+            </Column.Small>
+            <Column.Large>
+              {imagePlaceholder('(Column Large, full 50% width)')}
+            </Column.Large>
+          </ColumnWrapper>
+        ),
+      })}
+      {spacer}
+    </HorizontallyPaddedContainer>
+    {/* This color isn't in our approved list of colors so it's inline i guess */}
+    <div style={{ backgroundColor: '#F5F3F0' }}>
+      <HorizontallyPaddedContainer>
+        {moduleExample({
+          title: 'Intent Header',
+          description:
+            'Medium column + large column with hero image, then two large columns. Column to the right disappears on tablet.',
+          figmaUrl:
+            'https://www.figma.com/file/TUiIpan0bPpI2gGUCoSqoT/Intent-Header?node-id=132%3A92',
+          skipSpacer: true,
+          jsx: (
+            <>
+              <ColumnWrapper>
+                <Column.Medium>
+                  <div style={textWrapper}>
+                    <TitleXLarge.Serif.Book500>
+                      Life insurance, the human way.
+                    </TitleXLarge.Serif.Book500>
+                    {spacer}
+
+                    <Body.Regular400>
+                      Ethos makes it faster and easier to secure your family’s
+                      financial future with affordable policies that fit your
+                      life.
+                    </Body.Regular400>
+                    {bigSpacer}
+                    {bigSpacer}
+                    <Button.Medium.Black arrowIcon>
+                      Check my price
+                    </Button.Medium.Black>
+                  </div>
+                </Column.Medium>
+                <Column.Large>
+                  <div className="hideOnPhoneAndTablet">
+                    {imagePlaceholder('(Column Large)')}
+                    {imagePlaceholder('This is a pretty tall image')}
+                  </div>
+                </Column.Large>
+              </ColumnWrapper>
+
+              {bigSpacer}
+
+              <ColumnWrapper>
+                <Column.Large>
+                  <div className="columns-demo-margin-right-nonmobile">
+                    <TitleMedium.Serif.Book500>
+                      Want to know more about Ethos life insurance?
+                    </TitleMedium.Serif.Book500>
+                    {spacer}
+                    <Body.Regular400>
+                      Learn more about our quick and easy application process
+                      and how to pick the best policy for your family.
+                    </Body.Regular400>
+                    {spacer}
+                    <Button.Unstyled arrowIcon>Learn more</Button.Unstyled>
+                  </div>
+                </Column.Large>
+                <Column.Large>
+                  <div className="columns-demo-margin-left-nonmobile">
+                    <TitleMedium.Serif.Book500>
+                      Want to know more about Ethos life insurance?
+                    </TitleMedium.Serif.Book500>
+                    {spacer}
+                    <Body.Regular400>
+                      Learn more about our quick and easy application process
+                      and how to pick the best policy for your family.
+                    </Body.Regular400>
+                    {spacer}
+                    <Button.Unstyled arrowIcon>Learn more</Button.Unstyled>
+                  </div>
+                </Column.Large>
+              </ColumnWrapper>
+            </>
+          ),
+        })}
+      </HorizontallyPaddedContainer>
+    </div>
+
+    {/* End of demo */}
+    <div style={{ textAlign: 'center', padding: 40 }}>∎</div>
+  </div>
 </div>
 ```

--- a/src/components/Layout/Columns/Columns.module.scss
+++ b/src/components/Layout/Columns/Columns.module.scss
@@ -5,20 +5,28 @@
   align-items: center;
   position: relative;
   &.dividerLine {
-    :after {
-      content: '';
-      border-left: 1px solid var(--GrayStrokeAndDisabled--opaque);
-      height: 100%;
-      position: absolute;
-      left: 50%;
-      top: 0;
+    @include for-laptop-and-up {
+      &:after {
+        content: '';
+        border-left: 1px solid var(--GrayStrokeAndDisabled--opaque);
+        height: 100%;
+        position: absolute;
+        left: 50%;
+        top: 0;
+      }
     }
+  }
+  @include for-phone-and-tablet {
+    flex-direction: column;
   }
 }
 
 .columnWrapper {
   width: 50%;
   flex-shrink: 0;
+  @include for-phone-and-tablet {
+    width: 100%;
+  }
 }
 
 /* Spans entire column width. */
@@ -26,19 +34,42 @@
   width: 100%;
 }
 
-/* Gutter on left and right side. */
+/* Gutter on left or right side. */
 .columnMedium {
-  width: calc(100% - 80px);
-  max-width: 560px;
-  &.alignRight {
-    margin-left: 80px;
+  @include for-desktop-only {
+    width: calc(100% - 80px);
+    max-width: 560px;
+    &.alignRight {
+      margin-left: 80px;
+    }
+  }
+  @include for-laptop-only {
+    width: calc(100% - 64px);
+    max-width: 560px;
+    &.alignRight {
+      margin-left: 64px;
+    }
+  }
+
+  @include for-phone-and-tablet {
+    width: 100%;
   }
 }
 
 /* Left-aligned, gutter on left side and double width gutter on right side. 
 Usually used for text. */
 .columnSmall {
-  width: calc(100% - 160px);
-  margin-right: 80px;
+  @include for-desktop-only {
+    width: calc(100% - 80px);
+    margin-right: 80px;
+  }
+  @include for-laptop-only {
+    width: calc(100% - 64px);
+    margin-right: 64px;
+  }
+
+  @include for-phone-and-tablet {
+    width: 100%;
+  }
   max-width: 480px;
 }

--- a/src/components/Layout/Columns/Columns.module.scss
+++ b/src/components/Layout/Columns/Columns.module.scss
@@ -2,6 +2,18 @@
 
 .twoColumnLayout {
   display: flex;
+  align-items: center;
+  position: relative;
+  &.dividerLine {
+    :after {
+      content: '';
+      border-left: 1px solid var(--GrayStrokeAndDisabled--opaque);
+      height: 100%;
+      position: absolute;
+      left: 50%;
+      top: 0;
+    }
+  }
 }
 
 .columnWrapper {
@@ -16,17 +28,17 @@
 
 /* Gutter on left and right side. */
 .columnMedium {
-  width: 100%;
-  margin-left: 80px;
-  margin-right: 80px;
+  width: calc(100% - 80px);
   max-width: 560px;
+  &.alignRight {
+    margin-left: 80px;
+  }
 }
 
 /* Left-aligned, gutter on left side and double width gutter on right side. 
 Usually used for text. */
 .columnSmall {
-  width: 100%;
-  margin-left: 80px;
+  width: calc(100% - 160px);
   margin-right: 80px;
   max-width: 480px;
 }

--- a/src/components/Layout/Columns/Columns.module.scss
+++ b/src/components/Layout/Columns/Columns.module.scss
@@ -1,0 +1,32 @@
+@import '../../Media/Media.scss';
+
+.twoColumnLayout {
+  display: flex;
+}
+
+.columnWrapper {
+  width: 50%;
+  flex-shrink: 0;
+}
+
+/* Spans entire column width. */
+.columnLarge {
+  width: 100%;
+}
+
+/* Gutter on left and right side. */
+.columnMedium {
+  width: 100%;
+  margin-left: 80px;
+  margin-right: 80px;
+  max-width: 560px;
+}
+
+/* Left-aligned, gutter on left side and double width gutter on right side. 
+Usually used for text. */
+.columnSmall {
+  width: 100%;
+  margin-left: 80px;
+  margin-right: 80px;
+  max-width: 480px;
+}

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,6 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import ColumnWrapper from './Columns/ColumnWrapper'
+import Column from './Columns/Columns'
+
 import styles from './Layout.module.scss'
 
 export function Layout({ children }) {
@@ -93,5 +96,7 @@ HorizontallyPaddedContainer.defaultProps = {
 
 Layout.Container = HorizontallyPaddedContainer // overloaded alias, deprecated
 Layout.HorizontallyPaddedContainer = HorizontallyPaddedContainer
+Layout.ColumnWrapper = ColumnWrapper
+Layout.Column = Column
 
 Layout.ScrollDetector = ScrollDetector

--- a/styleguide/content/color/color.scss
+++ b/styleguide/content/color/color.scss
@@ -1,5 +1,8 @@
 @import '../../src/components/Colors.scss';
 
+/* These stylesheets don't use the css/scss modules patterns, 
+they are basically just ordinary stylesheets */
+
 .White {
   color: var(--White);
 }

--- a/styleguide/content/content.scss
+++ b/styleguide/content/content.scss
@@ -1,1 +1,2 @@
 @import './color/color.scss';
+@import './styleguideStyling.scss';

--- a/styleguide/content/styleguideStyling.scss
+++ b/styleguide/content/styleguideStyling.scss
@@ -1,0 +1,27 @@
+@import '../../src/components/Media/Media.scss';
+
+/* These stylesheets don't  css/scss modules 
+they are basically just ordinary stylesheets */
+
+/**
+ * Used in Columns.md 
+ */
+.hideOnPhoneAndTablet {
+  @include for-phone-and-tablet {
+    display: none;
+  }
+}
+
+.columns-demo-margin-left-nonmobile,
+.columns-demo-margin-right-nonmobile {
+  background-color: white;
+  padding: 32px;
+}
+@include for-laptop-and-up {
+  .columns-demo-margin-left-nonmobile {
+    margin-left: 1px;
+  }
+  .columns-demo-margin-right-nonmobile {
+    margin-right: 1px;
+  }
+}


### PR DESCRIPTION
## Preface: Whoopsie

Due to what i've been told was a clerical error, i've lost access to gmail, slack and ethos github access ahead of my scheduled end date of this Friday. Drew said he was looking into getting some of them back online but luckily this repo is public so i can make a PR anyway. (Also luckily, I still have access to figma for some reason.) 

This also means that the (small) changes I made to the CMS are not able to be pushed if I haven't already (I forgot what I pushed on top of Drew's video PR and don't have access to it anymore) and I certainly can't integrate my changes here into the CMS and push anything up there.

## Description 

This idea for a new EDS component came about when I was adding video support for the Highlight module while visiting last week. I realized I was reimplementing layout CSS which felt suspiciously similar to the CSS for the quote widget, as well as some other modules i've seen in my limited time working on the CMS. I asked Ryan about this and we discussed recurring patterns of two columns with optional 64/80px gutters (laptop/desktop viewports) to the left/right of a column's content. Suffice it to say there are recurring patterns which have been manually re-implemented in many cms modules and even a couple things in the monorepo. 

The reason for this layout being introduced now and not way back when the EDS was originally started is actually that these designs 'evolved over time' (quote from Ryan here) and seems not to be written down anywhere, but is still a repeating pattern. I was actually against adding additional Layout elements at the beginning because I couldn't see consistent patterns; I'm not sure if that was a mistake or not, but there's definitely consistent patterns now.

Looking around at various CMS modules it becomes clear that, despite (or more likely, due to) spending a ton of time doing similar-but-not-exactly-the-same layouts, we actually have a fair number of inconsistencies and little design issues that are live right now. You can see these for yourself by starting up the cms and navigating to /demo, placing your cursor exactly in the middle of a module that's supposed to cut the page evenly in half, and scrolling up or down until you find a module that also is supposed to cut the page in half but is off by ~5-10px. Here's some videos of that happening: https://i.gyazo.com/e7b38b50f9e1191e5b8a3d6b22b189b0.mp4 https://i.gyazo.com/ed56b6253e988cda41355063fdd68610.mp4
Highlight and Header Versatile modules seem to be the culprits here; Highlight was the module I was supposed to be working on originally, which is another reason I did this instead of just fixing that one module. 

The benefits of making a reusable component is not only to prevent repetitive implementation of the same or similar sets of code, but also to prevent subtle errors like this going forward. Layout.HorizontallyPaddedContainer is a great example of doing a layout component once and never having to worry about it again; ideally this would be similar.

## Instructions

Run `yarn styleguide` and go to the new 'columns' page to see four demos of loose reproductions of CMS modules. To see them you have to click the hot pink "show/hide button" in the upper right. I think the code and demos basically speak for themselves after that.

## Following up on this

I doubt that the code I've written here will get reviewed thoroughly before I finish at ethos on Friday. I also seriously doubt this implementation is where iteration on a module like 'columns' would end. I figured the most effective way to demonstrate the use of a 'columns' demo would be to reproduce the CMS modules that I think this will simplify, and during implementation I ended up adding features as I went (for example, the divider in between columns for the "Story" module). I imagine that we would want to replace our existing CSS for modules and add the occasional new feature to adapt to usage of this component when (if) it gets picked up, and asked Cole if he would be interested in taking this on should he get some spare time.

I'm not expecting this to be added or integrated into the CMS immediately, and with a new PM starting for growth team soon (and multiple 'pods' being shifted around and reassigned) I have no idea what the prioritization would be. 

Whenever someone picks this up I think it would be best to work very, very closely with design to make sure that what's happening is correct at every viewport. I've been cut off and it seemed not worth the time to get in contact with them before pushing up this early prototype, but the designers at Ethos always know exactly what they want to happen at every viewport even if the figma docs aren't 100% clear, and things work out great as long as they are included in the discussions, especially over video call or in person. 