### PR TITLE
Allow for element not having a parent which is the case for modals th…

### DIFF
--- a/src/hooks/a11y/useHideAriaSiblings.js
+++ b/src/hooks/a11y/useHideAriaSiblings.js
@@ -12,7 +12,7 @@ import { useLayoutEffect, useState } from 'react'
  */
 function getRootParent(elem) {
   const parent = elem.parentElement
-  if (parent === document.body) {
+  if (!parent || parent === document.body) {
     return elem
   }
 

--- a/src/hooks/a11y/useHideAriaSiblings.js
+++ b/src/hooks/a11y/useHideAriaSiblings.js
@@ -12,8 +12,8 @@ import { useLayoutEffect, useState } from 'react'
  */
 function getRootParent(elem) {
   const parent = elem.parentElement
-  // Why do we check if the parent exists? In the case where a modal is initially rendered the dom with exist but not
-  // be inserted into the document yet so the root element will of the modal will not have a parent.
+  // Why do we check if the parent exists? In the case where a modal is initially rendered, the dom with exist but not
+  // be inserted into the document yet. In this scenario the root element of the modal will not have a parent.
   if (!parent || parent === document.body) {
     return elem
   }

--- a/src/hooks/a11y/useHideAriaSiblings.js
+++ b/src/hooks/a11y/useHideAriaSiblings.js
@@ -12,6 +12,8 @@ import { useLayoutEffect, useState } from 'react'
  */
 function getRootParent(elem) {
   const parent = elem.parentElement
+  // Why do we check if the parent exists? In the case where a modal is initially rendered the dom with exist but not
+  // be inserted into the document yet so the root element will of the modal will not have a parent.
   if (!parent || parent === document.body) {
     return elem
   }


### PR DESCRIPTION
…at are shown immediately (initially).  When updating the HumanConnect modal in main found that it errored out if initially set to show. 

**Description:**
- [Asana Task](https://app.asana.com/0/1152139407849001/1159724756736139/f)


**Referencing PR or Branch (e.g. in CMS or monorepo):**
- https://github.com/getethos/ethos/pull/2350

