### PR TITLE
Adds validation, errors, and field label to Select

### DIFF
--- a/src/components/Form/Form.md
+++ b/src/components/Form/Form.md
@@ -10,6 +10,7 @@ import {
   InfoMessage,
   RadioButtonGroup,
   ZipInput,
+  Select,
   EmailInput,
 } from '../index'
 let count = 0
@@ -70,6 +71,15 @@ const analyticsCustomEvent = (fieldName, fieldValue) => {
         validationSuccess: [analyticsCustomEvent],
         name: 'this-zip-input-example',
         labelCopy: 'What is your zip code?',
+      },
+      states: {
+        component: (props, options) => {
+          return <Select placeholder="State" options={options} {...props} />
+        },
+        name: 'states',
+        labelCopy: 'What state?',
+        options: [{ value: 'CA', label: 'CA' }],
+        validators: [validateExists],
       },
       email: {
         component: (props, options) => {
@@ -170,6 +180,10 @@ const analyticsCustomEvent = (fieldName, fieldValue) => {
         <Spacer.H16 />
 
         {field('zipCode')}
+
+        <Spacer.H16 />
+
+        {field('states')}
 
         <Spacer.H16 />
 


### PR DESCRIPTION
**Description:**
- Supports this [Add DL edit functionality to user profiles in admin](https://app.asana.com/0/1149628124018183/1153703353529217)
- Validation for Forms was not hooked into our Select component. Also, labelCopy was not displayed like other form fields. This PR adds this stuff to Select. 
- For the future, it feels like we could use some sort of field wrapper to hold form-level logic as our components need a decent amount of form logic baked into them now. As you can see here, our simple Select component isn't so simple anymore. 

**Screenshots:**
![Screen Shot 2020-01-03 at 3 25 27 PM](https://user-images.githubusercontent.com/6633851/71750219-658f6300-2e3d-11ea-9ea4-933f592680da.png)