### PR TITLE
UniversalNavbar search/account icons + minor restyle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.80",
+  "version": "1.1.81",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.72",
+  "version": "1.1.73",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.76",
+  "version": "1.1.77",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.73",
-  "version": "1.1.74",
+  "version": "1.1.75",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/UniversalNavbar/FancyAnimatedLogo.scss
+++ b/src/components/UniversalNavbar/FancyAnimatedLogo.scss
@@ -29,18 +29,20 @@
     transition-delay: 0s;
   }
 
-  .get-an-estimate.show-when-scrolled {
+  .cta-button.show-when-scrolled {
     /* When not scrolled, is transparent and starts to the right */
-    transition: transform ease-in-out 0.7s, opacity ease-in-out 0.7s;
+    transition: transform ease-out 0.2s, opacity ease-out 0.2s;
     opacity: 0;
     pointer-events: none;
-    min-width: 135px; // Tied to "Check My Price" copy
+    position: absolute;
+    right: var(--Space-72);
   }
   .isScrolled {
-    .get-an-estimate.show-when-scrolled {
+    .cta-button.show-when-scrolled {
       opacity: 1;
       pointer-events: all;
-      transform: translateX(-5%);
+      transform: translateX(var(--NegativeSpace-16));
+      transition: transform ease-in 0.3s 0.7s, opacity ease-in 0.3s 0.7s;
     }
   }
 

--- a/src/components/UniversalNavbar/FancyAnimatedLogo.scss
+++ b/src/components/UniversalNavbar/FancyAnimatedLogo.scss
@@ -1,5 +1,4 @@
 @import '../Media/Media.scss';
-
 /**
    * Region:
    * Fancy animated scroll behavior
@@ -35,12 +34,13 @@
     transition: transform ease-in-out 0.7s, opacity ease-in-out 0.7s;
     opacity: 0;
     pointer-events: none;
+    min-width: 135px; // Tied to "Check My Price" copy
   }
   .isScrolled {
     .get-an-estimate.show-when-scrolled {
       opacity: 1;
       pointer-events: all;
-      transform: translateX(-15%);
+      transform: translateX(-5%);
     }
   }
 

--- a/src/components/UniversalNavbar/TransformingBurgerButton/TransformingBurgerButton.js
+++ b/src/components/UniversalNavbar/TransformingBurgerButton/TransformingBurgerButton.js
@@ -3,10 +3,20 @@ import PropTypes from 'prop-types'
 import styles from './TransformingBurgerButton.module.scss'
 
 // onClick is an event handler, showMobileMenu is a boolean
-const TransformingBurgerButton = ({ clickHandler, showMobileMenu }) => {
+const TransformingBurgerButton = ({
+  clickHandler,
+  keyPressHandler,
+  showMobileMenu,
+}) => {
   return (
     <span className={showMobileMenu ? styles.showMobileMenu : ''}>
-      <div onClick={clickHandler} className={styles.iconWrapper}>
+      <div
+        onClick={clickHandler}
+        onKeyPress={keyPressHandler}
+        className={styles.iconWrapper}
+        role="button"
+        tabIndex="0"
+      >
         <div className={styles.icon}>
           <i />
         </div>
@@ -17,6 +27,7 @@ const TransformingBurgerButton = ({ clickHandler, showMobileMenu }) => {
 
 TransformingBurgerButton.propTypes = {
   clickHandler: PropTypes.func.isRequired,
+  keyPressHandler: PropTypes.func.isRequired,
   showMobileMenu: PropTypes.bool.isRequired,
 }
 

--- a/src/components/UniversalNavbar/UniversalNavbar.js
+++ b/src/components/UniversalNavbar/UniversalNavbar.js
@@ -96,7 +96,9 @@ class UniversalNavbar extends React.Component {
         <NavLink
           href={link.href}
           LinkComponent={link.href !== '/login/' ? LinkComponent : null}
-          className={location.pathname === link.href ? styles.currentPage : null}
+          className={
+            location.pathname === link.href ? styles.currentPage : null
+          }
         >
           {link.title}
         </NavLink>

--- a/src/components/UniversalNavbar/UniversalNavbar.js
+++ b/src/components/UniversalNavbar/UniversalNavbar.js
@@ -78,10 +78,10 @@ class UniversalNavbar extends React.Component {
       logoHref,
     } = this.props
 
-    const getAnEstimate = (showWhenScrolled) => (
+    const renderCtaButton = (showWhenScrolled) => (
       <a
         className={
-          'get-an-estimate ' + (showWhenScrolled ? 'show-when-scrolled' : '')
+          'cta-button ' + (showWhenScrolled ? 'show-when-scrolled' : '')
         }
         onClick={this.props.trackCtaClick}
         href={LINKS.TERM.href}
@@ -111,21 +111,21 @@ class UniversalNavbar extends React.Component {
         LinkComponent={link.href !== '/login/' ? LinkComponent : null}
       >
         <svg
-          width="30"
-          height="30"
-          viewBox="0 0 30 30"
+          width="21"
+          height="21"
+          viewBox="0 0 21 21"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
           <circle
-            cx="13.0739"
-            cy="13.0739"
+            cx="8.0739"
+            cy="8.0739"
             r="7.0739"
             stroke="#221F1F"
             strokeWidth="2"
           />
           <path
-            d="M18.0997 18.1L25.0002 23.9909"
+            d="M13.0997 13.1L20.0002 18.9909"
             stroke="#221F1F"
             strokeWidth="2"
           />
@@ -141,28 +141,28 @@ class UniversalNavbar extends React.Component {
         LinkComponent={link.href !== '/login/' ? LinkComponent : null}
       >
         <svg
-          width="30"
-          height="30"
-          viewBox="0 0 30 30"
+          width="22"
+          height="21"
+          viewBox="0 0 22 21"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
           <circle
-            cx="14.9261"
-            cy="10.9261"
+            cx="10.9261"
+            cy="5.9261"
             r="4.9261"
             stroke="#221F1F"
             strokeWidth="2"
           />
           <circle
-            cx="14.9261"
-            cy="10.9261"
+            cx="10.9261"
+            cy="5.9261"
             r="4.9261"
             stroke="#221F1F"
             strokeWidth="2"
           />
           <path
-            d="M24.8522 25.7781C24.8522 20.2961 20.4081 15.8521 14.9261 15.8521C9.44407 15.8521 5 20.2961 5 25.7781"
+            d="M20.8522 20.7781C20.8522 15.2961 16.4081 10.8521 10.9261 10.8521C5.44407 10.8521 1 15.2961 1 20.7781"
             stroke="#221F1F"
             strokeWidth="2"
           />
@@ -236,7 +236,7 @@ class UniversalNavbar extends React.Component {
               >
                 <FancyAnimatedLogo />
               </NavLink>
-              {!hideMobileCta && getAnEstimate(true)}
+              {!hideMobileCta && renderCtaButton(true)}
               {renderSearchIcon(LINKS.NAVLINKS[3])}
             </div>
 
@@ -261,7 +261,7 @@ class UniversalNavbar extends React.Component {
                   {renderAccountIcon(LINKS.NAVLINKS[4])}
 
                   <div className={styles.cta}>
-                    {!hideDesktopCta && getAnEstimate(false)}
+                    {!hideDesktopCta && renderCtaButton(false)}
                   </div>
                 </div>
               </div>

--- a/src/components/UniversalNavbar/UniversalNavbar.js
+++ b/src/components/UniversalNavbar/UniversalNavbar.js
@@ -62,7 +62,7 @@ const LINKS = {
     },
     {
       id: uuidv4(),
-      href: '/faq/',
+      href: '/search/',
       title: 'Search',
     },
     {

--- a/src/components/UniversalNavbar/UniversalNavbar.js
+++ b/src/components/UniversalNavbar/UniversalNavbar.js
@@ -96,9 +96,6 @@ class UniversalNavbar extends React.Component {
         <NavLink
           href={link.href}
           LinkComponent={link.href !== '/login/' ? LinkComponent : null}
-          className={
-            location.pathname === link.href ? styles.currentPage : null
-          }
         >
           {link.title}
         </NavLink>

--- a/src/components/UniversalNavbar/UniversalNavbar.js
+++ b/src/components/UniversalNavbar/UniversalNavbar.js
@@ -13,14 +13,27 @@ import styles from './UniversalNavbar.module.scss'
 // TODO REDESIGN: Lots of sloppy inline styles here.
 
 // UPDATE anchor tags to NavLink when /term and /login is an internal link in CMS
-const NavLink = ({ href, LinkComponent, ...props }) => {
+const NavLink = ({ href, children, LinkComponent, ...props }) => {
   if (LinkComponent) {
-    return <LinkComponent to={href} {...props} />
+    return (
+      <LinkComponent to={href} {...props}>
+        {children}
+      </LinkComponent>
+    )
   }
-  return <a href={href} {...props} />
+  return (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  )
 }
 
 NavLink.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.string,
+    PropTypes.func,
+  ]),
   href: PropTypes.string.isRequired,
   LinkComponent: PropTypes.object,
 }
@@ -70,6 +83,12 @@ class UniversalNavbar extends React.Component {
     this.setState({ showMobileMenu: !this.state.showMobileMenu })
   }
 
+  handleHamburgerKeyPress = (event) => {
+    if (event.key === 'Enter') {
+      this.toggleHamburger()
+    }
+  }
+
   render() {
     const {
       LinkComponent,
@@ -103,13 +122,8 @@ class UniversalNavbar extends React.Component {
     )
 
     // These are bespoke icons but design may replace w/FA at a later date
-    const renderSearchIcon = (link) => (
-      <NavLink
-        className={styles.searchIcon}
-        key={link.id}
-        href={link.href}
-        LinkComponent={link.href !== '/login/' ? LinkComponent : null}
-      >
+    const renderSearchIcon = (link) => {
+      const searchIcon = (
         <svg
           width="23"
           height="22"
@@ -130,16 +144,22 @@ class UniversalNavbar extends React.Component {
             strokeWidth="1.5"
           />
         </svg>
-      </NavLink>
-    )
+      )
 
-    const renderAccountIcon = (link) => (
-      <NavLink
-        className={styles.accountIcon}
-        key={link.id}
-        href={link.href}
-        LinkComponent={link.href !== '/login/' ? LinkComponent : null}
-      >
+      return (
+        <NavLink
+          className={styles.searchIcon}
+          key={link.id}
+          href={link.href}
+          LinkComponent={link.href !== '/login/' ? LinkComponent : null}
+        >
+          {searchIcon}
+        </NavLink>
+      )
+    }
+
+    const renderAccountIcon = (link) => {
+      const accountIcon = (
         <svg
           width="25"
           height="23"
@@ -160,8 +180,19 @@ class UniversalNavbar extends React.Component {
             strokeWidth="1.5"
           />
         </svg>
-      </NavLink>
-    )
+      )
+
+      return (
+        <NavLink
+          className={styles.accountIcon}
+          key={link.id}
+          href={link.href}
+          LinkComponent={link.href !== '/login/' ? LinkComponent : null}
+        >
+          {accountIcon}
+        </NavLink>
+      )
+    }
 
     return (
       <div style={{ height: 64 }}>
@@ -180,6 +211,7 @@ class UniversalNavbar extends React.Component {
               <TransformingBurgerButton
                 showMobileMenu={showMobileMenu}
                 clickHandler={this.toggleHamburger}
+                keyPressHandler={this.handleHamburgerKeyPress}
               />
             </div>
 
@@ -227,7 +259,7 @@ class UniversalNavbar extends React.Component {
                 LinkComponent={LinkComponent}
                 className={styles.phoneLogoFancy}
               >
-                <FancyAnimatedLogo />
+                {FancyAnimatedLogo()}
               </NavLink>
               {!hideMobileCta && renderCtaButton(true)}
               {renderSearchIcon(LINKS.NAVLINKS[3])}
@@ -242,7 +274,6 @@ class UniversalNavbar extends React.Component {
                   </NavLink>
                   {renderTextLink(LINKS.NAVLINKS[0])}
                   {renderTextLink(LINKS.NAVLINKS[1])}
-
                   <div className={styles.laptopAndUp}>
                     {renderTextLink(LINKS.NAVLINKS[2])}
                   </div>
@@ -252,7 +283,6 @@ class UniversalNavbar extends React.Component {
                 <div className={`${styles.flex} ${styles.itemsCenter}`}>
                   {renderSearchIcon(LINKS.NAVLINKS[3])}
                   {renderAccountIcon(LINKS.NAVLINKS[4])}
-
                   <div className={styles.cta}>
                     {!hideDesktopCta && renderCtaButton(false)}
                   </div>

--- a/src/components/UniversalNavbar/UniversalNavbar.js
+++ b/src/components/UniversalNavbar/UniversalNavbar.js
@@ -12,10 +12,6 @@ import styles from './UniversalNavbar.module.scss'
 
 // TODO REDESIGN: Lots of sloppy inline styles here.
 
-// WIP - TODO: Confirm check my price vs get an estimate in figma
-// WIP - TODO: See if Design can provide spec using FontAwesome
-// WIP - TODO: Check search link text on expanded mobile nav (hamburger click)
-
 // UPDATE anchor tags to NavLink when /term and /login is an internal link in CMS
 const NavLink = ({ href, LinkComponent, ...props }) => {
   if (LinkComponent) {
@@ -95,24 +91,25 @@ class UniversalNavbar extends React.Component {
     )
 
     const { showMobileMenu } = this.state
-
     const renderTextLink = (link) => (
       <div key={link.id} className={styles.textLink}>
         <NavLink
           href={link.href}
           LinkComponent={link.href !== '/login/' ? LinkComponent : null}
+          className={location.pathname === link.href ? styles.currentPage : null}
         >
           {link.title}
         </NavLink>
       </div>
     )
 
+    // These are bespoke icons but design may replace w/FA at a later date
     const renderSearchIcon = (link) => (
-      <a
+      <NavLink
         className={styles.searchIcon}
         key={link.id}
-        // onClick={this.props.trackSearchClick}
         href={link.href}
+        LinkComponent={link.href !== '/login/' ? LinkComponent : null}
       >
         <svg
           width="30"
@@ -134,15 +131,15 @@ class UniversalNavbar extends React.Component {
             strokeWidth="2"
           />
         </svg>
-      </a>
+      </NavLink>
     )
 
     const renderAccountIcon = (link) => (
-      <a
+      <NavLink
         className={styles.accountIcon}
         key={link.id}
-        // onClick={this.props.trackAccountClick}
         href={link.href}
+        LinkComponent={link.href !== '/login/' ? LinkComponent : null}
       >
         <svg
           width="30"
@@ -171,7 +168,7 @@ class UniversalNavbar extends React.Component {
             strokeWidth="2"
           />
         </svg>
-      </a>
+      </NavLink>
     )
 
     return (
@@ -182,7 +179,7 @@ class UniversalNavbar extends React.Component {
             top: 0,
             left: 0,
             width: '100%',
-            height: 100,
+            height: 64,
             zIndex: 1,
           }}
         >
@@ -226,7 +223,6 @@ class UniversalNavbar extends React.Component {
                 <div style={{ position: 'absolute', bottom: 40 }}>
                   <a href={LINKS.TERM.href}>
                     <Button.Medium.WhiteOutline>
-                      {/* TODO: Double check this copy */}
                       Check my price
                     </Button.Medium.WhiteOutline>
                   </a>

--- a/src/components/UniversalNavbar/UniversalNavbar.js
+++ b/src/components/UniversalNavbar/UniversalNavbar.js
@@ -201,7 +201,11 @@ class UniversalNavbar extends React.Component {
                   showMobileMenu ? styles.mobileMenu : styles.hideMobileMenu
                 }
               >
-                <NavLink href={logoHref} LinkComponent={LinkComponent} className={styles.phoneLogo}>
+                <NavLink
+                  href={logoHref}
+                  LinkComponent={LinkComponent}
+                  className={styles.phoneLogo}
+                >
                   {LogoWhite({ className: styles.logo })}
                 </NavLink>
                 <Spacer.H56 />
@@ -230,7 +234,11 @@ class UniversalNavbar extends React.Component {
               </div>
 
               {/* Mobile menu items, getAnEstimate only shows when scrolled */}
-              <NavLink href={LINKS.INDEX.href} LinkComponent={LinkComponent} className={styles.phoneLogoFancy}>
+              <NavLink
+                href={LINKS.INDEX.href}
+                LinkComponent={LinkComponent}
+                className={styles.phoneLogoFancy}
+              >
                 <FancyAnimatedLogo />
               </NavLink>
               {!hideMobileCta && getAnEstimate(true)}

--- a/src/components/UniversalNavbar/UniversalNavbar.js
+++ b/src/components/UniversalNavbar/UniversalNavbar.js
@@ -11,7 +11,10 @@ import TransformingBurgerButton from './TransformingBurgerButton/TransformingBur
 import styles from './UniversalNavbar.module.scss'
 
 // TODO REDESIGN: Lots of sloppy inline styles here.
-// TODO: Remove last usages of the Media helper (and prefer the Sass MQ mixins).
+
+// WIP - TODO: Confirm check my price vs get an estimate in figma
+// WIP - TODO: See if Design can provide spec using FontAwesome
+// WIP - TODO: Check search link text on expanded mobile nav (hamburger click)
 
 // UPDATE anchor tags to NavLink when /term and /login is an internal link in CMS
 const NavLink = ({ href, LinkComponent, ...props }) => {
@@ -45,8 +48,13 @@ const LINKS = {
     },
     {
       id: uuidv4(),
+      href: '/blog/',
+      title: 'Blog',
+    },
+    {
+      id: uuidv4(),
       href: '/faq/',
-      title: 'FAQ',
+      title: 'Search',
     },
     {
       id: uuidv4(),
@@ -88,8 +96,8 @@ class UniversalNavbar extends React.Component {
 
     const { showMobileMenu } = this.state
 
-    const renderDesktopLink = (link) => (
-      <div key={link.id} className={styles.paddingLeft}>
+    const renderTextLink = (link) => (
+      <div key={link.id} className={styles.textLink}>
         <NavLink
           href={link.href}
           LinkComponent={link.href !== '/login/' ? LinkComponent : null}
@@ -97,6 +105,73 @@ class UniversalNavbar extends React.Component {
           {link.title}
         </NavLink>
       </div>
+    )
+
+    const renderSearchIcon = (link) => (
+      <a
+        className={styles.searchIcon}
+        key={link.id}
+        // onClick={this.props.trackSearchClick}
+        href={link.href}
+      >
+        <svg
+          width="30"
+          height="30"
+          viewBox="0 0 30 30"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="13.0739"
+            cy="13.0739"
+            r="7.0739"
+            stroke="#221F1F"
+            strokeWidth="2"
+          />
+          <path
+            d="M18.0997 18.1L25.0002 23.9909"
+            stroke="#221F1F"
+            strokeWidth="2"
+          />
+        </svg>
+      </a>
+    )
+
+    const renderAccountIcon = (link) => (
+      <a
+        className={styles.accountIcon}
+        key={link.id}
+        // onClick={this.props.trackAccountClick}
+        href={link.href}
+      >
+        <svg
+          width="30"
+          height="30"
+          viewBox="0 0 30 30"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="14.9261"
+            cy="10.9261"
+            r="4.9261"
+            stroke="#221F1F"
+            strokeWidth="2"
+          />
+          <circle
+            cx="14.9261"
+            cy="10.9261"
+            r="4.9261"
+            stroke="#221F1F"
+            strokeWidth="2"
+          />
+          <path
+            d="M24.8522 25.7781C24.8522 20.2961 20.4081 15.8521 14.9261 15.8521C9.44407 15.8521 5 20.2961 5 25.7781"
+            stroke="#221F1F"
+            strokeWidth="2"
+          />
+        </svg>
+      </a>
     )
 
     return (
@@ -126,7 +201,7 @@ class UniversalNavbar extends React.Component {
                   showMobileMenu ? styles.mobileMenu : styles.hideMobileMenu
                 }
               >
-                <NavLink href={logoHref} LinkComponent={LinkComponent}>
+                <NavLink href={logoHref} LinkComponent={LinkComponent} className={styles.phoneLogo}>
                   {LogoWhite({ className: styles.logo })}
                 </NavLink>
                 <Spacer.H56 />
@@ -147,6 +222,7 @@ class UniversalNavbar extends React.Component {
                 <div style={{ position: 'absolute', bottom: 40 }}>
                   <a href={LINKS.TERM.href}>
                     <Button.Medium.WhiteOutline>
+                      {/* TODO: Double check this copy */}
                       Check my price
                     </Button.Medium.WhiteOutline>
                   </a>
@@ -154,10 +230,11 @@ class UniversalNavbar extends React.Component {
               </div>
 
               {/* Mobile menu items, getAnEstimate only shows when scrolled */}
-              <NavLink href={LINKS.INDEX.href} LinkComponent={LinkComponent}>
+              <NavLink href={LINKS.INDEX.href} LinkComponent={LinkComponent} className={styles.phoneLogoFancy}>
                 <FancyAnimatedLogo />
               </NavLink>
               {!hideMobileCta && getAnEstimate(true)}
+              {renderSearchIcon(LINKS.NAVLINKS[3])}
             </div>
 
             <div className={styles.tabletAndUp}>
@@ -167,21 +244,20 @@ class UniversalNavbar extends React.Component {
                   <NavLink href={logoHref} LinkComponent={LinkComponent}>
                     {LogoNotAnimated({ className: styles.logo })}
                   </NavLink>
-                  {renderDesktopLink(LINKS.NAVLINKS[0])}
-                  {renderDesktopLink(LINKS.NAVLINKS[1])}
+                  {renderTextLink(LINKS.NAVLINKS[0])}
+                  {renderTextLink(LINKS.NAVLINKS[1])}
 
                   <div className={styles.laptopAndUp}>
-                    {renderDesktopLink(LINKS.NAVLINKS[2])}
+                    {renderTextLink(LINKS.NAVLINKS[2])}
                   </div>
                 </div>
 
                 {/* Desktop menu items to the right */}
                 <div className={`${styles.flex} ${styles.itemsCenter}`}>
-                  <div className={styles.laptopAndUp}>
-                    {LINKS.NAVLINKS.slice(-1).map(renderDesktopLink)}
-                  </div>
+                  {renderSearchIcon(LINKS.NAVLINKS[3])}
+                  {renderAccountIcon(LINKS.NAVLINKS[4])}
 
-                  <div className={styles.paddingLeft}>
+                  <div className={styles.cta}>
                     {!hideDesktopCta && getAnEstimate(false)}
                   </div>
                 </div>

--- a/src/components/UniversalNavbar/UniversalNavbar.js
+++ b/src/components/UniversalNavbar/UniversalNavbar.js
@@ -111,23 +111,23 @@ class UniversalNavbar extends React.Component {
         LinkComponent={link.href !== '/login/' ? LinkComponent : null}
       >
         <svg
-          width="21"
-          height="21"
-          viewBox="0 0 21 21"
+          width="23"
+          height="22"
+          viewBox="0 0 23 22"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
           <circle
-            cx="8.0739"
-            cy="8.0739"
-            r="7.0739"
-            stroke="#221F1F"
-            strokeWidth="2"
+            cx="8.94497"
+            cy="8.94399"
+            r="7.86196"
+            stroke="#272727"
+            strokeWidth="1.5"
           />
           <path
-            d="M13.0997 13.1L20.0002 18.9909"
-            stroke="#221F1F"
-            strokeWidth="2"
+            d="M14.3063 14.3041L21.6667 20.5876"
+            stroke="#272727"
+            strokeWidth="1.5"
           />
         </svg>
       </NavLink>
@@ -141,30 +141,23 @@ class UniversalNavbar extends React.Component {
         LinkComponent={link.href !== '/login/' ? LinkComponent : null}
       >
         <svg
-          width="22"
-          height="21"
-          viewBox="0 0 22 21"
+          width="25"
+          height="23"
+          viewBox="0 0 25 23"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
           <circle
-            cx="10.9261"
-            cy="5.9261"
-            r="4.9261"
-            stroke="#221F1F"
-            strokeWidth="2"
-          />
-          <circle
-            cx="10.9261"
-            cy="5.9261"
-            r="4.9261"
-            stroke="#221F1F"
-            strokeWidth="2"
+            cx="12.25"
+            cy="5.25"
+            r="4.5"
+            stroke="#272727"
+            strokeWidth="1.5"
           />
           <path
-            d="M20.8522 20.7781C20.8522 15.2961 16.4081 10.8521 10.9261 10.8521C5.44407 10.8521 1 15.2961 1 20.7781"
-            stroke="#221F1F"
-            strokeWidth="2"
+            d="M23.5639 22.25H0.751853C0.767099 19.9125 0.905198 17.7185 2.12836 16.0198C3.43803 14.201 6.17055 12.75 12.1579 12.75C18.1452 12.75 20.8778 14.201 22.1874 16.0198C23.4106 17.7185 23.5487 19.9125 23.5639 22.25Z"
+            stroke="#272727"
+            strokeWidth="1.5"
           />
         </svg>
       </NavLink>

--- a/src/components/UniversalNavbar/UniversalNavbar.module.scss
+++ b/src/components/UniversalNavbar/UniversalNavbar.module.scss
@@ -108,7 +108,7 @@ $tablet-small-end: 670px;
     color: var(--GraySecondary--translucent);
     &:hover,
     &:active,
-    &.current-page {
+    &.currentPage {
       color: inherit;
     }
   }

--- a/src/components/UniversalNavbar/UniversalNavbar.module.scss
+++ b/src/components/UniversalNavbar/UniversalNavbar.module.scss
@@ -1,5 +1,7 @@
 @import '../Media/Media.scss';
 
+$tablet-small-end: 670px;
+
 .flex {
   display: flex;
 }
@@ -29,7 +31,7 @@
   }
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
 }
 
 .tabletAndUp {
@@ -71,10 +73,56 @@
 
 .logo {
   height: 16px;
+  padding-right: var(--Space-40);
+  @media (min-width: $tablet-range-start) and (max-width: $tablet-small-end) {
+    padding-right: var(--Space-24);
+  }
 }
 
-.paddingLeft {
-  padding-left: 24px;
+.phoneLogo {
+  margin-right: auto;
+}
+
+.phoneLogoFancy {
+  margin-right: auto;
+}
+
+.cta {
+  padding-left: 21px;
+  @media (min-width: $tablet-range-start) and (max-width: $tablet-small-end) {
+    padding-left: var(--Space-8);
+  }
+}
+
+.textLink {
+  padding-right: var(--Space-24);
+  @media (min-width: $tablet-range-start) and (max-width: $tablet-small-end) {
+    &:nth-child(2) {
+      padding-right: var(--Space-16);
+    }
+    &:nth-child(3) {
+      padding-right: 0;
+    }
+  }
+}
+
+.searchIcon {
+  @include for-phone-only {
+    padding-right: var(--Space-24);
+    svg {
+      width: var(--Space-24);
+      height: var(--Space-24);
+    }
+  }
+  @include for-tablet-and-up {
+    padding-right: var(--Space-8);
+  }
+}
+
+.accountIcon {
+  @media (min-width: $tablet-range-start) and (max-width: $tablet-small-end) {
+    display: none;
+  }
 }
 
 /**

--- a/src/components/UniversalNavbar/UniversalNavbar.module.scss
+++ b/src/components/UniversalNavbar/UniversalNavbar.module.scss
@@ -104,6 +104,14 @@ $tablet-small-end: 670px;
       padding-right: 0;
     }
   }
+  a {
+    color: var(--GraySecondary--translucent);
+    &:hover,
+    &:active,
+    &.current-page {
+      color: inherit;
+    }
+  }
 }
 
 .searchIcon {

--- a/src/components/UniversalNavbar/UniversalNavbar.module.scss
+++ b/src/components/UniversalNavbar/UniversalNavbar.module.scss
@@ -90,7 +90,7 @@ $tablet-small-end: 670px;
 .cta {
   padding-left: 21px;
   @media (min-width: $tablet-range-start) and (max-width: $tablet-small-end) {
-    padding-left: var(--Space-8);
+    padding-left: 0;
   }
 }
 
@@ -108,7 +108,7 @@ $tablet-small-end: 670px;
     color: var(--GraySecondary--translucent);
     &:hover,
     &:active,
-    &[aria-current="page"] {
+    &[aria-current='page'] {
       color: inherit;
     }
   }
@@ -116,14 +116,15 @@ $tablet-small-end: 670px;
 
 .searchIcon {
   @include for-phone-only {
-    padding-right: var(--Space-24);
+    margin-right: var(--Space-32);
+    padding-top: 3px;
     svg {
-      width: var(--Space-24);
-      height: var(--Space-24);
+      width: var(--Space-16);
+      height: var(--Space-16);
     }
   }
   @include for-tablet-and-up {
-    padding-right: var(--Space-8);
+    margin-right: 18px;
   }
 }
 

--- a/src/components/UniversalNavbar/UniversalNavbar.module.scss
+++ b/src/components/UniversalNavbar/UniversalNavbar.module.scss
@@ -108,7 +108,7 @@ $tablet-small-end: 670px;
     color: var(--GraySecondary--translucent);
     &:hover,
     &:active,
-    &.currentPage {
+    &[aria-current="page"] {
       color: inherit;
     }
   }

--- a/src/components/UniversalNavbar/UniversalNavbar.module.scss
+++ b/src/components/UniversalNavbar/UniversalNavbar.module.scss
@@ -125,12 +125,16 @@ $tablet-small-end: 670px;
   }
   @include for-tablet-and-up {
     margin-right: 18px;
+    padding-top: 3px;
   }
 }
 
 .accountIcon {
   @media (min-width: $tablet-range-start) and (max-width: $tablet-small-end) {
     display: none;
+  }
+  @include for-tablet-and-up {
+    padding-top: 3px;
   }
 }
 

--- a/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
+++ b/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
@@ -29,6 +29,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
       >
         <TransformingBurgerButton
           clickHandler={[Function]}
+          keyPressHandler={[Function]}
           showMobileMenu={false}
         />
       </div>
@@ -158,7 +159,86 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           className="phoneLogoFancy"
           href="/"
         >
-          <FancyAnimatedLogo />
+          <div
+            aria-label="Ethos"
+            role="img"
+            style={
+              Object {
+                "height": 16,
+                "position": "relative",
+                "width": 86.6,
+              }
+            }
+          >
+            <svg
+              alt=""
+              className="letter fancyE"
+              viewBox="0 0 971.997 180.498"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                ethos-logo-E
+              </title>
+              <path
+                d="M0 2.845v175.23h129.318v-29.208H29.202v-43.806h86.988V75.859H29.202V32.047h100.116V2.845H0z"
+              />
+            </svg>
+            <svg
+              alt=""
+              className="letter fancyT"
+              viewBox="0 0 971.997 180.498"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                ethos-logo-T
+              </title>
+              <path
+                d="M184.573 2.845v29.202h58.416v146.028h29.202V32.047h58.41V2.845H184.573z"
+              />
+            </svg>
+            <svg
+              alt=""
+              className="letter fancyH"
+              viewBox="0 0 971.997 180.498"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                ethos-logo-H
+              </title>
+              <path
+                d="M505.833 2.845v73.014h-87.612V2.845h-29.208v175.23h29.208v-73.014h87.612v73.014h29.202V2.845h-29.202z"
+              />
+            </svg>
+            <svg
+              alt=""
+              className="letter fancyO"
+              viewBox="0 0 971.997 180.498"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                ethos-logo-O
+              </title>
+              <path
+                d="M758.521 19.368a63.8 63.8 0 0 0-90.227 0c-3.6 3.606-11.1 12.036-13.662 16.188a63.725 63.725 0 0 1 87.894 87.378l.984-.984c4.272-2.592 11.322-8.664 15.012-12.354a63.8 63.8 0 0 0 0-90.227"
+              />
+              <path
+                d="M650.356 127.535c-25.068-25.068-40.422-71.178-12.132-119.922L625 20.837a93.374 93.374 0 1 0 132.054 132.048l13.224-13.224c-46.422 26.988-92.616 15.18-119.922-12.126"
+              />
+            </svg>
+            <svg
+              alt=""
+              className="letter fancyS"
+              viewBox="0 0 971.997 180.498"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                ethos-logo-S
+              </title>
+              <path
+                d="M902.169 180.71c42.42 0 69.828-21.018 69.828-53.55 0-30.5-21.438-41.532-56.034-49.428l-21.192-4.65c-19.08-4.218-29.424-9.12-29.424-22.944 0-14.094 13.134-23.2 33.462-23.2 18.966 0 35.658 7.044 45.942 19.362l22.008-17.69C954.645 15.51 933.273.21 899.583.21c-38.064 0-65.694 21.648-65.694 51.48 0 34.044 27.87 44.436 52.152 49.686l23.52 5.172c18.594 4.038 30.978 9.576 30.978 23.454 0 14.916-13.422 23.46-36.816 23.46-25.518 0-44.808-12.534-52.89-25.17l-24.15 17.388c12.438 17.046 38.64 35.028 75.486 35.028"
+              />
+            </svg>
+          </div>
         </NavLink>
         <a
           className="cta-button show-when-scrolled"

--- a/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
+++ b/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
@@ -11,7 +11,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
   <div
     style={
       Object {
-        "height": 100,
+        "height": 64,
         "left": 0,
         "position": "fixed",
         "top": 0,
@@ -169,7 +169,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
             Check my price
           </PublicButtonComponent>
         </a>
-        <a
+        <NavLink
           className="searchIcon"
           href="/faq/"
         >
@@ -193,7 +193,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
               strokeWidth="2"
             />
           </svg>
-        </a>
+        </NavLink>
       </div>
       <div
         className="tabletAndUp"
@@ -227,6 +227,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
               className="textLink"
             >
               <NavLink
+                className={null}
                 href="/how-it-works/"
               >
                 How it works
@@ -236,6 +237,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
               className="textLink"
             >
               <NavLink
+                className={null}
                 href="/why-ethos/"
               >
                 Why Ethos
@@ -248,6 +250,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
                 className="textLink"
               >
                 <NavLink
+                  className={null}
                   href="/blog/"
                 >
                   Blog
@@ -258,7 +261,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           <div
             className="flex itemsCenter"
           >
-            <a
+            <NavLink
               className="searchIcon"
               href="/faq/"
             >
@@ -282,8 +285,9 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
                   strokeWidth="2"
                 />
               </svg>
-            </a>
-            <a
+            </NavLink>
+            <NavLink
+              LinkComponent={null}
               className="accountIcon"
               href="/login/"
             >
@@ -314,7 +318,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
                   strokeWidth="2"
                 />
               </svg>
-            </a>
+            </NavLink>
             <div
               className="cta"
             >

--- a/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
+++ b/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
@@ -39,6 +39,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           className="hideMobileMenu"
         >
           <NavLink
+            className="phoneLogo"
             href="/"
           >
             <svg
@@ -99,9 +100,24 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           >
             <PublicTypeComponent>
               <NavLink
+                href="/blog/"
+              >
+                Blog
+              </NavLink>
+            </PublicTypeComponent>
+          </div>
+          <div
+            style={
+              Object {
+                "marginBottom": 24,
+              }
+            }
+          >
+            <PublicTypeComponent>
+              <NavLink
                 href="/faq/"
               >
-                FAQ
+                Search
               </NavLink>
             </PublicTypeComponent>
           </div>
@@ -139,6 +155,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           </div>
         </div>
         <NavLink
+          className="phoneLogoFancy"
           href="/"
         >
           <FancyAnimatedLogo />
@@ -151,6 +168,31 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           <PublicButtonComponent>
             Check my price
           </PublicButtonComponent>
+        </a>
+        <a
+          className="searchIcon"
+          href="/faq/"
+        >
+          <svg
+            fill="none"
+            height="30"
+            viewBox="0 0 30 30"
+            width="30"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="13.0739"
+              cy="13.0739"
+              r="7.0739"
+              stroke="#221F1F"
+              strokeWidth="2"
+            />
+            <path
+              d="M18.0997 18.1L25.0002 23.9909"
+              stroke="#221F1F"
+              strokeWidth="2"
+            />
+          </svg>
         </a>
       </div>
       <div
@@ -182,7 +224,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
               </svg>
             </NavLink>
             <div
-              className="paddingLeft"
+              className="textLink"
             >
               <NavLink
                 href="/how-it-works/"
@@ -191,7 +233,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
               </NavLink>
             </div>
             <div
-              className="paddingLeft"
+              className="textLink"
             >
               <NavLink
                 href="/why-ethos/"
@@ -203,12 +245,12 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
               className="laptopAndUp"
             >
               <div
-                className="paddingLeft"
+                className="textLink"
               >
                 <NavLink
-                  href="/faq/"
+                  href="/blog/"
                 >
-                  FAQ
+                  Blog
                 </NavLink>
               </div>
             </div>
@@ -216,22 +258,65 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           <div
             className="flex itemsCenter"
           >
-            <div
-              className="laptopAndUp"
+            <a
+              className="searchIcon"
+              href="/faq/"
             >
-              <div
-                className="paddingLeft"
+              <svg
+                fill="none"
+                height="30"
+                viewBox="0 0 30 30"
+                width="30"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <NavLink
-                  LinkComponent={null}
-                  href="/login/"
-                >
-                  Account
-                </NavLink>
-              </div>
-            </div>
+                <circle
+                  cx="13.0739"
+                  cy="13.0739"
+                  r="7.0739"
+                  stroke="#221F1F"
+                  strokeWidth="2"
+                />
+                <path
+                  d="M18.0997 18.1L25.0002 23.9909"
+                  stroke="#221F1F"
+                  strokeWidth="2"
+                />
+              </svg>
+            </a>
+            <a
+              className="accountIcon"
+              href="/login/"
+            >
+              <svg
+                fill="none"
+                height="30"
+                viewBox="0 0 30 30"
+                width="30"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="14.9261"
+                  cy="10.9261"
+                  r="4.9261"
+                  stroke="#221F1F"
+                  strokeWidth="2"
+                />
+                <circle
+                  cx="14.9261"
+                  cy="10.9261"
+                  r="4.9261"
+                  stroke="#221F1F"
+                  strokeWidth="2"
+                />
+                <path
+                  d="M24.8522 25.7781C24.8522 20.2961 20.4081 15.8521 14.9261 15.8521C9.44407 15.8521 5 20.2961 5 25.7781"
+                  stroke="#221F1F"
+                  strokeWidth="2"
+                />
+              </svg>
+            </a>
             <div
-              className="paddingLeft"
+              className="cta"
             >
               <a
                 className="get-an-estimate "

--- a/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
+++ b/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
@@ -175,22 +175,22 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
         >
           <svg
             fill="none"
-            height="21"
-            viewBox="0 0 21 21"
-            width="21"
+            height="22"
+            viewBox="0 0 23 22"
+            width="23"
             xmlns="http://www.w3.org/2000/svg"
           >
             <circle
-              cx="8.0739"
-              cy="8.0739"
-              r="7.0739"
-              stroke="#221F1F"
-              strokeWidth="2"
+              cx="8.94497"
+              cy="8.94399"
+              r="7.86196"
+              stroke="#272727"
+              strokeWidth="1.5"
             />
             <path
-              d="M13.0997 13.1L20.0002 18.9909"
-              stroke="#221F1F"
-              strokeWidth="2"
+              d="M14.3063 14.3041L21.6667 20.5876"
+              stroke="#272727"
+              strokeWidth="1.5"
             />
           </svg>
         </NavLink>
@@ -264,22 +264,22 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
             >
               <svg
                 fill="none"
-                height="21"
-                viewBox="0 0 21 21"
-                width="21"
+                height="22"
+                viewBox="0 0 23 22"
+                width="23"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <circle
-                  cx="8.0739"
-                  cy="8.0739"
-                  r="7.0739"
-                  stroke="#221F1F"
-                  strokeWidth="2"
+                  cx="8.94497"
+                  cy="8.94399"
+                  r="7.86196"
+                  stroke="#272727"
+                  strokeWidth="1.5"
                 />
                 <path
-                  d="M13.0997 13.1L20.0002 18.9909"
-                  stroke="#221F1F"
-                  strokeWidth="2"
+                  d="M14.3063 14.3041L21.6667 20.5876"
+                  stroke="#272727"
+                  strokeWidth="1.5"
                 />
               </svg>
             </NavLink>
@@ -290,29 +290,22 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
             >
               <svg
                 fill="none"
-                height="21"
-                viewBox="0 0 22 21"
-                width="22"
+                height="23"
+                viewBox="0 0 25 23"
+                width="25"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <circle
-                  cx="10.9261"
-                  cy="5.9261"
-                  r="4.9261"
-                  stroke="#221F1F"
-                  strokeWidth="2"
-                />
-                <circle
-                  cx="10.9261"
-                  cy="5.9261"
-                  r="4.9261"
-                  stroke="#221F1F"
-                  strokeWidth="2"
+                  cx="12.25"
+                  cy="5.25"
+                  r="4.5"
+                  stroke="#272727"
+                  strokeWidth="1.5"
                 />
                 <path
-                  d="M20.8522 20.7781C20.8522 15.2961 16.4081 10.8521 10.9261 10.8521C5.44407 10.8521 1 15.2961 1 20.7781"
-                  stroke="#221F1F"
-                  strokeWidth="2"
+                  d="M23.5639 22.25H0.751853C0.767099 19.9125 0.905198 17.7185 2.12836 16.0198C3.43803 14.201 6.17055 12.75 12.1579 12.75C18.1452 12.75 20.8778 14.201 22.1874 16.0198C23.4106 17.7185 23.5487 19.9125 23.5639 22.25Z"
+                  stroke="#272727"
+                  strokeWidth="1.5"
                 />
               </svg>
             </NavLink>

--- a/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
+++ b/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
@@ -161,7 +161,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           <FancyAnimatedLogo />
         </NavLink>
         <a
-          className="get-an-estimate show-when-scrolled"
+          className="cta-button show-when-scrolled"
           href="/term"
           onClick={[Function]}
         >
@@ -175,20 +175,20 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
         >
           <svg
             fill="none"
-            height="30"
-            viewBox="0 0 30 30"
-            width="30"
+            height="21"
+            viewBox="0 0 21 21"
+            width="21"
             xmlns="http://www.w3.org/2000/svg"
           >
             <circle
-              cx="13.0739"
-              cy="13.0739"
+              cx="8.0739"
+              cy="8.0739"
               r="7.0739"
               stroke="#221F1F"
               strokeWidth="2"
             />
             <path
-              d="M18.0997 18.1L25.0002 23.9909"
+              d="M13.0997 13.1L20.0002 18.9909"
               stroke="#221F1F"
               strokeWidth="2"
             />
@@ -264,20 +264,20 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
             >
               <svg
                 fill="none"
-                height="30"
-                viewBox="0 0 30 30"
-                width="30"
+                height="21"
+                viewBox="0 0 21 21"
+                width="21"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <circle
-                  cx="13.0739"
-                  cy="13.0739"
+                  cx="8.0739"
+                  cy="8.0739"
                   r="7.0739"
                   stroke="#221F1F"
                   strokeWidth="2"
                 />
                 <path
-                  d="M18.0997 18.1L25.0002 23.9909"
+                  d="M13.0997 13.1L20.0002 18.9909"
                   stroke="#221F1F"
                   strokeWidth="2"
                 />
@@ -290,27 +290,27 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
             >
               <svg
                 fill="none"
-                height="30"
-                viewBox="0 0 30 30"
-                width="30"
+                height="21"
+                viewBox="0 0 22 21"
+                width="22"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <circle
-                  cx="14.9261"
-                  cy="10.9261"
+                  cx="10.9261"
+                  cy="5.9261"
                   r="4.9261"
                   stroke="#221F1F"
                   strokeWidth="2"
                 />
                 <circle
-                  cx="14.9261"
-                  cy="10.9261"
+                  cx="10.9261"
+                  cy="5.9261"
                   r="4.9261"
                   stroke="#221F1F"
                   strokeWidth="2"
                 />
                 <path
-                  d="M24.8522 25.7781C24.8522 20.2961 20.4081 15.8521 14.9261 15.8521C9.44407 15.8521 5 20.2961 5 25.7781"
+                  d="M20.8522 20.7781C20.8522 15.2961 16.4081 10.8521 10.9261 10.8521C5.44407 10.8521 1 15.2961 1 20.7781"
                   stroke="#221F1F"
                   strokeWidth="2"
                 />
@@ -320,7 +320,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
               className="cta"
             >
               <a
-                className="get-an-estimate "
+                className="cta-button "
                 href="/term"
                 onClick={[Function]}
               >

--- a/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
+++ b/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
@@ -116,7 +116,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           >
             <PublicTypeComponent>
               <NavLink
-                href="/faq/"
+                href="/search/"
               >
                 Search
               </NavLink>
@@ -251,7 +251,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
         </a>
         <NavLink
           className="searchIcon"
-          href="/faq/"
+          href="/search/"
         >
           <svg
             fill="none"
@@ -340,7 +340,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           >
             <NavLink
               className="searchIcon"
-              href="/faq/"
+              href="/search/"
             >
               <svg
                 fill="none"

--- a/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
+++ b/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
@@ -227,7 +227,6 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
               className="textLink"
             >
               <NavLink
-                className={null}
                 href="/how-it-works/"
               >
                 How it works
@@ -237,7 +236,6 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
               className="textLink"
             >
               <NavLink
-                className={null}
                 href="/why-ethos/"
               >
                 Why Ethos
@@ -250,7 +248,6 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
                 className="textLink"
               >
                 <NavLink
-                  className={null}
                   href="/blog/"
                 >
                   Blog

--- a/src/components/design-system.css
+++ b/src/components/design-system.css
@@ -268,11 +268,12 @@ a:hover {
     transition: transform ease-in-out 0.7s, opacity ease-in-out 0.7s;
     opacity: 0;
     pointer-events: none;
+    min-width: 135px;
   }
   .isScrolled .get-an-estimate.show-when-scrolled {
     opacity: 1;
     pointer-events: all;
-    transform: translateX(-15%);
+    transform: translateX(-5%);
   }
   .letter {
     opacity: 1;

--- a/src/components/design-system.css
+++ b/src/components/design-system.css
@@ -263,17 +263,19 @@ a:hover {
   .fancyS {
     transition-delay: 0s;
   }
-  .get-an-estimate.show-when-scrolled {
+  .cta-button.show-when-scrolled {
     /* When not scrolled, is transparent and starts to the right */
-    transition: transform ease-in-out 0.7s, opacity ease-in-out 0.7s;
+    transition: transform ease-out 0.2s, opacity ease-out 0.2s;
     opacity: 0;
     pointer-events: none;
-    min-width: 135px;
+    position: absolute;
+    right: var(--Space-72);
   }
-  .isScrolled .get-an-estimate.show-when-scrolled {
+  .isScrolled .cta-button.show-when-scrolled {
     opacity: 1;
     pointer-events: all;
-    transform: translateX(-5%);
+    transform: translateX(var(--NegativeSpace-16));
+    transition: transform ease-in 0.3s 0.7s, opacity ease-in 0.3s 0.7s;
   }
   .letter {
     opacity: 1;

--- a/stats.json
+++ b/stats.json
@@ -1,5 +1,5 @@
 {
-  "cssBytes": 6560,
+  "cssBytes": 6581,
   "cssRules": 48,
   "cssTypeSelectors": 32,
   "cssClassSelectors": 27,


### PR DESCRIPTION
[WIP] Until following CMS PR / todos complete. Otherwise it's ready from a code perspective & has been QA'd by design. (02/04/2020)

**Todo**
- [x] Wait for [CMS PR #2285](https://github.com/getethos/cms/pull/2285/files) to be merged (contains the new search module on /faq/ page)
- [x] Merge in changes from #254 (universalNavbar fixes now in `master`)
- [x] Bump EDS version here and push git tag
- [x] Check no Optimizely experiments are targeting old Navbar selectors before merging
- [x] Wait for https://github.com/getethos/cms/pull/2622 to be merged for FontAwesome support when bumping EDS version
- [ ] After merging, bump EDS for Mono and CMS at the same time, so changes go live together.
- [x] Design QA (requested & addressed)

**Description:**
- Note this component will be overhauled very soon with the work in this [ticket](https://app.asana.com/0/1116481661798430/1158569544825133/f), so I'm hoping to push these smaller changes through quickly so we can get the initial help center work live in CMS
- [Asana Task](https://app.asana.com/0/1116481661798430/1142541556943565/f)
- Adds search icon linked to `/faq/`
- Replaced Account text link with account icon for `/login/`
- Tweaked `FancyAnimatedLogo` to fit with new search icon on mobile
- Changes old `FAQ` text link to `Blog` (`/faq/` -> `/blog/`)
- Design is choosing to use custom icons over FontAwesome for these changes
- Adds Search link to expanded hamburger menu
- Account icon hidden on phone, search icon added
- Variable display of account icon on tablet based on viewport width, 3rd text link still hidden
- Fixes a height issue with the navbar being too tall on mobile and blocking on screen content from being clicked
- Current page highlighted if it exists in the 3 text links


**Referencing PR or Branch (e.g. in CMS or monorepo):**
- CMS PR 2285 [New search module / help center](https://github.com/getethos/cms/pull/2285/files)
- CMS PR 2613 [For design QA of this PR in CMS](https://github.com/getethos/cms/pull/2613) https://deploy-preview-2613--ethos-cms.netlify.com/

**Screenshots:**
![Screen Shot 2020-01-31 at 8 06 20 PM](https://user-images.githubusercontent.com/4285270/73586649-37fdff80-4465-11ea-9efe-425bfbe77e9f.png)
![Screen Shot 2020-01-31 at 8 06 16 PM](https://user-images.githubusercontent.com/4285270/73586650-37fdff80-4465-11ea-8a19-2af7d7f2126b.png)

![Screen Shot 2020-01-31 at 5 00 30 PM](https://user-images.githubusercontent.com/4285270/73584159-68d13b00-444b-11ea-862d-344767bf3e47.png)
![Screen Shot 2020-01-31 at 5 00 21 PM](https://user-images.githubusercontent.com/4285270/73584160-68d13b00-444b-11ea-9b67-924fd64afe86.png)
![Screen Shot 2020-01-31 at 5 00 14 PM](https://user-images.githubusercontent.com/4285270/73584161-68d13b00-444b-11ea-88b0-82664f263a10.png)
![Screen Shot 2020-01-31 at 5 00 03 PM](https://user-images.githubusercontent.com/4285270/73584162-68d13b00-444b-11ea-955b-c43a1a575b4e.png)
![Screen Shot 2020-01-31 at 4 59 52 PM](https://user-images.githubusercontent.com/4285270/73584164-68d13b00-444b-11ea-9e8f-a9f98bd835c6.png)
![Screen Shot 2020-01-31 at 4 59 32 PM](https://user-images.githubusercontent.com/4285270/73584165-6969d180-444b-11ea-913e-5e881091db79.png)
![Screen Shot 2020-01-31 at 5 01 40 PM](https://user-images.githubusercontent.com/4285270/73584155-6838a480-444b-11ea-8fd0-f9e5e6546325.png)
![Screen Shot 2020-01-31 at 5 00 58 PM](https://user-images.githubusercontent.com/4285270/73584156-6838a480-444b-11ea-9e49-a8d65d1c140e.png)
