### PR TITLE
EDS / Nora Issues

### DIFF
--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -292,7 +292,7 @@ export declare namespace RadioButtonGroup {
     currentValue?: string
     currentError?: string
     formChangeHandler?: (value: string, errorValue: string) => void
-    onChange?: any
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
     'data-tid'?: string
     validator?: (value: string) => string
     disabled?: boolean
@@ -308,7 +308,7 @@ export declare namespace RadioButtonGroup {
     currentValue?: string
     currentError?: string
     formChangeHandler?: (value: string, errorValue: string) => void
-    onChange?: any
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
     'data-tid'?: string
     validator?: (value: string) => string
     disabled?: boolean

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -292,7 +292,7 @@ export declare namespace RadioButtonGroup {
     currentValue?: string
     currentError?: string
     formChangeHandler?: (value: string, errorValue: string) => void
-    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+    onChange?: ({ value: string, isAnswered: boolean })
     'data-tid'?: string
     validator?: (value: string) => string
     disabled?: boolean
@@ -308,7 +308,7 @@ export declare namespace RadioButtonGroup {
     currentValue?: string
     currentError?: string
     formChangeHandler?: (value: string, errorValue: string) => void
-    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+    onChange?: ({ value: string, isAnswered: boolean })
     'data-tid'?: string
     validator?: (value: string) => string
     disabled?: boolean

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -336,7 +336,7 @@ export declare const Pagination: {
     /**
      * Ultimately, this returns the JSON.parse'd data
      */
-    fetchPageCallback: (pageNumber: number | string) => any
+    fetchPageCallback: (pageNumber: number | string) => object
     /**
      * Will usually return the JSX unless !rows.length in which case it'll be null
      */
@@ -346,7 +346,7 @@ export declare const Pagination: {
     /**
      * Ultimately, this returns the JSON.parse'd data
      */
-    fetchPageCallback: (pageNumber: number | string) => any
+    fetchPageCallback: (pageNumber: number | string) => object
     /**
      * Will usually return the JSX unless !rows.length in which case it'll be null
      */

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -74,36 +74,36 @@ export declare const Logo: {
   Inline: typeof LogoInline
 }
 
-interface downstreamProperties {
+interface downstreamButtonProps {
   backArrowIcon?: boolean,
   arrowIcon?: boolean,
-  type: string,
-  isSelected: boolean,
-  fullWidth: boolean,
-  disabled: boolean,
-  name: string,
-  onClick: any,
-  'data-tid': string,
+  type?: string,
+  isSelected?: boolean,
+  fullWidth?: boolean,
+  disabled?: boolean,
+  name?: string,
+  onClick?: any,
+  'data-tid'?: string,
   children: string,
-  role: string,
-  ariaLabelId: string,
+  role?: string,
+  ariaLabelId?: string,
 }
 
 export declare const Button: {
   Medium: {
-    Black: (downstreamProps: downstreamProperties) => any
-    BlackOutline: (downstreamProps: downstreamProperties) => any
-    WhiteOutline: (downstreamProps: downstreamProperties) => any
+    Black: (downstreamProps: downstreamButtonProps) => any
+    BlackOutline: (downstreamProps: downstreamButtonProps) => any
+    WhiteOutline: (downstreamProps: downstreamButtonProps) => any
     Stateful: {
-      Default: (downstreamProps: downstreamProperties) => any
-      White: (downstreamProps: downstreamProperties) => any
+      Default: (downstreamProps: downstreamButtonProps) => any
+      White: (downstreamProps: downstreamButtonProps) => any
     }
   }
   Small: {
-    BlackOutline: (downstreamProps: any) => any
+    BlackOutline: (downstreamProps: downstreamButtonProps) => any
   }
-  Unstyled: (downstreamProps: any) => any
-  WhiteCTA: (downstreamProps: any) => any
+  Unstyled: (downstreamProps: downstreamButtonProps) => any
+  WhiteCTA: (downstreamProps: downstreamButtonProps) => any
 }
 
 export declare const CLOUDINARY_CLOUD_NAME = 'getethos'

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -340,7 +340,7 @@ export declare const Pagination: {
     /**
      * Will usually return the JSX unless !rows.length in which case it'll be null
      */
-    renderCallback: (rowsData: any) => JSX.Element | null 
+    renderCallback: (rowsData: any) => JSX.Element | null | void
   }): JSX.Element
   propTypes: {
     /**
@@ -350,7 +350,7 @@ export declare const Pagination: {
     /**
      * Will usually return the JSX unless !rows.length in which case it'll be null
      */
-    renderCallback: (rowsData: any) => JSX.Element | null 
+    renderCallback: (rowsData: any) => JSX.Element | null | void
   }
   displayName: string
 }

--- a/src/validators/validateExists.d.ts
+++ b/src/validators/validateExists.d.ts
@@ -1,2 +1,4 @@
-import validateExists from './validateExists.js'
-export function validateExists(x: string): string
+declare const validateExists: (
+    x: string
+) => '' | 'Please provide a value'
+export default validateExists


### PR DESCRIPTION
This PR fixes issues testing pulling in latest v1.1.46 EDS into Nora...

**Screenshots:**

Fixed in 6de837a9cc93af0fbce6cde68e451752805c59d1

![image](https://user-images.githubusercontent.com/142403/71754536-75a64300-2e3b-11ea-9e8c-5a6d1d3be8f0.png)


Fixed in 70fb439d98f24b2a4a46af4a3ddfb60c2053e6f6 ... we needed to add `void` to the union type for `renderCallback`. Use case is we want to just set state with updated rows and have that trigger a re-render that picks up rendering the grid from another method:

```jsx
  const renderCases = (rows: any) => {
    if (!rows || !rows.length) {
      return
    }
    /*** Here we are returning void but also updating state which will ultimately ***/
    /*** kick in renderGrid method which renders the `JSX.Element | null` ***/
    setRows(rows) 
  }
  const renderGrid = () => {
    if (rows.length) {
      return <LeGrid rows={rows} columns={columns} /> 
    }
    return null
  }

  return (
    <>
      {renderGrid()}
      <Pagination fetchPageCallback={fetchPage} renderCallback={renderCases} />
    </>
  )
```


![image](https://user-images.githubusercontent.com/142403/71754949-4b558500-2e3d-11ea-9e02-d468fe322f88.png)


ac48fb9dd3786277d40367583b762079825d3c85 fixed a "not assignable to type" for `validateExists` ...I forgot a screenshot


a6a174529d8054a32a40d319804763c882963112 is an improvement per Gordon's recommendation on another PR to switch return type of `any` to `object`