### PR TITLE
Nora colors and Tag additions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.59",
+  "version": "1.1.60",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.60",
+  "version": "1.1.61",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Grid/Pagination.module.scss
+++ b/src/components/Grid/Pagination.module.scss
@@ -33,7 +33,7 @@
 }
 
 .active {
-  background-color: var(--NoraBlue);
+  background-color: var(--NoraBlue-400);
   color: white;
-  border: 1px solid var(--NoraBlue);
+  border: 1px solid var(--NoraBlue-400);
 }

--- a/src/nora/components/Colors.css
+++ b/src/nora/components/Colors.css
@@ -1,14 +1,25 @@
 :root {
-  --NoraBlue: #1a7ff6;
+  --NoraRed-400: #E84733;
+  --NoraRed-100: #FBE2DE;
 
-  --NoraGreen--opaque: #2bd04b;
-  --NoraGreen--translucent: rgba(101, 217, 124, 0.17);
+  --NoraOrange-400: #ed9031;
+  --NoraOrange-100: #fcedde;
 
-  --NoraRed--opaque: #e63754;
-  --NoraRed--translucent: rgba(230, 55, 84, 0.16);
+  --NoraGreen-400: #51be4d;
+  --NoraGreen-100: #e3f5e3;
 
-  --NoraGray--opaque: #4f5972;
-  --NoraGray--translucent: #eaebee;
-  --NoraGrayHeader--opaque: #7c8699;
-  --NoraGrayHeaderBar--opaque: #dfe1e6;
+  --NoraCyan-400: #3bbce4;
+  --NoraCyan-100: #e0f4fb;
+
+  --NoraBlue-400: #187df7;
+  --NoraBlue-100: #f2f8ff;
+
+  --NoraSilver-400: #7f7f8b;
+  --NoraSilver-100: #e8e7ec;
+
+  --NoraNeutral-900: #0d1f40;
+  --NoraNeutral-400: #7c8699;
+  --NoraNeutral-300: #a7adb9;
+  --NoraNeutral-200: #dfe1e6;
+  --NoraNeutral-100: #f4f5f7;
 }

--- a/src/nora/components/Header/Header.module.scss
+++ b/src/nora/components/Header/Header.module.scss
@@ -2,7 +2,7 @@
 @import '../../../components/Spacer/Spacer.scss';
 
 .Header {
-  color: var(--NoraGrayHeader--opaque);
+  color: var(--NoraNeutral-400);
   font-weight: 400;
   height: var(--Space-56);
   background-color: white;
@@ -11,7 +11,7 @@
   left: 0;
   right: 0;
   z-index: 1;
-  border-bottom: 1px solid var(--NoraGrayHeaderBar--opaque);
+  border-bottom: 1px solid var(--NoraNeutral-200);
   display: flex;
   align-items: center;
 }

--- a/src/nora/components/Tag/Tag.js
+++ b/src/nora/components/Tag/Tag.js
@@ -5,11 +5,17 @@ import styles from './Tag.module.scss'
 export const Tag = ({ children, type }) => {
   let colorClass
   switch (type) {
-    case 'approved':
-      colorClass = styles.Approved
+    case 'red':
+      colorClass = styles.Red
       break
-    case 'rejected':
-      colorClass = styles.Rejected
+    case 'orange':
+      colorClass = styles.Orange
+      break
+    case 'green':
+      colorClass = styles.Green
+      break
+    case 'blue':
+      colorClass = styles.Blue
       break
     default:
       colorClass = styles.Default

--- a/src/nora/components/Tag/Tag.js
+++ b/src/nora/components/Tag/Tag.js
@@ -14,8 +14,8 @@ export const Tag = ({ children, type }) => {
     case 'green':
       colorClass = styles.Green
       break
-    case 'blue':
-      colorClass = styles.Blue
+    case 'cyan':
+      colorClass = styles.Cyan
       break
     default:
       colorClass = styles.Default

--- a/src/nora/components/Tag/Tag.md
+++ b/src/nora/components/Tag/Tag.md
@@ -7,6 +7,6 @@ Default tag
 
 Rejected tag
 ```jsx
-<Tag type='rejected'>Preview Text</Tag>
+<Tag type='green'>Preview Text</Tag>
 ```
 

--- a/src/nora/components/Tag/Tag.module.scss
+++ b/src/nora/components/Tag/Tag.module.scss
@@ -7,17 +7,27 @@
   padding: var(--Space-4);
 }
 
-.Approved {
-  background-color: var(--NoraGreen--translucent);
-  color: var(--NoraGreen--opaque);
+.Red {
+  background-color: var(--NoraRed-100);
+  color: var(--NoraRed-400);
 }
 
-.Rejected {
-  background-color: var(--NoraRed--translucent);
-  color: var(--NoraRed--opaque);
+.Orange {
+  background-color: var(--NoraOrange-100);
+  color: var(--NoraOrange-400);
+}
+
+.Green {
+  background-color: var(--NoraGreen-100);
+  color: var(--NoraGreen-400);
+}
+
+.Cyan {
+  background-color: var(--NoraCyan-100);
+  color: var(--NoraCyan-400);
 }
 
 .Default {
-  background-color: var(--NoraGray--translucent);
-  color: var(--NoraGray--opaque);
+  background-color: var(--NoraSilver-100);
+  color: var(--NoraSilver-400);
 }

--- a/src/nora/components/Tag/Tag.module.scss
+++ b/src/nora/components/Tag/Tag.module.scss
@@ -5,6 +5,7 @@
   display: inline-block;
   align-items: center;
   padding: var(--Space-4);
+  font-weight: 500;
 }
 
 .Red {


### PR DESCRIPTION
**Description:**
- [Asana Task](https://app.asana.com/0/1150068311310825/1158041380837745)
- This PR adds Nora colors and also updates the `Tag` component to have all the colors we need. I decided to make the `Tag` component colors independent of status. In other words, the props we are passing are now colors e.g .`green` instead of `approved`.
- Tom and I worked on a color naming convention that would make sense for the Nora app. What we came up with is [here](https://www.figma.com/file/2Ulqfby7GNX8xU2yA2KeRW/%C2%B7%E2%80%80%E2%80%80%E2%80%80%E2%80%80%E2%80%80Nora%E2%80%80%E2%80%80%E2%80%80%E2%80%80%E2%80%80%C2%B7?node-id=790%3A122):
![image](https://user-images.githubusercontent.com/12839832/72786915-c2768000-3c69-11ea-958c-808db3f2d7e6.png)


**Referencing PR or Branch (e.g. in CMS or monorepo):**
- 


**Screenshots:**
