### PR TITLE
Nora chevron back button & fix black icon links

### DIFF
--- a/src/components/fa.js
+++ b/src/components/fa.js
@@ -34,6 +34,7 @@ import { faExternalLink } from '@fortawesome/pro-regular-svg-icons/faExternalLin
 import { faCheck } from '@fortawesome/pro-light-svg-icons/faCheck'
 import { faTimes } from '@fortawesome/pro-light-svg-icons/faTimes'
 import { faLayerPlus } from '@fortawesome/pro-light-svg-icons/faLayerPlus'
+import { faChevronLeft } from '@fortawesome/pro-regular-svg-icons/faChevronLeft'
 
 library.add(
   faAlignLeft,
@@ -41,6 +42,7 @@ library.add(
   faCheck,
   faCheckSquare,
   faCheckSquareSolid,
+  faChevronLeft,
   faCircleNotch,
   faClock,
   faExchange,

--- a/src/nora/components/IconLink/IconLink.md
+++ b/src/nora/components/IconLink/IconLink.md
@@ -359,6 +359,26 @@ const iconContainerClasses = `${styles.IconLinkContainer} ${noraStyles.RightNavI
 />
 ```
 
+Back Button Chevron
+
+```jsx
+import styles from './IconLink.module.scss'
+
+;<IconLink
+  iconPrefix="far"
+  iconName="chevron-left"
+  iconClassName={`${styles.Icon}`}
+  iconContainerClassName={styles.IconLinkContainer}
+  linkClassName={styles.LinkRight}
+  linkPosition="right"
+  copy="Back"
+  onClick={(ev) => {
+    console.log('Back button -- onclick called...')
+  }}
+/>
+```
+
+
 ## Right Aligned
 
 Additionally, you can position the icon to the right and have the icon link

--- a/src/nora/components/IconLink/IconLink.md
+++ b/src/nora/components/IconLink/IconLink.md
@@ -378,7 +378,6 @@ import styles from './IconLink.module.scss'
 />
 ```
 
-
 ## Right Aligned
 
 Additionally, you can position the icon to the right and have the icon link
@@ -399,3 +398,5 @@ import styles from './IconLink.module.scss'
   }}
 />
 ```
+
+

--- a/src/nora/components/IconLink/IconLink.md
+++ b/src/nora/components/IconLink/IconLink.md
@@ -398,5 +398,3 @@ import styles from './IconLink.module.scss'
   }}
 />
 ```
-
-

--- a/src/nora/components/IconLink/IconLink.module.scss
+++ b/src/nora/components/IconLink/IconLink.module.scss
@@ -46,6 +46,7 @@
 .LinkAdjusted {
   /* Hack: Our current font is vertically aligned too far to the top of the line box */
   margin-bottom: -2px;
+  color: inherit;
 }
 
 .LinkLeft {


### PR DESCRIPTION
**Description:**
- [Asana Task](https://app.asana.com/0/1150068311310825/1160196321421673/f)
- This started as the back button chevron but turned into also fixing the black icon links
- Referencing from [Nora PR](https://github.com/getethos/ethos/pull/2207)

**Screenshots:**


BEFORE (notice the link text is black not gray like the icon it's besides):

![image](https://user-images.githubusercontent.com/142403/73692370-08c7d800-4689-11ea-954e-f842284718aa.png)



AFTER


![image](https://user-images.githubusercontent.com/142403/73692402-18472100-4689-11ea-80a3-63c7779d2a64.png)



