### PR TITLE
Make labels optional, pt. II

### DIFF
--- a/src/components/BirthdateInput/BirthdateInput.js
+++ b/src/components/BirthdateInput/BirthdateInput.js
@@ -119,7 +119,7 @@ PrivateBirthdateInput.PUBLIC_PROPS = {
   disabled: PropTypes.bool,
   allCaps: PropTypes.bool,
   name: PropTypes.string.isRequired,
-  labelCopy: PropTypes.string.isRequired,
+  labelCopy: PropTypes.string,
   validator: PropTypes.func,
   initialValue: PropTypes.string,
 }

--- a/src/components/BirthdateInput/BirthdateInput.js
+++ b/src/components/BirthdateInput/BirthdateInput.js
@@ -130,7 +130,6 @@ PrivateBirthdateInput.propTypes = {
 
 PrivateBirthdateInput.defaultProps = {
   dateFormat: 'mm/dd/yyyy',
-  labelCopy: 'Birthdate',
 }
 
 const BirthdateInputFactory = (privateProps) => {

--- a/src/components/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/TextMaskedInput/TextMaskedInput.js
@@ -135,7 +135,9 @@ export const TextMaskedInput = (props) => {
 
   return (
     <>
-      <InputLabel name={name} labelCopy={labelCopy} allCaps={allCaps} />
+      {labelCopy && (
+        <InputLabel name={name} labelCopy={labelCopy} allCaps={allCaps} />
+      )}
       {getMaskedInputByType(mask)}
       {!doValidation && getError(currentError, whichTouched)}
     </>


### PR DESCRIPTION
Recent designs don't include labels, and the fields shouldn't require or assume them. 

Also, I think labelCopy in defaultProps is an antipattern now, because you can't omit it now or even pass an empty string. We'd have to add another prop like `showLabel` and that seems unnecessary.

The only place I see this used in production is on the CMS and the partner flow. I am making PRs to put those folks in the loop.