### PR TITLE
Navbar spelling error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.79",
+  "version": "1.1.80",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/UniversalNavbar/UniversalNavbar.module.scss
+++ b/src/components/UniversalNavbar/UniversalNavbar.module.scss
@@ -116,6 +116,6 @@
   z-index: $z-index-navbar;
 }
 
-.blockNavBar {
+.blockNavbar {
   height: var(--Space-64);
 }


### PR DESCRIPTION
**Description:**
- `blockNavbar` and NOT `blockNavBar`


**Referencing PR or Branch (e.g. in CMS or monorepo):**
- 


**Screenshots:**
