### PR TITLE
Revert select box changes for form support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.50",
+  "version": "1.1.51",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.51",
+  "version": "1.1.52",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.49",
+  "version": "1.1.50",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Form/Form.md
+++ b/src/components/Form/Form.md
@@ -10,7 +10,6 @@ import {
   InfoMessage,
   RadioButtonGroup,
   ZipInput,
-  Select,
   EmailInput,
 } from '../index'
 let count = 0
@@ -71,15 +70,6 @@ const analyticsCustomEvent = (fieldName, fieldValue) => {
         validationSuccess: [analyticsCustomEvent],
         name: 'this-zip-input-example',
         labelCopy: 'What is your zip code?',
-      },
-      states: {
-        component: (props, options) => {
-          return <Select placeholder="State" options={options} {...props} />
-        },
-        name: 'states',
-        labelCopy: 'What state?',
-        options: [{ value: 'CA', label: 'CA' }],
-        validators: [validateExists],
       },
       email: {
         component: (props, options) => {
@@ -180,10 +170,6 @@ const analyticsCustomEvent = (fieldName, fieldValue) => {
         <Spacer.H16 />
 
         {field('zipCode')}
-
-        <Spacer.H16 />
-
-        {field('states')}
 
         <Spacer.H16 />
 

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 // See React-Select -- https://github.com/JedWatson/react-select for documentation
 // on usage, Async configuration, etc.
@@ -6,64 +6,16 @@ import ReactSelect from 'react-select'
 import ReactSelectAsync from 'react-select/async'
 import ReactSelectAsyncCreatable from 'react-select/async-creatable'
 import ReactSelectCreatable from 'react-select/creatable'
-import useErrorMessage from '../../hooks/useErrorMessage.js'
-import { InputLabel } from '../InputLabel'
 
 import styles from './Select.module.scss'
 
-export const Select = ({
-  className,
-  title,
-  isAsync,
-  isCreatable,
-  validator,
-  onChange,
-  formChangeHandler,
-  currentError,
-  formTouched,
-  labelCopy,
-  name,
-  ...rest
-}) => {
-  const onChangeHandler = (event) => {
-    updateSelectedValue(event.value)
-
-    if (onChange) {
-      onChange(event)
-    }
-  }
-
-  const resolvedValidator = validator ? validator : () => ''
-  const [getError, setError, , validate] = useErrorMessage(resolvedValidator)
-  const [selectedValue, updateSelectedValue] = useState(undefined)
-
-  const validationSelect = () => {
-    const errorMessage = validate(selectedValue)
-    setError(errorMessage)
-    if (formChangeHandler) {
-      formChangeHandler(selectedValue, errorMessage)
-    }
-  }
-
-  useEffect(() => {
-    const isSelectedValue = typeof selectedValue !== 'undefined'
-    if (isSelectedValue) {
-      validationSelect()
-    }
-  }, [selectedValue])
-
-  const onBlur = () => {
-    validationSelect()
+export const Select = ({ className, title, isAsync, isCreatable, ...rest }) => {
+  const props = {
+    className: `${className ? className : ''} ${styles.root}`,
+    ...rest,
   }
 
   const wrapperClass = title ? styles.wrapper : ''
-
-  const props = {
-    className: `${className ? className : ''} ${styles.root}`,
-    onChange: onChangeHandler,
-    onBlur,
-    ...rest,
-  }
 
   const getTag = () => {
     if (isAsync && isCreatable) {
@@ -81,10 +33,8 @@ export const Select = ({
 
   return (
     <div className={wrapperClass}>
-      {labelCopy && <InputLabel name={name} labelCopy={labelCopy} />}
       <SelectTag {...props} />
       {title && <div className={styles.title}>{title}</div>}
-      {getError(currentError, formTouched)}
     </div>
   )
 }
@@ -99,12 +49,6 @@ Select.propTypes = {
   title: PropTypes.string,
   className: PropTypes.string,
   isCreatable: PropTypes.bool,
-  formChangeHandler: PropTypes.func,
-  currentError: PropTypes.string,
-  formTouched: PropTypes.bool,
-  labelCopy: PropTypes.string,
-  name: PropTypes.string,
-  validator: PropTypes.func,
 }
 
 Select.defaultProps = {

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -7,7 +7,6 @@ import ReactSelectAsync from 'react-select/async'
 import ReactSelectAsyncCreatable from 'react-select/async-creatable'
 import ReactSelectCreatable from 'react-select/creatable'
 import useErrorMessage from '../../hooks/useErrorMessage.js'
-import useInputValidation from '../../hooks/useInputValidation.js'
 import { InputLabel } from '../InputLabel'
 
 import styles from './Select.module.scss'
@@ -24,43 +23,37 @@ export const Select = ({
   formTouched,
   labelCopy,
   name,
-  initialValue,
-  options,
   ...rest
 }) => {
-  const defaultValue = options.find((option) => option.value === initialValue)
-  const resolvedValidator = validator ? validator : () => ''
-
-  const [selectedOption, updateSelectedOption] = useState(defaultValue)
-  const [touched, setTouched] = useState(initialValue ? true : false)
-  const [getError, setError, , validate] = useErrorMessage(resolvedValidator)
-  const [doValidation] = useInputValidation({
-    validate,
-    setError,
-    formChangeHandler,
-  })
-
-  const getSelectedValue = () =>
-    selectedOption ? selectedOption.value : undefined
-
-  useEffect(() => {
-    if (touched) {
-      doValidation(getSelectedValue(), touched)
-    }
-  }, [selectedOption])
-
   const onChangeHandler = (event) => {
-    updateSelectedOption(options.find((option) => option.value === event.value))
-    setTouched(true)
+    updateSelectedValue(event.value)
 
     if (onChange) {
       onChange(event)
     }
   }
 
+  const resolvedValidator = validator ? validator : () => ''
+  const [getError, setError, , validate] = useErrorMessage(resolvedValidator)
+  const [selectedValue, updateSelectedValue] = useState(undefined)
+
+  const validationSelect = () => {
+    const errorMessage = validate(selectedValue)
+    setError(errorMessage)
+    if (formChangeHandler) {
+      formChangeHandler(selectedValue, errorMessage)
+    }
+  }
+
+  useEffect(() => {
+    const isSelectedValue = typeof selectedValue !== 'undefined'
+    if (isSelectedValue) {
+      validationSelect()
+    }
+  }, [selectedValue])
+
   const onBlur = () => {
-    setTouched(true)
-    doValidation(getSelectedValue(), true)
+    validationSelect()
   }
 
   const wrapperClass = title ? styles.wrapper : ''
@@ -69,8 +62,6 @@ export const Select = ({
     className: `${className ? className : ''} ${styles.root}`,
     onChange: onChangeHandler,
     onBlur,
-    defaultValue,
-    options,
     ...rest,
   }
 
@@ -114,8 +105,6 @@ Select.propTypes = {
   labelCopy: PropTypes.string,
   name: PropTypes.string,
   validator: PropTypes.func,
-  initialValue: PropTypes.string,
-  options: PropTypes.array,
 }
 
 Select.defaultProps = {


### PR DESCRIPTION
**Description:**
- After attempting to make our Select boxes work in our forms, I realized it's a bit more complex than I had  anticipated. These changes currently break any select box that use loadOptions instead of options. Rather than try to keep patching this, I'd rather revert, and really think about how to solve this problem. 

- Part of the complexity comes from react-select features that we use for the `AuraDeSearchField`, for example. When we use multi-select, we no longer have one selectedOption, we have an array of selectedOptions. We may pass in options or loadOptions and need to handle both. It's hard to touch the Select component and be confident that it works for all these cases. So more tests would also need to be written for me to feel secure changing this. 

- For the original ticket that prompted these changes, I will use old components we have in the monorepo.