### PR TITLE
Refactors useGridSorting and adds test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.64",
+  "version": "1.1.65",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.63",
+  "version": "1.1.64",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Grid/useGridSorting.js
+++ b/src/components/Grid/useGridSorting.js
@@ -5,12 +5,11 @@ import styles from './useGridSorting.module.scss'
 export const useGridSorting = (rows, columns) => {
   const [currentSort, setCurrentSort] = useState({})
 
-  const SortIcon = ({ columnKey }) => {
+  const SortIcon = ({ direction }) => {
     let sortIcon
-    const key = columnKey
-    if (currentSort[key] && currentSort[key].direction === 'up') {
+    if (direction === 'up') {
       sortIcon = <FaSortUp className={[styles.icon, styles.iconUp].join(' ')} />
-    } else if (currentSort[key] && currentSort[key].direction === 'down') {
+    } else if (direction === 'down') {
       sortIcon = (
         <FaSortDown className={[styles.icon, styles.iconDown].join(' ')} />
       )
@@ -22,27 +21,36 @@ export const useGridSorting = (rows, columns) => {
     return sortIcon
   }
 
+  const getSortDirection = (key) => {
+    if (currentSort[key] && currentSort[key].direction === 'up') {
+      return 'up'
+    } else if (currentSort[key] && currentSort[key].direction === 'down') {
+      return 'down'
+    } else {
+      return 'default'
+    }
+  }
+
   const getSortIcon = (key) => {
-    return <SortIcon columnKey={key} />
+    const sortDirection = getSortDirection(key)
+    return <SortIcon direction={sortDirection} />
   }
 
   const setSortState = (key) => {
     let nextSort
-    let currSortCopy = currentSort
-
     // Have we sorted by this key before? If so, follow next state rules.
-    if (currSortCopy[key]) {
-      if (currSortCopy[key].direction === 'down') {
+    if (currentSort[key]) {
+      if (currentSort[key].direction === 'down') {
         nextSort = 'up'
-      } else if (currSortCopy[key].direction === 'up') {
+      } else if (currentSort[key].direction === 'up') {
         nextSort = 'down'
       }
-      currSortCopy[key].direction = nextSort
+      currentSort[key].direction = nextSort
     } else {
       // First time sorting by this key, so we'll assume current direction is
       // 'default', and update it to 'down'.
       nextSort = 'down'
-      currSortCopy[key] = {
+      currentSort[key] = {
         direction: nextSort,
         key,
       }
@@ -51,7 +59,7 @@ export const useGridSorting = (rows, columns) => {
     // When we sort by a certain column, we want the other columns to go back
     // to being unsorted, so, we overwrite our state with only `currentSort[key]`
     const newSortState = {}
-    newSortState[key] = { ...currSortCopy[key] }
+    newSortState[key] = { ...currentSort[key] }
     setCurrentSort(newSortState)
   }
 
@@ -117,6 +125,7 @@ export const useGridSorting = (rows, columns) => {
     compareBy,
     setSortState,
     updateRowsRefs,
+    getSortDirection,
     getSortIcon,
   }
 }

--- a/src/components/Grid/useGridSorting.js
+++ b/src/components/Grid/useGridSorting.js
@@ -2,14 +2,20 @@ import React, { useState } from 'react'
 import { FaSort, FaSortUp, FaSortDown } from 'react-icons/fa'
 import styles from './useGridSorting.module.scss'
 
+const DIR = {
+  UP: 'up',
+  DOWN: 'down',
+  DEFAULT: 'default',
+}
+
 export const useGridSorting = (rows, columns) => {
   const [currentSort, setCurrentSort] = useState({})
 
   const SortIcon = ({ direction }) => {
     let sortIcon
-    if (direction === 'up') {
+    if (direction === DIR.UP) {
       sortIcon = <FaSortUp className={[styles.icon, styles.iconUp].join(' ')} />
-    } else if (direction === 'down') {
+    } else if (direction === DIR.DOWN) {
       sortIcon = (
         <FaSortDown className={[styles.icon, styles.iconDown].join(' ')} />
       )
@@ -22,12 +28,12 @@ export const useGridSorting = (rows, columns) => {
   }
 
   const getSortDirection = (key) => {
-    if (currentSort[key] && currentSort[key].direction === 'up') {
-      return 'up'
-    } else if (currentSort[key] && currentSort[key].direction === 'down') {
-      return 'down'
+    if (currentSort[key] && currentSort[key].direction === DIR.UP) {
+      return DIR.UP
+    } else if (currentSort[key] && currentSort[key].direction === DIR.DOWN) {
+      return DIR.DOWN
     } else {
-      return 'default'
+      return DIR.DEFAULT
     }
   }
 
@@ -40,16 +46,16 @@ export const useGridSorting = (rows, columns) => {
     let nextSort
     // Have we sorted by this key before? If so, follow next state rules.
     if (currentSort[key]) {
-      if (currentSort[key].direction === 'down') {
-        nextSort = 'up'
-      } else if (currentSort[key].direction === 'up') {
-        nextSort = 'down'
+      if (currentSort[key].direction === DIR.DOWN) {
+        nextSort = DIR.UP
+      } else if (currentSort[key].direction === DIR.UP) {
+        nextSort = DIR.DOWN
       }
       currentSort[key].direction = nextSort
     } else {
       // First time sorting by this key, so we'll assume current direction is
-      // 'default', and update it to 'down'.
-      nextSort = 'down'
+      // 'default', and update it to DIR.DOWN.
+      nextSort = DIR.DOWN
       currentSort[key] = {
         direction: nextSort,
         key,
@@ -110,9 +116,9 @@ export const useGridSorting = (rows, columns) => {
 
     return function(a, b) {
       switch (nextSort) {
-        case 'down':
+        case DIR.DOWN:
           return sortMethod(a[key], b[key])
-        case 'up':
+        case DIR.UP:
           return sortMethod(b[key], a[key])
       }
     }

--- a/src/components/Grid/useGridSorting.test.js
+++ b/src/components/Grid/useGridSorting.test.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { act } from 'react-test-renderer'
 import { useGridSorting } from './useGridSorting.js'
 import testHook from '../../hooks/testHook.js'

--- a/src/components/Grid/useGridSorting.test.js
+++ b/src/components/Grid/useGridSorting.test.js
@@ -1,0 +1,78 @@
+import React from 'react'
+import { act } from 'react-test-renderer'
+import { useGridSorting } from './useGridSorting.js'
+import testHook from '../../hooks/testHook.js'
+
+describe('useGridSorting', () => {
+  let columns, rows
+
+  beforeEach(() => {
+    columns = [
+      {
+        name: 'Description',
+        labelCopy: 'Task',
+        interactive: true,
+        sortable: true,
+        flexBasis: '40%',
+      },
+      {
+        name: 'Type',
+        labelCopy: 'Type of Task',
+        flexBasis: '30%',
+      },
+    ]
+    rows = [
+      {
+        Description: 'Zoo Trip',
+        Type: 'Travel',
+      },
+      {
+        Description: 'Coffee and Bagel',
+        Type: 'Food',
+      },
+      {
+        Description: 'Acting Classes',
+        Type: 'Grooming',
+      },
+    ]
+  })
+
+  afterEach(() => {
+    columns = null
+    rows = null
+  })
+
+  it('defaults', async () => {
+    await act(async () => {
+      testHook(() => {
+        const {
+          rowsRefs,
+          columnRefs,
+          sortedRows,
+          compareBy,
+          setSortState,
+          updateRowsRefs,
+          getSortIcon,
+        } = useGridSorting(rows, columns)
+
+        expect(columnRefs[0].length).toEqual(2)
+        expect(rowsRefs.length).toEqual(3)
+        expect(sortedRows.length).toEqual(3)
+        expect(compareBy).toBeDefined()
+        expect(setSortState).toBeDefined()
+        expect(updateRowsRefs).toBeDefined()
+        expect(getSortIcon).toBeDefined()
+      })
+    })
+  })
+
+  it('default sort direction', async () => {
+    await act(async () => {
+      testHook(() => {
+        const { getSortDirection } = useGridSorting(rows, columns)
+        const direction = getSortDirection('Description')
+        expect(direction).toEqual('default')
+      })
+    })
+  })
+})


### PR DESCRIPTION
Why: There was no coverage for useGridSorting
How: Exposes a getSortDirection method and adds a spec
Tags: hooks, testing, grid, pagination

**Description:**
- [Asana Task](https://app.asana.com/0/1150068311310825/1157190385219569)
- Adds specs to the corresponding EDS changes that were merged yesterday and correspond to 2046 PR

**Referencing PR or Branch (e.g. in CMS or monorepo):**
- https://github.com/getethos/ethos/pull/2046/files

**Screenshots:**

Consumed from Nora and was able to click the sort icons and it looked correct:

![image](https://user-images.githubusercontent.com/142403/72919766-e931c680-3cfc-11ea-9595-905016314639.png)
