### PR TITLE
Change UniversalNavbar Blog (/blog/) link to FAQ (/faq/)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.81",
+  "version": "1.1.82",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/UniversalNavbar/UniversalNavbar.js
+++ b/src/components/UniversalNavbar/UniversalNavbar.js
@@ -57,8 +57,8 @@ const LINKS = {
     },
     {
       id: uuidv4(),
-      href: '/blog/',
-      title: 'Blog',
+      href: '/faq/',
+      title: 'FAQ',
     },
     {
       id: uuidv4(),

--- a/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
+++ b/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
@@ -88,9 +88,9 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           >
             <PublicTypeComponent>
               <NavLink
-                href="/blog/"
+                href="/faq/"
               >
-                Blog
+                FAQ
               </NavLink>
             </PublicTypeComponent>
           </div>
@@ -315,9 +315,9 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
                 className="textLink"
               >
                 <NavLink
-                  href="/blog/"
+                  href="/faq/"
                 >
-                  Blog
+                  FAQ
                 </NavLink>
               </div>
             </div>


### PR DESCRIPTION
### After merging create PRs for mono and CMS to bump EDS to v1.1.82!

**Description:**
- No related Asana task. 
- Recent updates to the `UniversalNavbar` changed the `FAQ` link to `Blog` and this PR reverts that change. There was some back and forth during development and since deployment went out this morning @justinsayarath has requested we revert to `FAQ`.
- Will coordinate with @iamvictorli to deploy this change on monorepo and CMS at the same time (Wednesday).


**Referencing PR or Branch (e.g. in CMS or monorepo):**
- n/a


**Screenshots:**
![Screen Shot 2020-02-10 at 2 14 47 PM](https://user-images.githubusercontent.com/4285270/74195320-d16ca480-4c0f-11ea-9625-ae5ead10570c.png)
![Screen Shot 2020-02-10 at 2 15 50 PM](https://user-images.githubusercontent.com/4285270/74195354-e3e6de00-4c0f-11ea-9601-275a5d73b223.png)
