### PR TITLE
Add some descriptive comments about why we're using React.cloneElemen…

### DIFF
--- a/src/components/Grid/Grid.js
+++ b/src/components/Grid/Grid.js
@@ -11,6 +11,12 @@ export const Grid = (props) => {
     <Position className={props.className} refs={gridRefs} role="grid">
       {(positionX, positionY) =>
         Children.map(props.children, (row, index) => {
+          // From https://bit.ly/2tq3FiS
+          // ...`props.children` isn't the actual children; It is the descriptor
+          // of the children. So you don't have actually anything to change; you
+          // can't change any props, or edit any functionality; you can only read
+          // from it. If you need to make any modifications you have to create new
+          // elements using React.CloneElement.
           return React.cloneElement(row, {
             active: index === positionY,
             columnIndex: positionX,

--- a/src/components/Grid/Row.js
+++ b/src/components/Grid/Row.js
@@ -13,6 +13,12 @@ export const Row = React.memo((props) => {
   return (
     <div className={css} role="row">
       {React.Children.map(props.children, (column, index) =>
+        // From https://bit.ly/2tq3FiS
+        // ...`props.children` isn't the actual children; It is the descriptor
+        // of the children. So you don't have actually anything to change; you
+        // can't change any props, or edit any functionality; you can only read
+        // from it. If you need to make any modifications you have to create new
+        // elements using React.CloneElement.
         React.cloneElement(column, {
           active: props.active && index === props.columnIndex,
         })


### PR DESCRIPTION
This PR only contains a couple of comments which I feel help clarify the nuanced use of `React.cloneElement` in the grid codes