### PR TITLE
Uses columnheader for header cells which is more idiomatic then rowhe…

### DIFF
--- a/src/components/Grid/Column.js
+++ b/src/components/Grid/Column.js
@@ -27,7 +27,7 @@ export const Column = React.memo((props) => {
         className={props.className}
         style={inlineStyles}
         data-label={props.name}
-        role={props.header ? 'rowheader' : 'cell'}
+        role={props.header ? 'columnheader' : 'cell'}
       >
         {props.children(props.active, props.columnRef)}
       </div>
@@ -45,7 +45,7 @@ export const Column = React.memo((props) => {
         data-label={props.name}
         // eslint-disable-next-line
         {...!props.sortable && { ref: props.columnRef }}
-        role={props.header ? 'rowheader' : 'cell'}
+        role={props.header ? 'columnheader' : 'cell'}
         tabIndex={tabIndex}
       >
         {props.children(props.active)}

--- a/src/components/Grid/Column.test.js
+++ b/src/components/Grid/Column.test.js
@@ -82,11 +82,11 @@ describe('focus behavior', () => {
 })
 
 describe('header property', () => {
-  it('dictates rowheader role', () => {
+  it('dictates columnheader role', () => {
     const renderer = render({ header: true })
     const root = renderer.toJSON()
 
-    expect(root.props.role).toStrictEqual('rowheader')
+    expect(root.props.role).toStrictEqual('columnheader')
   })
 
   it('dictates column role', () => {

--- a/src/components/Grid/Grid.md
+++ b/src/components/Grid/Grid.md
@@ -5,6 +5,8 @@ This `Grid` follows the [wai-aria-practices-1.1](https://www.w3.org/TR/wai-aria-
 - Simpler API
 - Boilerplate default styles
 - Sort by column
+- Uses `columnheader` for header cells which is more idiomatic then `rowheader` which is usually used on the first column of
+a row to act as a header for just that row
 - Responsive stacking at mobile and lower with column label on left and values on the right
 
 ### Aria Support in Screen Readers


### PR DESCRIPTION
This is a small fix for the Grids stuff. After doing a bit more research I realized that `columnheader` should have been used instead of `rowheader`. The later is generally used in the first column of a row and relates to the rest of the columns in that row:
https://www.digitala11y.com/rowheader-role/

But for things similar to table header columns e.g. `<th>` `columnheader` seems more appropriate