### PR TITLE
Adding a `<Portal />` Component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .vscode/
+.nova/
 
 node_modules
 yarn-error.log

--- a/src/components/Portal/Portal.js
+++ b/src/components/Portal/Portal.js
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import PropTypes from 'prop-types'
+
+/**
+ *
+ * Automatically handles creating and tearing-down the root elements
+ * so there is no need to ensure the parent target already
+ * exists.
+ *
+ * @private
+ *
+ * @param {String} id - The id of the target container
+ *
+ * @return {HTMLElement} - The DOM node to use as the Portal target
+ */
+function usePortal(id) {
+  const [isAttached, setIsAttached] = useState(false)
+  const el = useRef(
+    document.getElementById(id) || document.createElement('div')
+  )
+
+  useEffect(() => {
+    setIsAttached(!!el.current.parentElement)
+
+    if (!isAttached) {
+      el.current.id = id
+      document.body.appendChild(el.current)
+      setIsAttached(true)
+    }
+
+    return () => {
+      if (isAttached) {
+        el.current.parentElement.removeChild(el.current)
+      }
+    }
+  }, [id, el, isAttached])
+
+  return el.current
+}
+
+/**
+ * Dynamically create's a portal component that appends to the end of the DOM
+ *
+ * @public
+ *
+ * @param {object} props - the component's props
+ * @param {string} props.id - the portal root element's id
+ * @param {React.children} props.children - the children element
+ *
+ * @example ```
+ * <Portal id="glados">
+ *   <h1>This was a triumph</h1>
+ * </Portal>
+ * ```
+ *
+ * @return {React.ReactPortal}
+ */
+export const Portal = ({ id, children }) => {
+  const root = usePortal(id)
+
+  return createPortal(children, root)
+}
+
+Portal.propTypes = {
+  id: PropTypes.string,
+  children: PropTypes.node,
+}

--- a/src/components/Portal/Portal.js
+++ b/src/components/Portal/Portal.js
@@ -3,10 +3,8 @@ import { createPortal } from 'react-dom'
 import PropTypes from 'prop-types'
 
 /**
- *
- * Automatically handles creating and tearing-down the root elements
- * so there is no need to ensure the parent target already
- * exists.
+ * Hooks handles the creation and tear down of the portal's root
+ * element.
  *
  * @private
  *

--- a/src/components/Portal/Portal.js
+++ b/src/components/Portal/Portal.js
@@ -8,33 +8,35 @@ import PropTypes from 'prop-types'
  *
  * @private
  *
- * @param {String} id - The id of the target container
+ * @param {string} [id] - The optional id of the target container. If the `id` is not passed,
+ * the target container will be a div without an `id`
  *
  * @return {HTMLElement} - The DOM node to use as the Portal target
  */
 function usePortal(id) {
   const [isAttached, setIsAttached] = useState(false)
-  const el = useRef(
+  const elRef = useRef(
     document.getElementById(id) || document.createElement('div')
   )
 
   useEffect(() => {
-    setIsAttached(!!el.current.parentElement)
+    const el = elRef.current
+    setIsAttached(!!el.parentElement)
 
     if (!isAttached) {
-      el.current.id = id
-      document.body.appendChild(el.current)
+      el.id = id
+      document.body.appendChild(el)
       setIsAttached(true)
     }
 
     return () => {
       if (isAttached) {
-        el.current.parentElement.removeChild(el.current)
+        elRef.current.parentElement.removeChild(el)
       }
     }
-  }, [id, el, isAttached])
+  }, [id, elRef, isAttached])
 
-  return el.current
+  return elRef.current
 }
 
 /**
@@ -43,7 +45,9 @@ function usePortal(id) {
  * @public
  *
  * @param {object} props - the component's props
- * @param {string} props.id - the portal root element's id
+ * @param {string} [props.id] - The optional id of the target container. If the `id` is not passed,
+ * the target container will be a div without an `id`
+ *
  * @param {React.children} props.children - the children element
  *
  * @example ```

--- a/src/components/Portal/Portal.md
+++ b/src/components/Portal/Portal.md
@@ -1,0 +1,22 @@
+## Description
+The `Portal` element provides a way to create React portals dynamically. The component will create a new `DOM` node that attaches to the end of the `document.body` and render's the passed children within that DOM node.
+
+## Example
+
+```jsx
+const styles = {
+    position: 'fixed',
+    top: '20px',
+    right: '20px',
+    border: '1px solid var(--BrandForest)',
+    color: 'var(--BrandForest)',
+    background: 'var(--BrandMoss)',
+    borderRadius: '3px',
+    padding: 'var(--Space-16) var(--Space-24)',
+};
+<Portal id="foo">
+    <div style={styles}>
+        <h1>Diagon Alley!</h1>
+    </div>
+</Portal>
+```

--- a/src/components/Portal/Portal.test.js
+++ b/src/components/Portal/Portal.test.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Portal } from './Portal'
+import renderer from 'react-test-renderer'
+import ReactDOM from 'react-dom'
+
+const TEST_ID = 'my-portal'
+
+describe('Portal', () => {
+  beforeAll(() => {
+    // createPortal needs to be mocked
+    // SEE: https://github.com/facebook/react/issues/11565
+    ReactDOM.createPortal = jest.fn((element) => {
+      return element
+    })
+  })
+
+  afterEach(() => {
+    ReactDOM.createPortal.mockClear()
+  })
+
+  it("render's a portal", () => {
+    const tree = renderer
+      .create(
+        <Portal id={TEST_ID}>
+          <h1>hello world</h1>
+        </Portal>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/Portal/__snapshots__/Portal.test.js.snap
+++ b/src/components/Portal/__snapshots__/Portal.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Portal render's a portal 1`] = `
+<h1>
+  hello world
+</h1>
+`;

--- a/src/components/Portal/index.js
+++ b/src/components/Portal/index.js
@@ -1,0 +1,1 @@
+export { Portal } from './Portal.js'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -24,6 +24,7 @@ export { Spacer } from './Spacer'
 export { TextAreaInput } from './TextAreaInput'
 export { TextInput } from './TextInput'
 export { TextMaskedInput } from './TextMaskedInput'
+export { Portal } from './Portal'
 export {
   Body,
   Caption,


### PR DESCRIPTION
## Description
This PR adds the `<Portal />` component to the `EDS`. The `<Portal />` component.

The Portal component provides a way to create React portals dynamically. The component will create a new DOM node that attaches to the end of the document.body and render's the passed children within that DOM node.

This provides us a base for building Modals, Notifications, etc.

## Screenshots
<img width="1067" alt="Screen Shot 2019-12-20 at 2 30 57 PM" src="https://user-images.githubusercontent.com/137689/71290522-a6638400-2335-11ea-947e-73a297ae9573.png">

