### PR TITLE
Add yarn test:types to pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "yarn test"
+      "pre-push": "yarn test && yarn test:types"
     }
   }
 }


### PR DESCRIPTION
**Description:**
- While I was working in EDS recently, I changed the input types for a component, but didn't realize that there was a corresponding test that I caused to fail. After realizing this in https://github.com/getethos/ethos-design-system/pull/268#issue-379281602, I thought I'd put up a PR to see whether people would be okay with adding `yarn test:types` to the pre-push hook.
- On my computer right now, `yarn test:types` takes about 6.5 seconds to run, while `yarn test` takes about 13.5.
![image](https://user-images.githubusercontent.com/12839832/75200132-c50d3f00-5719-11ea-8cdd-02df37436186.png)
- Below, I've validated that this hook works by purposely adding an incorrect type and validating that pre push hook throws an error.
<img width="1486" alt="Image 2020-02-24 at 3 20 19 PM" src="https://user-images.githubusercontent.com/12839832/75200194-ee2dcf80-5719-11ea-9b50-c87583c88640.png">


**Referencing PR or Branch (e.g. in CMS or monorepo):**
- 


**Screenshots:**
