### PR TITLE
Conditionally paging buttons and add labelCopy prop to grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.54",
+  "version": "1.1.55",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Grid/Grid.md
+++ b/src/components/Grid/Grid.md
@@ -1,4 +1,5 @@
 ### Accessible React Grid
+
 This `Grid` follows the [wai-aria-practices-1.1](https://www.w3.org/TR/wai-aria-practices-1.1/#grid) specifications for data grids. It's influenced by [juanca's](https://github.com/juanca) original [react-aria-components](https://github.com/juanca/react-aria-components) data-grid component in the way the keyboard navigation and roles are assigned, but otherwise is a complete rewrite with the following added features:
 
 - The class-based lifecycle components were all converted to use functional hook-based components
@@ -6,7 +7,7 @@ This `Grid` follows the [wai-aria-practices-1.1](https://www.w3.org/TR/wai-aria-
 - Boilerplate default styles
 - Sort by column
 - Uses `columnheader` for header cells which is more idiomatic then `rowheader` which is usually used on the first column of
-a row to act as a header for just that row
+  a row to act as a header for just that row
 - Responsive stacking at mobile and lower with column label on left and values on the right
 
 ### Aria Support in Screen Readers
@@ -16,7 +17,6 @@ While support from screenreaders for aria roles is not yet perfect, it's on an [
 ### Usage
 
 Place focus anywhere just above the data grid and then tab. You've put focus on the grid. Now, use your arrow keys to navigate within the grid. On a Mac, `fn-rightarrow` simulates a _Page Right_, `fn-downarrow` a _Page Down_ and so on.
-
 
 ```jsx
 import React, { useState } from 'react'
@@ -31,16 +31,19 @@ import styles from './grid-example.module.scss'
 const columns = [
   {
     name: 'Description',
+    labelCopy: 'Task',
     interactive: true,
     sortable: true /* will use default sort function */,
     flexBasis: '40%',
   },
   {
     name: 'Type',
+    labelCopy: 'Type of Task',
     flexBasis: '30%',
   },
   {
     name: 'Date',
+    labelCopy: 'Task Date',
     flexBasis: '15%',
     sortable: true,
     // Custom sort function example
@@ -105,7 +108,7 @@ function GridExample() {
 
   const sortBy = (ev) => {
     ev.preventDefault()
-    const key = ev.currentTarget.text
+    const key = ev.currentTarget.dataset.key
     let rowsCopy = sortedRows
     let sortFunction
     // See if we have a custom sort function. If `sortFunction` is
@@ -140,9 +143,10 @@ function GridExample() {
                       onClick={sortBy}
                       tabIndex={active ? 0 : -1}
                       className={styles.iconContainer}
+                      data-key={col.name}
                       ref={columnRef}
                     >
-                      {col.name}
+                      {col.labelCopy || col.name}
                       {getSortIcon(col.name)}
                     </a>
                   )}
@@ -158,8 +162,11 @@ function GridExample() {
                 header
               >
                 {(active) => (
-                  <span className={active ? 'active' : undefined}>
-                    {col.name}
+                  <span
+                    data-key={col.name}
+                    className={active ? 'active' : undefined}
+                  >
+                    {col.labelCopy || col.name}
                   </span>
                 )}
               </Column>
@@ -211,7 +218,7 @@ function GridExample() {
   )
 }
 
-<GridExample />
+;<GridExample />
 ```
 
 You can pass `Small` or `Large` to the `Row` component to get a compressed or enlarged grid.
@@ -230,16 +237,19 @@ import styles from './grid-example.module.scss'
 const columns = [
   {
     name: 'Description',
+    labelCopy: 'Task Description',
     interactive: true,
     sortable: true /* will use default sort function */,
     flexBasis: '40%',
   },
   {
     name: 'Type',
+    labelCopy: 'Type of Task',
     flexBasis: '30%',
   },
   {
     name: 'Date',
+    labelCopy: 'Task Date',
     flexBasis: '15%',
     sortable: true,
     // Custom sort function example
@@ -254,11 +264,13 @@ const columns = [
   },
   {
     name: 'Cost',
+    labelCopy: 'Cost of Activity',
     flexBasis: '15%',
     interactive: true,
     sortable: true /* will use default sort function */,
   },
 ]
+
 const rows = [
   {
     Description: 'Learn Typescript',
@@ -304,7 +316,7 @@ function GridSmall() {
 
   const sortBy = (ev) => {
     ev.preventDefault()
-    const key = ev.currentTarget.text
+    const key = ev.currentTarget.dataset.key
     let rowsCopy = sortedRows
     let sortFunction
     // See if we have a custom sort function. If `sortFunction` is
@@ -339,9 +351,10 @@ function GridSmall() {
                       onClick={sortBy}
                       tabIndex={active ? 0 : -1}
                       className={styles.iconContainer}
+                      data-key={col.name}
                       ref={columnRef}
                     >
-                      {col.name}
+                      {col.labelCopy || col.name}
                       {getSortIcon(col.name)}
                     </a>
                   )}
@@ -357,8 +370,11 @@ function GridSmall() {
                 header
               >
                 {(active) => (
-                  <span className={active ? 'active' : undefined}>
-                    {col.name}
+                  <span
+                    data-key={col.name}
+                    className={active ? 'active' : undefined}
+                  >
+                    {col.labelCopy || col.name}
                   </span>
                 )}
               </Column>
@@ -366,7 +382,11 @@ function GridSmall() {
           })}
         </Row>
         {sortedRows.map((row, y) => (
-          <Row size={y === 3 ? "Large" : "Small"} key={uuidv4()} columnRefs={rowsRefs[y]}>
+          <Row
+            size={y === 3 ? 'Large' : 'Small'}
+            key={uuidv4()}
+            columnRefs={rowsRefs[y]}
+          >
             {columns.map((col, x) => {
               if (col.interactive) {
                 return (
@@ -410,6 +430,5 @@ function GridSmall() {
   )
 }
 
-<GridSmall />
-
+;<GridSmall />
 ```

--- a/src/components/Grid/Pagination.js
+++ b/src/components/Grid/Pagination.js
@@ -1,7 +1,7 @@
-import React, { memo } from 'react'
-import { usePagination } from './usePagination'
 import PropTypes from 'prop-types'
+import React, { memo } from 'react'
 import styles from './Pagination.module.scss'
+import { usePagination } from './usePagination'
 
 export const Pagination = memo(({ fetchPageCallback, renderCallback }) => {
   if (!fetchPageCallback || !renderCallback) {
@@ -14,32 +14,42 @@ export const Pagination = memo(({ fetchPageCallback, renderCallback }) => {
     fetchPage: fetchPageCallback,
   })
 
+  const conditionallyRenderPagingButtons = () => {
+    if (pagingState.pageCount > 1) {
+      return (
+        <nav aria-label="pagination" className={styles.pagination}>
+          <button
+            className={[
+              styles.paginationButtons,
+              styles.paginationButtonsLeft,
+            ].join(' ')}
+            onClick={() => fetchPage(1)}
+            aria-label="Goto Page 1"
+          >
+            &laquo;
+          </button>
+          {getPaginationNumbers()}
+          <button
+            className={[
+              styles.paginationButtons,
+              styles.paginationButtonsRight,
+            ].join(' ')}
+            onClick={() => fetchPage(pagingState.pageCount)}
+            aria-label={`Goto Page ${pagingState.pageCount}`}
+          >
+            &raquo;
+          </button>
+        </nav>
+      )
+    } else {
+      return null
+    }
+  }
+
   return (
     <>
       {renderCallback(pagingState.items)}
-      <nav aria-label="pagination" className={styles.pagination}>
-        <button
-          className={[
-            styles.paginationButtons,
-            styles.paginationButtonsLeft,
-          ].join(' ')}
-          onClick={() => fetchPage(1)}
-          aria-label="Goto Page 1"
-        >
-          &laquo;
-        </button>
-        {getPaginationNumbers()}
-        <button
-          className={[
-            styles.paginationButtons,
-            styles.paginationButtonsRight,
-          ].join(' ')}
-          onClick={() => fetchPage(pagingState.pageCount)}
-          aria-label={`Goto Page ${pagingState.pageCount}`}
-        >
-          &raquo;
-        </button>
-      </nav>
+      {conditionallyRenderPagingButtons()}
     </>
   )
 })

--- a/src/components/Grid/Pagination.md
+++ b/src/components/Grid/Pagination.md
@@ -23,17 +23,10 @@ const stubs = {
 }
 
 const toCaps = (str) => {
-  const capitalizedWords = str.split('_').map(word => {
+  const capitalizedWords = str.split(' ').map((word) => {
     return `${word.charAt(0).toUpperCase()}${word.slice(1)}`
   })
   return capitalizedWords.join(' ')
-}
-
-const toSnakeCase = (str) => {
-  const snakeCasedWords = str.split(' ').map(word => {
-    return word.toLowerCase()
-  })
-  return snakeCasedWords.join('_')
 }
 
 const LeGrid = ({ rows, columns }) => {
@@ -48,8 +41,7 @@ const LeGrid = ({ rows, columns }) => {
 
   const sortBy = (ev) => {
     ev.preventDefault()
-    // Put back to snake case e.g. 'Pantone Value' becomes 'pantone_value'
-    const key = toSnakeCase(ev.currentTarget.text)
+    const key = ev.currentTarget.dataset.key
     let rowsCopy = sortedRows
     let sortFunction
     // See if we have a custom sort function. If `sortFunction` is
@@ -63,10 +55,10 @@ const LeGrid = ({ rows, columns }) => {
   }
 
   useEffect(() => {
-   if (rows.length) {
-     updateRowsRefs(rows);
-   }
-  },[rows]);
+    if (rows.length) {
+      updateRowsRefs(rows)
+    }
+  }, [rows])
 
   return (
     <Grid rowRefs={rowsRefs} columnRefs={columnRefs}>
@@ -87,11 +79,12 @@ const LeGrid = ({ rows, columns }) => {
                   <a
                     href="./#"
                     onClick={sortBy}
+                    data-key={col.name}
                     tabIndex={active ? 0 : -1}
                     className={styles.iconContainer}
                     ref={columnRef}
                   >
-                    {toCaps(col.name)}
+                    {toCaps(col.labelCopy || col.name)}
                     {getSortIcon(col.name)}
                   </a>
                 )}
@@ -107,8 +100,11 @@ const LeGrid = ({ rows, columns }) => {
               header
             >
               {(active) => (
-                <span className={active ? 'active' : undefined}>
-                  {toCaps(col.name)}
+                <span
+                  data-key={col.name}
+                  className={active ? 'active' : undefined}
+                >
+                  {toCaps(col.labelCopy || col.name)}
                 </span>
               )}
             </Column>
@@ -167,18 +163,21 @@ const GridAndPagination = memo(() => {
     },
     {
       name: 'name',
+      labelCopy: 'color name',
       interactive: true,
       sortable: true /* will use default sort function */,
       flexBasis: '30%',
     },
     {
       name: 'color',
+      labelCopy: 'hex',
       interactive: true,
       sortable: true /* will use default sort function */,
       flexBasis: '30%',
     },
     {
       name: 'pantone_value',
+      labelCopy: 'pantone value',
       flexBasis: '15%',
     },
   ]
@@ -209,7 +208,7 @@ const GridAndPagination = memo(() => {
   }
   const renderGrid = () => {
     if (rows.length) {
-      return <LeGrid rows={rows} columns={columns} /> 
+      return <LeGrid rows={rows} columns={columns} />
     }
     return null
   }

--- a/src/components/Grid/Pagination.test.js
+++ b/src/components/Grid/Pagination.test.js
@@ -1,21 +1,20 @@
 import React from 'react'
 import TestRenderer, { act } from 'react-test-renderer'
-
 import { Pagination } from './Pagination'
 import styles from './Pagination.module.scss'
-
-const responseStub = {
-  page: 1,
-  itemCount: 2,
-  total: 6,
-  pageCount: 3,
-  items: [{ id: 1 }, { id: 2 }],
-}
 
 describe('Pagination Component', () => {
   let tree
   let fetchFn
   let renderFn
+
+  const responseStub = {
+    page: 1,
+    itemCount: 2,
+    total: 6,
+    pageCount: 3,
+    items: [{ id: 1 }, { id: 2 }],
+  }
 
   beforeEach(() => {
     fetchFn = jest.fn()
@@ -41,13 +40,14 @@ describe('Pagination Component', () => {
   })
 
   it('fetches', async () => {
-    tree = TestRenderer.create(
-      <Pagination fetchPageCallback={fetchFn} renderCallback={renderFn} />
-    )
+    await act(async () => {
+      tree = TestRenderer.create(
+        <Pagination fetchPageCallback={fetchFn} renderCallback={renderFn} />
+      )
+    })
     const root = tree.root
     const buttons = root.findAllByType('button')
     const [first] = buttons
-
     await act(async () => {
       first.props.onClick()
     })
@@ -81,5 +81,41 @@ describe('Pagination Component', () => {
     const buttons = root.findAllByType('button')
     const firstPageNumberButton = buttons[1]
     expect(firstPageNumberButton.props.className).toContain(styles.active)
+  })
+})
+
+describe('Hide Pagination', () => {
+  let tree
+  let fetchFn
+  let renderFn
+  const singlePageResponseStub = {
+    page: 1,
+    itemCount: 2,
+    total: 2,
+    pageCount: 1,
+    items: [{ id: 1 }, { id: 2 }],
+  }
+
+  beforeEach(() => {
+    fetchFn = jest.fn()
+    renderFn = jest.fn()
+    fetchFn.mockReturnValue(singlePageResponseStub)
+  })
+
+  afterEach(() => {
+    tree = null
+    fetchFn = null
+    renderFn = null
+  })
+
+  it('hides the pagination if only a single page worth of items', async () => {
+    await act(async () => {
+      tree = TestRenderer.create(
+        <Pagination fetchPageCallback={fetchFn} renderCallback={renderFn} />
+      )
+    })
+    const root = tree.root
+    const buttons = root.findAllByType('button')
+    expect(buttons.length).toEqual(0)
   })
 })


### PR DESCRIPTION
**Description:**
- [Asana Task](https://app.asana.com/0/1150068311310825/1155921313537887/f)
- Pagination should hide itself if items is <= number of items per page
- Data Grid column headers need to support `labelCopy` property

**Referencing PR or Branch (e.g. in CMS or monorepo):**
- https://github.com/getethos/ethos/pull/2012


**Screenshots:**

# Hiding Pagination

Context: We noticed on the Nora side that if you only have a single page of results, the pagination arrow buttons still showed up which is a poor UX...

Consuming from Nora example with 6 items (1 page). Thing to note is the pagination is now completely hidden since there's only 1 page.

![image](https://user-images.githubusercontent.com/142403/72635966-e573fd80-3912-11ea-8f20-a972042808ff.png)

Nominal case (there are pages to paginate) still works:

![image](https://user-images.githubusercontent.com/142403/72636332-b01bdf80-3913-11ea-8972-8fc003a895fb.png)


# labelCopy

Context on the issue: 
![image](https://user-images.githubusercontent.com/142403/72639536-a0ec6000-391a-11ea-90c2-3db6725d7a9f.png)

So we were using the `col.name` for both key and label which is of course silly 😋 

___

Turned out nothing needed to be added in terms of incoming component props. We just need to use dataset and utilize the key and label copy properly. By design, the data grid inverts control to the consumer in how they want to build up the cell to allow for more flexbility, and then ultimately just renders that `child` or `children` if you will.

The work done was to update the examples and encourage use of `labelCopy` with an optional approach of using the `name` as a fallback if you'd like.

Here's the EDS example:

![image](https://user-images.githubusercontent.com/142403/72638794-12c3aa00-3919-11ea-8cc4-7dac90f56e4e.png)


And here's the Nora EDS Fetch Applications example (after consuming these EDS updates):

![image](https://user-images.githubusercontent.com/142403/72641112-33dac980-391e-11ea-8b74-b69c358cc841.png)
