### PR TITLE
Add setSortState function for arrow control

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.62",
+  "version": "1.1.63",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Grid/useGridSorting.js
+++ b/src/components/Grid/useGridSorting.js
@@ -26,6 +26,35 @@ export const useGridSorting = (rows, columns) => {
     return <SortIcon columnKey={key} />
   }
 
+  const setSortState = (key) => {
+    let nextSort
+    let currSortCopy = currentSort
+
+    // Have we sorted by this key before? If so, follow next state rules.
+    if (currSortCopy[key]) {
+      if (currSortCopy[key].direction === 'down') {
+        nextSort = 'up'
+      } else if (currSortCopy[key].direction === 'up') {
+        nextSort = 'down'
+      }
+      currSortCopy[key].direction = nextSort
+    } else {
+      // First time sorting by this key, so we'll assume current direction is
+      // 'default', and update it to 'down'.
+      nextSort = 'down'
+      currSortCopy[key] = {
+        direction: nextSort,
+        key,
+      }
+    }
+
+    // When we sort by a certain column, we want the other columns to go back
+    // to being unsorted, so, we overwrite our state with only `currentSort[key]`
+    const newSortState = {}
+    newSortState[key] = { ...currSortCopy[key] }
+    setCurrentSort(newSortState)
+  }
+
   const [sortedRows, setSortedRows] = useState(rows)
 
   const columnRefs = [columns.map(() => React.createRef())]
@@ -67,32 +96,9 @@ export const useGridSorting = (rows, columns) => {
   }
 
   const compareBy = (key, sortMethod = defaultSortMethod) => {
-    let nextSort
-    let currSortCopy = currentSort
+    setSortState(key)
 
-    // Have we sorted by this key before? If so, follow next state rules.
-    if (currSortCopy[key]) {
-      if (currSortCopy[key].direction === 'down') {
-        nextSort = 'up'
-      } else if (currSortCopy[key].direction === 'up') {
-        nextSort = 'down'
-      }
-      currSortCopy[key].direction = nextSort
-    } else {
-      // First time sorting by this key, so we'll assume current direction is
-      // 'default', and update it to 'down'.
-      nextSort = 'down'
-      currSortCopy[key] = {
-        direction: nextSort,
-        key,
-      }
-    }
-
-    // When we sort by a certain column, we want the other columns to go back
-    // to being unsorted, so, we overwrite our state with only `currentSort[key]`
-    const newSortState = {}
-    newSortState[key] = { ...currSortCopy[key] }
-    setCurrentSort(newSortState)
+    const nextSort = currentSort[key].direction
 
     return function(a, b) {
       switch (nextSort) {
@@ -109,6 +115,7 @@ export const useGridSorting = (rows, columns) => {
     columnRefs,
     sortedRows,
     compareBy,
+    setSortState,
     updateRowsRefs,
     getSortIcon,
   }

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -364,12 +364,12 @@ export declare const useGridSorting: (
   columnRefs: any[]
   sortedRows: any
   compareBy: (
-    key: any,
+    key: string | number,
     sortMethod?: (a: any, b: any) => 1 | 0 | -1
   ) => (a: any, b: any) => 1 | 0 | -1
   setSortState: (key: any) => void
   updateRowsRefs: (sortedRowsCopy: any) => void
-  getSortIcon: (key: any) => JSX.Element
+  getSortIcon: (key: string | number) => JSX.Element
 }
 
 export declare const TextInput: (downstreamProps: any) => JSX.Element

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -364,11 +364,12 @@ export declare const useGridSorting: (
   columnRefs: any[]
   sortedRows: any
   compareBy: (
-    key: string | number,
+    key: any,
     sortMethod?: (a: any, b: any) => 1 | 0 | -1
   ) => (a: any, b: any) => 1 | 0 | -1
+  setSortState: (key: any) => void
   updateRowsRefs: (sortedRowsCopy: any) => void
-  getSortIcon: (key: string | number) => JSX.Element
+  getSortIcon: (key: any) => JSX.Element
 }
 
 export declare const TextInput: (downstreamProps: any) => JSX.Element

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -367,7 +367,7 @@ export declare const useGridSorting: (
     key: string | number,
     sortMethod?: (a: any, b: any) => 1 | 0 | -1
   ) => (a: any, b: any) => 1 | 0 | -1
-  setSortState: (key: any) => void
+  setSortState: (key: string | number) => void
   updateRowsRefs: (sortedRowsCopy: any) => void
   getSortIcon: (key: string | number) => JSX.Element
 }


### PR DESCRIPTION
**Description:**
- [Ticket](https://app.asana.com/0/1150068311310825/1158253271849323)
- We aren't using the `compareBy` function when using the Grid in Nora because we have to re-fetch the page rather than sorting locally. 
- As a result, we need a way to set the sort state so that the correct sort icons appear.
- This PR adds the ability to set the sort state from outside of the EDS component.

**Screenshots:**
- Tested locally to make sure that the sort still works and there are no console errors.
<img width="1408" alt="Image 2020-01-22 at 12 01 13 PM" src="https://user-images.githubusercontent.com/12839832/72864436-f657b100-3d0e-11ea-878f-7aa20efcb565.png">

**Referencing PR or Branch (e.g. in CMS or monorepo):**
- https://github.com/getethos/ethos/pull/2046

