### PR TITLE
UniversalNavbarExpanded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.102",
+  "version": "1.1.103",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -215,6 +215,10 @@ export const Button = {
       size: PrivateButton.SIZES.SMALL,
       style: PrivateButton.STYLES.BLACK_OUTLINE,
     }),
+    Black: ButtonFactory({
+      size: PrivateButton.SIZES.SMALL,
+      style: PrivateButton.STYLES.BLACK,
+    }),
   },
   Unstyled: ButtonFactory({
     size: PrivateButton.SIZES.UNSIZED,

--- a/src/components/UniversalNavbar/FancyAnimatedLogo.scss
+++ b/src/components/UniversalNavbar/FancyAnimatedLogo.scss
@@ -3,7 +3,9 @@
    * Region:
    * Fancy animated scroll behavior
    */
-@include for-phone-only {
+
+// -and-tablet required here for UniversalNavbarExpanded support
+@include for-phone-and-tablet {
   .letter:not(.fancyO) {
     transition-property: all;
     transition-timing-function: ease-in-out;

--- a/src/components/UniversalNavbar/NavLink.js
+++ b/src/components/UniversalNavbar/NavLink.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+// UPDATE anchor tags to NavLink when /term and /login is an internal link in CMS
+const NavLink = ({ href, children, LinkComponent, ...props }) => {
+  if (LinkComponent) {
+    return (
+      <LinkComponent to={href} {...props}>
+        {children}
+      </LinkComponent>
+    )
+  }
+  return (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  )
+}
+
+NavLink.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.string,
+    PropTypes.func,
+  ]),
+  href: PropTypes.string.isRequired,
+  LinkComponent: PropTypes.object,
+}
+
+export default NavLink

--- a/src/components/UniversalNavbar/UniversalNavbar.js
+++ b/src/components/UniversalNavbar/UniversalNavbar.js
@@ -106,7 +106,7 @@ class UniversalNavbar extends React.Component {
           href={link.href}
           LinkComponent={link.href !== '/login/' ? LinkComponent : null}
         >
-          <SearchIcon/>
+          <SearchIcon />
         </NavLink>
       )
     }
@@ -119,7 +119,7 @@ class UniversalNavbar extends React.Component {
           href={link.href}
           LinkComponent={link.href !== '/login/' ? LinkComponent : null}
         >
-          <AccountIcon/>
+          <AccountIcon />
         </NavLink>
       )
     }

--- a/src/components/UniversalNavbar/UniversalNavbar.js
+++ b/src/components/UniversalNavbar/UniversalNavbar.js
@@ -5,38 +5,14 @@ import uuidv4 from 'uuid/v4'
 import FancyAnimatedLogo from './FancyAnimatedLogo'
 import LogoNotAnimated from './assets/ethos-logo-black.js'
 import LogoWhite from './assets/ethos-logo-white.js'
+import { AccountIcon, SearchIcon } from './assets/icons.js'
 import { Button, Layout, Spacer, TitleXLarge } from '../index'
 import TransformingBurgerButton from './TransformingBurgerButton/TransformingBurgerButton'
+import NavLink from './NavLink'
 
 import styles from './UniversalNavbar.module.scss'
 
 // TODO REDESIGN: Lots of sloppy inline styles here.
-
-// UPDATE anchor tags to NavLink when /term and /login is an internal link in CMS
-const NavLink = ({ href, children, LinkComponent, ...props }) => {
-  if (LinkComponent) {
-    return (
-      <LinkComponent to={href} {...props}>
-        {children}
-      </LinkComponent>
-    )
-  }
-  return (
-    <a href={href} {...props}>
-      {children}
-    </a>
-  )
-}
-
-NavLink.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.element,
-    PropTypes.string,
-    PropTypes.func,
-  ]),
-  href: PropTypes.string.isRequired,
-  LinkComponent: PropTypes.object,
-}
 
 const LINKS = {
   // These are used e.g. in the logo and CTA button:
@@ -123,29 +99,6 @@ class UniversalNavbar extends React.Component {
 
     // These are bespoke icons but design may replace w/FA at a later date
     const renderSearchIcon = (link) => {
-      const searchIcon = (
-        <svg
-          width="23"
-          height="22"
-          viewBox="0 0 23 22"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <circle
-            cx="8.94497"
-            cy="8.94399"
-            r="7.86196"
-            stroke="#272727"
-            strokeWidth="1.5"
-          />
-          <path
-            d="M14.3063 14.3041L21.6667 20.5876"
-            stroke="#272727"
-            strokeWidth="1.5"
-          />
-        </svg>
-      )
-
       return (
         <NavLink
           className={styles.searchIcon}
@@ -153,35 +106,12 @@ class UniversalNavbar extends React.Component {
           href={link.href}
           LinkComponent={link.href !== '/login/' ? LinkComponent : null}
         >
-          {searchIcon}
+          <SearchIcon/>
         </NavLink>
       )
     }
 
     const renderAccountIcon = (link) => {
-      const accountIcon = (
-        <svg
-          width="25"
-          height="23"
-          viewBox="0 0 25 23"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <circle
-            cx="12.25"
-            cy="5.25"
-            r="4.5"
-            stroke="#272727"
-            strokeWidth="1.5"
-          />
-          <path
-            d="M23.5639 22.25H0.751853C0.767099 19.9125 0.905198 17.7185 2.12836 16.0198C3.43803 14.201 6.17055 12.75 12.1579 12.75C18.1452 12.75 20.8778 14.201 22.1874 16.0198C23.4106 17.7185 23.5487 19.9125 23.5639 22.25Z"
-            stroke="#272727"
-            strokeWidth="1.5"
-          />
-        </svg>
-      )
-
       return (
         <NavLink
           className={styles.accountIcon}
@@ -189,7 +119,7 @@ class UniversalNavbar extends React.Component {
           href={link.href}
           LinkComponent={link.href !== '/login/' ? LinkComponent : null}
         >
-          {accountIcon}
+          <AccountIcon/>
         </NavLink>
       )
     }

--- a/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
+++ b/src/components/UniversalNavbar/__snapshots__/UniversalNavbar.test.js.snap
@@ -240,26 +240,7 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
           className="searchIcon"
           href="/search/"
         >
-          <svg
-            fill="none"
-            height="22"
-            viewBox="0 0 23 22"
-            width="23"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <circle
-              cx="8.94497"
-              cy="8.94399"
-              r="7.86196"
-              stroke="#272727"
-              strokeWidth="1.5"
-            />
-            <path
-              d="M14.3063 14.3041L21.6667 20.5876"
-              stroke="#272727"
-              strokeWidth="1.5"
-            />
-          </svg>
+          <SearchIcon />
         </NavLink>
       </div>
       <div
@@ -329,52 +310,14 @@ exports[`<UniversalNavbar> matches snapshot with no arguments 1`] = `
               className="searchIcon"
               href="/search/"
             >
-              <svg
-                fill="none"
-                height="22"
-                viewBox="0 0 23 22"
-                width="23"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="8.94497"
-                  cy="8.94399"
-                  r="7.86196"
-                  stroke="#272727"
-                  strokeWidth="1.5"
-                />
-                <path
-                  d="M14.3063 14.3041L21.6667 20.5876"
-                  stroke="#272727"
-                  strokeWidth="1.5"
-                />
-              </svg>
+              <SearchIcon />
             </NavLink>
             <NavLink
               LinkComponent={null}
               className="accountIcon"
               href="/login/"
             >
-              <svg
-                fill="none"
-                height="23"
-                viewBox="0 0 25 23"
-                width="25"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="12.25"
-                  cy="5.25"
-                  r="4.5"
-                  stroke="#272727"
-                  strokeWidth="1.5"
-                />
-                <path
-                  d="M23.5639 22.25H0.751853C0.767099 19.9125 0.905198 17.7185 2.12836 16.0198C3.43803 14.201 6.17055 12.75 12.1579 12.75C18.1452 12.75 20.8778 14.201 22.1874 16.0198C23.4106 17.7185 23.5487 19.9125 23.5639 22.25Z"
-                  stroke="#272727"
-                  strokeWidth="1.5"
-                />
-              </svg>
+              <AccountIcon />
             </NavLink>
             <div
               className="cta"

--- a/src/components/UniversalNavbar/assets/icons.js
+++ b/src/components/UniversalNavbar/assets/icons.js
@@ -55,3 +55,34 @@ export const AccordionToggleIcon = () => (
     />
   </svg>
 )
+
+export const DropdownParentIcon = () => (
+  <svg
+    width="8"
+    height="8"
+    viewBox="0 0 8 8"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M0.999942 3.17157L3.82837 6L6.6568 3.17157"
+      stroke="#272727"
+      strokeWidth="2"
+    />
+  </svg>
+)
+
+export const DropdownLinkIcon = () => (
+  <svg
+    width="19"
+    height="12"
+    viewBox="0 0 19 12"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M10.704 0.576L15.888 5.688H0.864V6.888H15.864L10.704 12H12.504L18.192 6.288L12.504 0.576H10.704Z"
+      fill="#272727"
+    />
+  </svg>
+)

--- a/src/components/UniversalNavbar/assets/icons.js
+++ b/src/components/UniversalNavbar/assets/icons.js
@@ -1,0 +1,57 @@
+import React from 'react'
+
+export const AccountIcon = () => (
+  <svg
+    width="25"
+    height="23"
+    viewBox="0 0 25 23"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle cx="12.25" cy="5.25" r="4.5" stroke="#272727" strokeWidth="1.5" />
+    <path
+      d="M23.5639 22.25H0.751853C0.767099 19.9125 0.905198 17.7185 2.12836 16.0198C3.43803 14.201 6.17055 12.75 12.1579 12.75C18.1452 12.75 20.8778 14.201 22.1874 16.0198C23.4106 17.7185 23.5487 19.9125 23.5639 22.25Z"
+      stroke="#272727"
+      strokeWidth="1.5"
+    />
+  </svg>
+)
+
+export const SearchIcon = () => (
+  <svg
+    width="23"
+    height="22"
+    viewBox="0 0 23 22"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle
+      cx="8.94497"
+      cy="8.94399"
+      r="7.86196"
+      stroke="#272727"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M14.3063 14.3041L21.6667 20.5876"
+      stroke="#272727"
+      strokeWidth="1.5"
+    />
+  </svg>
+)
+
+export const AccordionToggleIcon = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 14 14"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M1.34315 6.34315L7 12L12.6569 6.34315"
+      stroke="white"
+      strokeWidth="2"
+    />
+  </svg>
+)

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -33,6 +33,9 @@ import styles from './UniversalNavbarExpanded.module.scss'
 //     : null
 // }
 
+// TODO: alternate caret weight for DropdownParentIcon pre:hover
+// TODO: 'talk to us' CTA integration once Kustomer is implemented
+
 // TODO: convert from class to hook?
 class UniversalNavbarExpanded extends React.Component {
   state = {
@@ -80,7 +83,7 @@ class UniversalNavbarExpanded extends React.Component {
         onClick={this.props.trackCtaClick}
         href={LINKS.TERM.href}
       >
-        <Button.Small.BlackOutline>Check my price</Button.Small.BlackOutline>
+        <Button.Small.Black>Check my price</Button.Small.Black>
       </a>
     )
 

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -1,0 +1,349 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import uuidv4 from 'uuid/v4'
+import FancyAnimatedLogo from '../UniversalNavbar/FancyAnimatedLogo'
+import LogoNotAnimated from '../UniversalNavbar/assets/ethos-logo-black.js'
+import LogoWhite from '../UniversalNavbar/assets/ethos-logo-white.js'
+import {
+  AccountIcon,
+  SearchIcon,
+  AccordionToggleIcon,
+} from '../UniversalNavbar/assets/icons.js'
+import {
+  Body,
+  Button,
+  Layout,
+  Spacer,
+  TitleMedium,
+  TitleSmall,
+  Footnote,
+  COLORS,
+} from '../index'
+import TransformingBurgerButton from '../UniversalNavbar/TransformingBurgerButton/TransformingBurgerButton'
+import { LINKS } from './constants.js'
+import NavLink from '../UniversalNavbar/NavLink'
+import styles from './UniversalNavbarExpanded.module.scss'
+
+// TODO: convert from class to hook?
+class UniversalNavbarExpanded extends React.Component {
+  state = {
+    showMobileMenu: false,
+    activeAccordionItem: false,
+  }
+
+  toggleHamburger = () => {
+    this.setState({ ...this.state, showMobileMenu: !this.state.showMobileMenu })
+  }
+
+  handleHamburgerKeyPress = (event) => {
+    if (event.key === 'Enter') {
+      this.toggleHamburger(true)
+    }
+  }
+
+  toggleAccordionItem = (toggledItem) => {
+    this.setState({
+      ...this.state,
+      activeAccordionItem:
+        this.state.activeAccordionItem === toggledItem ? false : toggledItem,
+    })
+  }
+
+  handleAccordionItemKeyPress = (event, index) => {
+    if (event.key === 'Enter' || event.which == 13 || event.keyCode == 13) {
+      this.toggleAccordionItem(index)
+    }
+  }
+
+  render() {
+    const {
+      LinkComponent,
+      hideMobileCta,
+      hideDesktopCta,
+      logoHref,
+    } = this.props
+
+    const renderCtaButton = (showWhenScrolled) => (
+      <a
+        className={
+          'cta-button ' + (showWhenScrolled ? 'show-when-scrolled' : '')
+        }
+        onClick={this.props.trackCtaClick}
+        href={LINKS.TERM.href}
+      >
+        <Button.Small.BlackOutline>Check my price</Button.Small.BlackOutline>
+      </a>
+    )
+
+    const { showMobileMenu, activeAccordionItem } = this.state
+    console.log(this.state)
+    const renderTextLink = (link) => (
+      <div key={link.id} className={styles.textLink}>
+        <NavLink
+          href={link.href}
+          LinkComponent={link.href !== '/login/' ? LinkComponent : null}
+        >
+          {link.title}
+        </NavLink>
+      </div>
+    )
+
+    // These are bespoke icons but design may replace w/FA at a later date
+    const renderSearchIcon = (link) => {
+      return (
+        <NavLink
+          className={styles.searchIcon}
+          key={link.id}
+          href={link.href}
+          LinkComponent={link.href !== '/login/' ? LinkComponent : null}
+        >
+          <SearchIcon />
+        </NavLink>
+      )
+    }
+
+    const renderAccountIcon = (link) => {
+      return (
+        <NavLink
+          className={styles.accountIcon}
+          key={link.id}
+          href={link.href}
+          LinkComponent={link.href !== '/login/' ? LinkComponent : null}
+        >
+          <AccountIcon />
+        </NavLink>
+      )
+    }
+
+    const Hamburger = () => (
+      <div className={styles.hamburger}>
+        <TransformingBurgerButton
+          showMobileMenu={showMobileMenu}
+          clickHandler={this.toggleHamburger}
+          keyPressHandler={this.handleHamburgerKeyPress}
+        />
+      </div>
+    )
+
+    return (
+      <div className={styles.blockNavbar}>
+        <div className={styles.navbar}>
+          <Layout.ScrollDetector>
+            <Hamburger />
+            <div
+              className={
+                showMobileMenu
+                  ? [styles.phoneAndTablet, styles.visible].join(' ')
+                  : styles.phoneAndTablet
+              }
+            >
+              <div
+                className={
+                  showMobileMenu ? styles.mobileMenu : styles.hideMobileMenu
+                }
+              >
+                <NavLink
+                  href={logoHref}
+                  LinkComponent={LinkComponent}
+                  className={styles.phoneLogo}
+                >
+                  {LogoWhite({ className: styles.logo })}
+                </NavLink>
+                <Hamburger />
+                <div className={styles.accordion}>
+                  {LINKS.NAVLINKS.map((link, idx) => (
+                    <div
+                      key={link.id}
+                      className={
+                        idx === activeAccordionItem
+                          ? [styles.accordionItem, styles.active].join(' ')
+                          : styles.accordionItem
+                      }
+                      onClick={() => this.toggleAccordionItem(idx)}
+                      onKeyPress={(e) =>
+                        this.handleAccordionItemKeyPress(e, idx)
+                      }
+                      tabIndex={0}
+                      role="button"
+                    >
+                      <div className={styles.accordionParent}>
+                        <TitleMedium.Sans.Regular400>
+                          {link.title}
+                        </TitleMedium.Sans.Regular400>
+                        <AccordionToggleIcon />
+                      </div>
+                      <div className={styles.accordionChildren}>
+                        {link.subnav &&
+                          link.subnav.items.length > 0 &&
+                          link.subnav.items.map((link) => (
+                            <div className={styles.accordionChild}>
+                              <TitleSmall.Sans.Light300>
+                                <NavLink
+                                  href={link.href}
+                                  LinkComponent={
+                                    link.href !== '/login/'
+                                      ? LinkComponent
+                                      : null
+                                  }
+                                >
+                                  {link.title}
+                                </NavLink>
+                              </TitleSmall.Sans.Light300>
+                            </div>
+                          ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div class={styles.belowAccordion}>
+                  <div class={styles.belowAccordionItem}>
+                    <NavLink
+                      href={LINKS.TERM.href}
+                      LinkComponent={
+                        LINKS.TERM.href !== '/login/' ? LinkComponent : null
+                      }
+                    >
+                      <TitleMedium.Sans.Regular400>
+                        {LINKS.TERM.title}
+                      </TitleMedium.Sans.Regular400>
+                    </NavLink>
+                  </div>
+                  <div class={styles.belowAccordionItem}>
+                    <NavLink
+                      href={LINKS.ACCOUNT.href}
+                      LinkComponent={
+                        LINKS.ACCOUNT.href !== '/login/' ? LinkComponent : null
+                      }
+                    >
+                      <TitleMedium.Sans.Regular400>
+                        {LINKS.ACCOUNT.title}
+                      </TitleMedium.Sans.Regular400>
+                    </NavLink>
+                  </div>
+                  <div class={styles.belowAccordionItem}>
+                    <NavLink
+                      href={LINKS.SEARCH.href}
+                      LinkComponent={
+                        LINKS.SEARCH.href !== '/login/' ? LinkComponent : null
+                      }
+                    >
+                      <TitleMedium.Sans.Regular400>
+                        {LINKS.SEARCH.title}
+                      </TitleMedium.Sans.Regular400>
+                    </NavLink>
+                  </div>
+                </div>
+              </div>
+
+              {/* Mobile menu items, getAnEstimate only shows when scrolled */}
+              <NavLink
+                href={LINKS.INDEX.href}
+                LinkComponent={LinkComponent}
+                className={styles.phoneLogoFancy}
+              >
+                {FancyAnimatedLogo()}
+              </NavLink>
+              {!hideMobileCta && renderCtaButton(true)}
+              {renderSearchIcon(LINKS.SEARCH)}
+            </div>
+
+            <div className={styles.laptopAndUp}>
+              <div className={styles.laptopAndUpContainer}>
+                {/* Desktop menu items to the left */}
+                <div className={`${styles.flex} ${styles.itemsCenter}`}>
+                  <NavLink href={logoHref} LinkComponent={LinkComponent}>
+                    {LogoNotAnimated({ className: styles.logo })}
+                  </NavLink>
+                  <div className={styles.dropdownNav}>
+                    {LINKS.NAVLINKS.map((link, idx) => (
+                      <div className={styles.dropdownNavParent}>
+                        <Footnote.Regular400>{link.title}</Footnote.Regular400>
+                        <div className={styles.dropdownNavChildren}>
+                          <Layout.HorizontallyPaddedContainer>
+                            {link.subnav &&
+                              link.subnav.cta &&
+                              link.subnav.cta.href && (
+                                <NavLink
+                                  href={link.subnav.cta.href}
+                                  LinkComponent={
+                                    link.subnav.cta.href !== '/login/'
+                                      ? LinkComponent
+                                      : null
+                                  }
+                                >
+                                  {link.subnav.cta.title && (
+                                    <TitleSmall.Serif.Book500>
+                                      {link.subnav.cta.title}
+                                    </TitleSmall.Serif.Book500>
+                                  )}
+                                  <Spacer.H8 />
+                                  {link.subnav.cta.subcopy && (
+                                    <Body.Regular400 color={COLORS.GRAY_SECONDARY}>
+                                      {link.subnav.cta.subcopy}
+                                    </Body.Regular400>
+                                  )}
+                                </NavLink>
+                              )}
+                            {link.subnav &&
+                              link.subnav.items.length > 0 &&
+                              link.subnav.items.map((link) => (
+                                <div className={styles.dropdownNavChild}>
+                                  <TitleSmall.Sans.Light300>
+                                    <NavLink
+                                      href={link.href}
+                                      LinkComponent={
+                                        link.href !== '/login/'
+                                          ? LinkComponent
+                                          : null
+                                      }
+                                    >
+                                      {link.title}
+                                    </NavLink>
+                                  </TitleSmall.Sans.Light300>
+                                </div>
+                              ))}
+                          </Layout.HorizontallyPaddedContainer>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Desktop menu items to the right */}
+                <div className={`${styles.flex} ${styles.itemsCenter}`}>
+                  {renderSearchIcon(LINKS.SEARCH)}
+                  {renderAccountIcon(LINKS.ACCOUNT)}
+                  <div className={styles.cta}>
+                    {!hideDesktopCta && renderCtaButton(false)}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </Layout.ScrollDetector>
+        </div>
+      </div>
+    )
+  }
+}
+
+UniversalNavbarExpanded.propTypes = {
+  /** Hide cta on mobile viewport */
+  hideMobileCta: PropTypes.bool,
+  /** Hide cta on desktop */
+  hideDesktopCta: PropTypes.bool,
+  /** Run analytics function when CTA Button gets clicked */
+  trackCtaClick: PropTypes.func,
+  /** agnotistic Reach and React Router Link */
+  LinkComponent: PropTypes.object,
+  /** Href for the logo */
+  logoHref: PropTypes.string,
+}
+
+UniversalNavbarExpanded.defaultProps = {
+  hideMobileCta: false,
+  hideDesktopCta: false,
+  logoHref: LINKS.INDEX.href,
+  trackCtaClick: () => {},
+}
+
+export { UniversalNavbarExpanded }

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -36,14 +36,27 @@ import styles from './UniversalNavbarExpanded.module.scss'
 // TODO: alternate caret weight for DropdownParentIcon pre:hover
 // TODO: 'talk to us' CTA integration once Kustomer is implemented
 // TODO: adjust width of bottom forest border on parent links
-// TODO: smallest laptop size, lower width between subitems
+// TODO: smallest laptop size, lower width between subitems w/shorter text
 // TODO: set subnav height to largest
 // TODO: arrow on same line as individual link
 // TODO: replace blue outline on focus with cleaner white underline
-// TODO: add section CTA top of mobile menu
-// TODO: change to check my price for main CTA
 // TODO: remove clickability of right side of accordion submenu
-// TODO: move CTA on mobile further right, 20px from hamburger (on scroll)
+// TODO: 3/2/20 QA: Add 1px stroke (#000000 20%) beneath default navbar and underneath dropdown when it's open (low priority)
+// TODO: 3/2/20 QA: Reduce padding between "check my price" CTA and hamburger icon on scrolled mobile nav (low priority)
+// TODO: 3/2/20 QA: Side arrow breaks to new line for one of the menu items on laptop size (low priority)
+// TODO:  Create a constant for the 13 keycode
+// TODO:  Do an array and join(' ') like in the other components for classNames
+// TODO:  Make a helper function that checks for /login/
+// TODO:  Split main file into separate components
+// TODO:  Update test descriptions / more tests
+// TODO:  Implement lodash/get usage for nested props
+// TODO:  FancyAnimatedLogo functional component
+// TODO:  use .map instead of checking for .length > 0 (2 places)
+// TODO:  z index variables
+// TODO:  JS Docs
+// TODO:  more code commenting in general
+// TODO:  PropTypes review
+// TODO:  LINKS constant passed in from CMS
 
 // TODO: convert from class to hook?
 class UniversalNavbarExpanded extends React.Component {
@@ -53,18 +66,17 @@ class UniversalNavbarExpanded extends React.Component {
   }
 
   toggleHamburger = () => {
-    this.setState({ ...this.state, showMobileMenu: !this.state.showMobileMenu })
+    this.setState({ showMobileMenu: !this.state.showMobileMenu })
   }
 
   handleHamburgerKeyPress = (event) => {
     if (event.key === 'Enter') {
-      this.toggleHamburger(true)
+      this.toggleHamburger()
     }
   }
 
   toggleAccordionItem = (toggledItem) => {
     this.setState({
-      ...this.state,
       activeAccordionItem:
         this.state.activeAccordionItem === toggledItem ? false : toggledItem,
     })
@@ -182,6 +194,23 @@ class UniversalNavbarExpanded extends React.Component {
                         <AccordionToggleIcon />
                       </div>
                       <div className={styles.accordionChildren}>
+                        <div
+                          key={link.subnav.cta.id}
+                          className={styles.accordionChild}
+                        >
+                          <TitleSmall.Sans.Light300>
+                            <NavLink
+                              href={link.subnav.cta.href}
+                              LinkComponent={
+                                link.subnav.cta.href !== '/login/'
+                                  ? LinkComponent
+                                  : null
+                              }
+                            >
+                              {link.subnav.cta.title}
+                            </NavLink>
+                          </TitleSmall.Sans.Light300>
+                        </div>
                         {link.subnav &&
                           link.subnav.items.length > 0 &&
                           link.subnav.items.map((link) => (

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import uuidv4 from 'uuid/v4'
+
 import FancyAnimatedLogo from '../UniversalNavbar/FancyAnimatedLogo'
 import LogoNotAnimated from '../UniversalNavbar/assets/ethos-logo-black.js'
 import LogoWhite from '../UniversalNavbar/assets/ethos-logo-white.js'
@@ -76,19 +76,7 @@ class UniversalNavbarExpanded extends React.Component {
     )
 
     const { showMobileMenu, activeAccordionItem } = this.state
-    console.log(this.state)
-    const renderTextLink = (link) => (
-      <div key={link.id} className={styles.textLink}>
-        <NavLink
-          href={link.href}
-          LinkComponent={link.href !== '/login/' ? LinkComponent : null}
-        >
-          {link.title}
-        </NavLink>
-      </div>
-    )
 
-    // These are bespoke icons but design may replace w/FA at a later date
     const renderSearchIcon = (link) => {
       return (
         <NavLink
@@ -176,7 +164,10 @@ class UniversalNavbarExpanded extends React.Component {
                         {link.subnav &&
                           link.subnav.items.length > 0 &&
                           link.subnav.items.map((link) => (
-                            <div className={styles.accordionChild}>
+                            <div
+                              key={link.id}
+                              className={styles.accordionChild}
+                            >
                               <TitleSmall.Sans.Light300>
                                 <NavLink
                                   href={link.href}
@@ -195,8 +186,8 @@ class UniversalNavbarExpanded extends React.Component {
                     </div>
                   ))}
                 </div>
-                <div class={styles.belowAccordion}>
-                  <div class={styles.belowAccordionItem}>
+                <div className={styles.belowAccordion}>
+                  <div className={styles.belowAccordionItem}>
                     <NavLink
                       href={LINKS.TERM.href}
                       LinkComponent={
@@ -208,7 +199,7 @@ class UniversalNavbarExpanded extends React.Component {
                       </TitleMedium.Sans.Regular400>
                     </NavLink>
                   </div>
-                  <div class={styles.belowAccordionItem}>
+                  <div className={styles.belowAccordionItem}>
                     <NavLink
                       href={LINKS.ACCOUNT.href}
                       LinkComponent={
@@ -220,7 +211,7 @@ class UniversalNavbarExpanded extends React.Component {
                       </TitleMedium.Sans.Regular400>
                     </NavLink>
                   </div>
-                  <div class={styles.belowAccordionItem}>
+                  <div className={styles.belowAccordionItem}>
                     <NavLink
                       href={LINKS.SEARCH.href}
                       LinkComponent={
@@ -255,53 +246,64 @@ class UniversalNavbarExpanded extends React.Component {
                     {LogoNotAnimated({ className: styles.logo })}
                   </NavLink>
                   <div className={styles.dropdownNav}>
-                    {LINKS.NAVLINKS.map((link, idx) => (
-                      <div className={styles.dropdownNavParent}>
+                    {LINKS.NAVLINKS.map((link) => (
+                      <div className={styles.dropdownNavParent} key={link.id}>
                         <Footnote.Regular400>{link.title}</Footnote.Regular400>
                         <div className={styles.dropdownNavChildren}>
                           <Layout.HorizontallyPaddedContainer>
-                            {link.subnav &&
-                              link.subnav.cta &&
-                              link.subnav.cta.href && (
-                                <NavLink
-                                  href={link.subnav.cta.href}
-                                  LinkComponent={
-                                    link.subnav.cta.href !== '/login/'
-                                      ? LinkComponent
-                                      : null
-                                  }
-                                >
-                                  {link.subnav.cta.title && (
-                                    <TitleSmall.Serif.Book500>
-                                      {link.subnav.cta.title}
-                                    </TitleSmall.Serif.Book500>
-                                  )}
-                                  <Spacer.H8 />
-                                  {link.subnav.cta.subcopy && (
-                                    <Body.Regular400 color={COLORS.GRAY_SECONDARY}>
-                                      {link.subnav.cta.subcopy}
-                                    </Body.Regular400>
-                                  )}
-                                </NavLink>
-                              )}
-                            {link.subnav &&
-                              link.subnav.items.length > 0 &&
-                              link.subnav.items.map((link) => (
-                                <div className={styles.dropdownNavChild}>
-                                  <TitleSmall.Sans.Light300>
+                            <div className={styles.dropdownNavChildrenInner}>
+                              <div className={styles.dropdownNavChildrenCta}>
+                                {link.subnav &&
+                                  link.subnav.cta &&
+                                  link.subnav.cta.href && (
                                     <NavLink
-                                      href={link.href}
+                                      href={link.subnav.cta.href}
                                       LinkComponent={
-                                        link.href !== '/login/'
+                                        link.subnav.cta.href !== '/login/'
                                           ? LinkComponent
                                           : null
                                       }
                                     >
-                                      {link.title}
+                                      {link.subnav.cta.title && (
+                                        <TitleSmall.Serif.Book500>
+                                          {link.subnav.cta.title}
+                                        </TitleSmall.Serif.Book500>
+                                      )}
+                                      <Spacer.H8 />
+                                      {link.subnav.cta.subcopy && (
+                                        <Body.Regular400
+                                          color={COLORS.GRAY_SECONDARY}
+                                        >
+                                          {link.subnav.cta.subcopy}
+                                        </Body.Regular400>
+                                      )}
                                     </NavLink>
-                                  </TitleSmall.Sans.Light300>
-                                </div>
-                              ))}
+                                  )}
+                              </div>
+                              <div className={styles.dropdownNavChildrenItems}>
+                                {link.subnav &&
+                                  link.subnav.items.length > 0 &&
+                                  link.subnav.items.map((link) => (
+                                    <div
+                                      className={styles.dropdownNavChild}
+                                      key={link.id}
+                                    >
+                                      <Footnote.Regular400>
+                                        <NavLink
+                                          href={link.href}
+                                          LinkComponent={
+                                            link.href !== '/login/'
+                                              ? LinkComponent
+                                              : null
+                                          }
+                                        >
+                                          {link.title}
+                                        </NavLink>
+                                      </Footnote.Regular400>
+                                    </div>
+                                  ))}
+                              </div>
+                            </div>
                           </Layout.HorizontallyPaddedContainer>
                         </div>
                       </div>

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -33,6 +33,10 @@ import styles from './UniversalNavbarExpanded.module.scss'
 //     : null
 // }
 
+// TODO: more spacing var usage in scss
+// TODO: less nesting in scss
+// TODO: replace white with color var in scss
+// TODO: 504px that's an odd value
 // TODO: alternate caret weight for DropdownParentIcon pre:hover
 // TODO: 'talk to us' CTA integration once Kustomer is implemented
 // TODO: adjust width of bottom forest border on parent links

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -8,6 +8,8 @@ import {
   AccountIcon,
   SearchIcon,
   AccordionToggleIcon,
+  DropdownParentIcon,
+  DropdownLinkIcon,
 } from '../UniversalNavbar/assets/icons.js'
 import {
   Body,
@@ -23,6 +25,13 @@ import TransformingBurgerButton from '../UniversalNavbar/TransformingBurgerButto
 import { LINKS } from './constants.js'
 import NavLink from '../UniversalNavbar/NavLink'
 import styles from './UniversalNavbarExpanded.module.scss'
+
+// TODO: Dry up this prop usage for NavLink
+// LinkComponent={
+//   link.href !== '/login/'
+//     ? LinkComponent
+//     : null
+// }
 
 // TODO: convert from class to hook?
 class UniversalNavbarExpanded extends React.Component {
@@ -248,7 +257,12 @@ class UniversalNavbarExpanded extends React.Component {
                   <div className={styles.dropdownNav}>
                     {LINKS.NAVLINKS.map((link) => (
                       <div className={styles.dropdownNavParent} key={link.id}>
-                        <Footnote.Regular400>{link.title}</Footnote.Regular400>
+                        <Footnote.Regular400>
+                          {link.title}
+                          <span className={styles.dropdownNavParentIcon}>
+                            <DropdownParentIcon />
+                          </span>
+                        </Footnote.Regular400>
                         <div className={styles.dropdownNavChildren}>
                           <Layout.HorizontallyPaddedContainer>
                             <div className={styles.dropdownNavChildrenInner}>
@@ -266,7 +280,8 @@ class UniversalNavbarExpanded extends React.Component {
                                     >
                                       {link.subnav.cta.title && (
                                         <TitleSmall.Serif.Book500>
-                                          {link.subnav.cta.title}
+                                          <span>{link.subnav.cta.title}</span>
+                                          <DropdownLinkIcon />
                                         </TitleSmall.Serif.Book500>
                                       )}
                                       <Spacer.H8 />
@@ -297,7 +312,8 @@ class UniversalNavbarExpanded extends React.Component {
                                               : null
                                           }
                                         >
-                                          {link.title}
+                                          <span>{link.title}</span>
+                                          <DropdownLinkIcon />
                                         </NavLink>
                                       </Footnote.Regular400>
                                     </div>

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -35,6 +35,15 @@ import styles from './UniversalNavbarExpanded.module.scss'
 
 // TODO: alternate caret weight for DropdownParentIcon pre:hover
 // TODO: 'talk to us' CTA integration once Kustomer is implemented
+// TODO: adjust width of bottom forest border on parent links
+// TODO: smallest laptop size, lower width between subitems
+// TODO: set subnav height to largest
+// TODO: arrow on same line as individual link
+// TODO: replace blue outline on focus with cleaner white underline
+// TODO: add section CTA top of mobile menu
+// TODO: change to check my price for main CTA
+// TODO: remove clickability of right side of accordion submenu
+// TODO: move CTA on mobile further right, 20px from hamburger (on scroll)
 
 // TODO: convert from class to hook?
 class UniversalNavbarExpanded extends React.Component {

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -44,6 +44,7 @@ import styles from './UniversalNavbarExpanded.module.scss'
 // TODO: 3/2/20 QA: Add 1px stroke (#000000 20%) beneath default navbar and underneath dropdown when it's open (low priority)
 // TODO: 3/2/20 QA: Reduce padding between "check my price" CTA and hamburger icon on scrolled mobile nav (low priority)
 // TODO: 3/2/20 QA: Side arrow breaks to new line for one of the menu items on laptop size (low priority)
+// TODO: right 44px override not working for scrolled CTA in navbar on mobile
 // TODO:  Create a constant for the 13 keycode
 // TODO:  Do an array and join(' ') like in the other components for classNames
 // TODO:  Make a helper function that checks for /login/

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.md
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.md
@@ -1,0 +1,5 @@
+This element has a fixed position at the top of the screen which you can see here. Also, it behaves very differently on mobile.
+
+```jsx
+<UniversalNavbarExpanded logoHref={'http://test.com'} />
+```

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
@@ -61,10 +61,10 @@ $tablet-small-end: 670px;
   display: flex;
   justify-content: space-between;
   @include for-laptop-only {
-    padding: var(--Space-24) var(--ContainerPadding--Laptop);
+    padding: var(--Space-24);
   }
   @include for-desktop-only {
-    padding: var(--Space-24) var(--ContainerPadding--Desktop);
+    padding: var(--Space-24) var(--Space-48);
   }
 }
 
@@ -345,5 +345,24 @@ $tablet-small-end: 670px;
         height: 12px;
       }
     }
+  }
+}
+
+
+
+@media (min-width: 900px) and (max-width: 929px) {
+  .accountIcon,
+  .searchIcon {
+    display: none;
+  }
+}
+
+@media (min-width: 900px) and (max-width: 1050px) {
+  .dropdownNav .dropdownNavChildren .dropdownNavChildrenCta {
+    margin-right: 48px;
+      max-width: 224px;
+  }
+  .dropdownNav .dropdownNavChildren .dropdownNavChild:nth-child(odd) {
+    margin-right: 24px;
   }
 }

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
@@ -253,8 +253,9 @@ $tablet-small-end: 670px;
     }
     &:hover {
       > div:first-child {
-        // either this text shadow or we have to set fixed widths on each nav item
-        // in order to meet bolding spec without changing item width
+        /** either this text shadow or we have to set fixed widths on each nav item
+          * in order to meet bolding spec without changing item width
+        **/
         text-shadow: 0 0 0.25px #272727, 0 0 0.25px #272727;
       }
       .dropdownNavChildren {

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
@@ -348,8 +348,6 @@ $tablet-small-end: 670px;
   }
 }
 
-
-
 @media (min-width: 900px) and (max-width: 929px) {
   .accountIcon,
   .searchIcon {
@@ -360,9 +358,10 @@ $tablet-small-end: 670px;
 @media (min-width: 900px) and (max-width: 1050px) {
   .dropdownNav .dropdownNavChildren .dropdownNavChildrenCta {
     margin-right: 48px;
-      max-width: 224px;
+      max-width: 232px;
   }
   .dropdownNav .dropdownNavChildren .dropdownNavChild:nth-child(odd) {
     margin-right: 24px;
+      max-width: 208px;
   }
 }

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
@@ -208,7 +208,7 @@ $tablet-small-end: 670px;
   .accordionParent > div:first-child,
   .accordionChild {
     max-width: calc(100% - 14px);
-    padding-right: var(--Space-80);
+    padding-right: var(--Space-64);
     @include for-tablet-only {
       padding-right: 120px;
     }
@@ -348,6 +348,14 @@ $tablet-small-end: 670px;
   }
 }
 
+@include for-phone-and-tablet {
+  :global {
+    .cta-button.show-when-scrolled {
+      right: 44px;
+    }
+  }
+}
+
 @media (min-width: 900px) and (max-width: 929px) {
   .accountIcon,
   .searchIcon {
@@ -358,10 +366,10 @@ $tablet-small-end: 670px;
 @media (min-width: 900px) and (max-width: 1050px) {
   .dropdownNav .dropdownNavChildren .dropdownNavChildrenCta {
     margin-right: 48px;
-      max-width: 232px;
+    max-width: 232px;
   }
   .dropdownNav .dropdownNavChildren .dropdownNavChild:nth-child(odd) {
     margin-right: 24px;
-      max-width: 208px;
+    max-width: 208px;
   }
 }

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
@@ -118,6 +118,9 @@ $tablet-small-end: 670px;
   @include for-laptop-and-up {
     margin-right: 18px;
     padding-top: 3px;
+    &:hover {
+      opacity: 0.78;
+    }
   }
 }
 
@@ -127,6 +130,9 @@ $tablet-small-end: 670px;
   }
   @include for-laptop-and-up {
     padding-top: 3px;
+    &:hover {
+      opacity: 0.78;
+    }
   }
 }
 
@@ -290,6 +296,9 @@ $tablet-small-end: 670px;
   margin-bottom: 16px;
   a {
     text-decoration: none;
+    &:hover {
+      opacity: 0.78;
+    }
   }
 }
 
@@ -299,6 +308,7 @@ $tablet-small-end: 670px;
   .dropdownNavChildrenCta {
     &:hover {
       span {
+        opacity: 0.78;
         text-decoration: underline;
       }
     }

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
@@ -195,6 +195,9 @@ $tablet-small-end: 670px;
     .accordionChildren {
       display: block;
     }
+    .accordionParent svg {
+      transform: scale(1, -1);
+    }
   }
   .accordionParent > div:first-child,
   .accordionChild {
@@ -261,10 +264,14 @@ $tablet-small-end: 670px;
       }
       .dropdownNavChildren {
         display: block;
+        cursor: default;
       }
     }
     &:not(:last-child) {
       margin-right: var(--Space-24);
+    }
+    .dropdownNavParentIcon {
+      margin-left: 4px;
     }
   }
 }
@@ -290,12 +297,22 @@ $tablet-small-end: 670px;
   display: flex;
   padding: var(--Space-40) 0 var(--Space-24);
   .dropdownNavChildrenCta {
+    &:hover {
+      span {
+        text-decoration: underline;
+      }
+    }
     margin-right: 120px;
     @include for-laptop-only {
       max-width: 264px;
     }
     @include for-desktop-only {
       max-width: 320px;
+    }
+    svg {
+      margin-left: 4px;
+      width: 19px;
+      height: 19px;
     }
   }
   .dropdownNavChildrenItems {
@@ -306,8 +323,13 @@ $tablet-small-end: 670px;
     .dropdownNavChild {
       flex-basis: calc(50%);
       max-width: 216px;
-      &:nth-child(odd){
+      &:nth-child(odd) {
         margin-right: 72px;
+      }
+      svg {
+        margin-left: 4px;
+        width: 15px;
+        height: 12px;
       }
     }
   }

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
@@ -248,10 +248,11 @@ $tablet-small-end: 670px;
     height: 64px;
     display: flex;
     align-items: center;
-    > div:first-child {
-      transition: text-shadow 0.3s;
-    }
+    padding-top: 4px;
+    border-bottom: 4px solid transparent;
     &:hover {
+      border-bottom-color: var(--BrandForest);
+
       > div:first-child {
         /** either this text shadow or we have to set fixed widths on each nav item
           * in order to meet bolding spec without changing item width
@@ -263,7 +264,7 @@ $tablet-small-end: 670px;
       }
     }
     &:not(:last-child) {
-      padding-right: var(--Space-24);
+      margin-right: var(--Space-24);
     }
   }
 }
@@ -275,7 +276,39 @@ $tablet-small-end: 670px;
   left: 0;
   width: 100%;
   background: var(--White);
+  border-top: solid 1px var(--GrayStrokeAndDisabled--translucent);
 }
 
 .dropdownNavChild {
+  margin-bottom: 16px;
+  a {
+    text-decoration: none;
+  }
+}
+
+.dropdownNavChildrenInner {
+  display: flex;
+  padding: var(--Space-40) 0 var(--Space-24);
+  .dropdownNavChildrenCta {
+    margin-right: 120px;
+    @include for-laptop-only {
+      max-width: 264px;
+    }
+    @include for-desktop-only {
+      max-width: 320px;
+    }
+  }
+  .dropdownNavChildrenItems {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    max-width: 504px;
+    .dropdownNavChild {
+      flex-basis: calc(50%);
+      max-width: 216px;
+      &:nth-child(odd){
+        margin-right: 72px;
+      }
+    }
+  }
 }

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
@@ -1,0 +1,280 @@
+@import '../Media/Media.scss';
+@import '../Variables.scss';
+
+$tablet-small-end: 670px;
+
+.flex {
+  display: flex;
+}
+
+.itemsCenter {
+  align-items: center;
+}
+
+.hamburger {
+  position: fixed;
+  top: 24px;
+  right: 24px;
+  z-index: 2;
+
+  @include for-laptop-and-up {
+    display: none;
+  }
+}
+
+.phoneAndTablet {
+  position: relative;
+  height: var(--Space-64);
+  background-color: white;
+  padding: var(--Space-24) var(--ContainerPadding--Phone);
+  display: none;
+  align-items: center;
+  justify-content: flex-end;
+  display: flex;
+  @include for-laptop-and-up {
+    display: none;
+  }
+  &.visible {
+    z-index: 3;
+  }
+  .hamburger {
+    position: absolute;
+  }
+}
+
+.laptopAndUp {
+  height: var(--Space-64);
+  background-color: white;
+
+  display: none;
+  @include for-laptop-and-up {
+    display: block;
+  }
+}
+
+.laptopAndUpContainer {
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: var(--Space-24);
+  height: var(--Space-64);
+
+  display: flex;
+  justify-content: space-between;
+  @include for-laptop-only {
+    padding: var(--Space-24) var(--ContainerPadding--Laptop);
+  }
+  @include for-desktop-only {
+    padding: var(--Space-24) var(--ContainerPadding--Desktop);
+  }
+}
+
+.logo {
+  height: 16px;
+  padding-right: var(--Space-40);
+  @media (min-width: $tablet-range-start) and (max-width: $tablet-small-end) {
+    padding-right: var(--Space-24);
+  }
+}
+
+.phoneLogo {
+  margin-right: auto;
+}
+
+.phoneLogoFancy {
+  margin-right: auto;
+}
+
+.cta {
+  padding-left: 21px;
+  @media (min-width: $tablet-range-start) and (max-width: $tablet-small-end) {
+    padding-left: 0;
+  }
+}
+
+.textLink {
+  padding-right: var(--Space-24);
+  @media (min-width: $tablet-range-start) and (max-width: $tablet-small-end) {
+    &:nth-child(2) {
+      padding-right: var(--Space-16);
+    }
+    &:nth-child(3) {
+      padding-right: 0;
+    }
+  }
+  a {
+    color: var(--GraySecondary--translucent);
+    &:hover,
+    &:active,
+    &[aria-current='page'] {
+      color: inherit;
+    }
+  }
+}
+
+.searchIcon {
+  @include for-phone-and-tablet {
+    display: none;
+  }
+  @include for-laptop-and-up {
+    margin-right: 18px;
+    padding-top: 3px;
+  }
+}
+
+.accountIcon {
+  @include for-phone-and-tablet {
+    display: none;
+  }
+  @include for-laptop-and-up {
+    padding-top: 3px;
+  }
+}
+
+/**
+ * Big green mobile hamburger menu
+ */
+.mobileMenu {
+  position: fixed;
+  padding: 24px 24px 40px;
+  height: 100vh;
+  width: 100vw;
+  top: 0;
+  left: 0;
+  background-color: var(--BrandForest);
+  color: white;
+  z-index: 1;
+  overflow-y: scroll;
+  & a,
+  & a:visited,
+  & a:hover {
+    /* TODO REDESIGN: this should be a DS component */
+    font-weight: 300;
+    color: white;
+    text-decoration: unset !important;
+  }
+}
+
+.hideMobileMenu {
+  composes: mobileMenu;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--Space-64);
+  z-index: $z-index-navbar;
+}
+
+.blockNavbar {
+  height: var(--Space-64);
+}
+
+.accordion {
+  padding: var(--Space-40) 0;
+  margin-bottom: var(--Space-40);
+  @include for-tablet-only {
+    padding-bottom: var(--Space-56);
+    margin-bottom: var(--Space-56);
+  }
+  border-bottom: solid 1px var(--White);
+}
+
+.accordionItem {
+  cursor: pointer;
+  &:not(:last-child) {
+    margin-bottom: var(--Space-24);
+    @include for-tablet-only {
+      margin-bottom: var(--Space-32);
+    }
+  }
+  &.active {
+    .accordionChildren {
+      display: block;
+    }
+  }
+  .accordionParent > div:first-child,
+  .accordionChild {
+    max-width: calc(100% - 14px);
+    padding-right: var(--Space-80);
+    @include for-tablet-only {
+      padding-right: 120px;
+    }
+  }
+}
+
+.accordionParent {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  > svg {
+    width: 12px;
+    height: 12px;
+    margin-bottom: var(--Space-8);
+  }
+}
+
+.accordionChildren {
+  display: none;
+  padding-bottom: var(--Space-8);
+}
+
+.accordionChild {
+  padding-top: var(--Space-24);
+}
+
+.belowAccordion {
+  display: flex;
+  flex-direction: column;
+  .belowAccordionItem {
+    display: inline-block;
+    &:not(:last-child) {
+      margin-bottom: var(--Space-24);
+      @include for-tablet-only {
+        margin-bottom: var(--Space-32);
+      }
+    }
+  }
+}
+
+.dropdownNav {
+  display: flex;
+  .dropdownNavParent {
+    cursor: pointer;
+    height: 64px;
+    display: flex;
+    align-items: center;
+    > div:first-child {
+      transition: text-shadow 0.3s;
+    }
+    &:hover {
+      > div:first-child {
+        // either this text shadow or we have to set fixed widths on each nav item
+        // in order to meet bolding spec without changing item width
+        text-shadow: 0 0 0.25px #272727, 0 0 0.25px #272727;
+      }
+      .dropdownNavChildren {
+        display: block;
+      }
+    }
+    &:not(:last-child) {
+      padding-right: var(--Space-24);
+    }
+  }
+}
+
+.dropdownNavChildren {
+  display: none;
+  position: absolute;
+  top: 64px;
+  left: 0;
+  width: 100%;
+  background: var(--White);
+}
+
+.dropdownNavChild {
+}

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
@@ -274,7 +274,10 @@ $tablet-small-end: 670px;
       }
     }
     &:not(:last-child) {
-      margin-right: var(--Space-24);
+      padding-right: var(--Space-12);
+    }
+    &:not(:first-child) {
+      padding-left: var(--Space-12);
     }
     .dropdownNavParentIcon {
       margin-left: 4px;

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.test.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.test.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import ShallowRenderer from 'react-test-renderer/shallow'
+
+import { UniversalNavbarExpanded } from './UniversalNavbarExpanded'
+
+describe('<UniversalNavbarExpanded>', () => {
+  describe('matches snapshot', () => {
+    it('with no arguments', () => {
+      expect(shallowSnapshot(<UniversalNavbarExpanded />)).toMatchSnapshot()
+    })
+  })
+})
+
+function shallowSnapshot(jsx) {
+  const renderer = new ShallowRenderer()
+  renderer.render(jsx)
+  return renderer.getRenderOutput()
+}

--- a/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
+++ b/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
@@ -67,6 +67,17 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                 >
                   <PublicTypeComponent>
                     <NavLink
+                      href="/insurance/term-life-insurance/"
+                    >
+                      Our plans
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
                       href="/life/ethos-term-insurance/"
                     >
                       What is term life insurance and how much does it cost?
@@ -137,6 +148,17 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
               <div
                 className="accordionChildren"
               >
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/life/life-insurance-basics/"
+                    >
+                      Life insurance 101
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
                 <div
                   className="accordionChild"
                 >
@@ -217,6 +239,17 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                 >
                   <PublicTypeComponent>
                     <NavLink
+                      href="/why-ethos/"
+                    >
+                      The Ethos Difference
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
                       href="/about/"
                     >
                       Our mission
@@ -292,6 +325,17 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                 >
                   <PublicTypeComponent>
                     <NavLink
+                      href="/faq/"
+                    >
+                      FAQ
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
                       href="/faq/life-insurance-basics/"
                     >
                       Questions about life insurance
@@ -355,7 +399,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                 href="/term"
               >
                 <PublicTypeComponent>
-                  Get covered
+                  Check my price
                 </PublicTypeComponent>
               </NavLink>
             </div>

--- a/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
+++ b/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
@@ -1,0 +1,513 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
+<div
+  className="blockNavbar"
+>
+  <div
+    className="navbar"
+  >
+    <ScrollDetector
+      element="div"
+      offsetHeight={0}
+    >
+      <Hamburger />
+      <div
+        className="phoneAndTablet"
+      >
+        <div
+          className="hideMobileMenu"
+        >
+          <NavLink
+            className="phoneLogo"
+            href="/"
+          >
+            <svg
+              className="logo"
+              viewBox="0 0 971.997 180.498"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Ethos Logo
+              </title>
+              <path
+                d="M184.573 2.845v29.202h58.416v146.028h29.202V32.047h58.41V2.845H184.573zM0 2.845v175.23h129.318v-29.208H29.202v-43.806h86.988V75.859H29.202V32.047h100.116V2.845H0zm505.833 0v73.014h-87.612V2.845h-29.208v175.23h29.208v-73.014h87.612v73.014h29.202V2.845h-29.202zm252.688 16.523a63.8 63.8 0 0 0-90.228 0c-3.6 3.606-11.1 12.036-13.662 16.188a63.725 63.725 0 0 1 87.894 87.378l.984-.984c4.272-2.592 11.322-8.664 15.012-12.354a63.8 63.8 0 0 0 0-90.228"
+                fill="white"
+              />
+              <path
+                d="M650.356 127.535c-25.068-25.068-40.422-71.178-12.132-119.922L625 20.837a93.374 93.374 0 0 0 132.054 132.048l13.224-13.224c-46.422 26.988-92.616 15.18-119.922-12.126m251.813 53.175c42.42 0 69.828-21.018 69.828-53.55 0-30.5-21.438-41.532-56.034-49.428l-21.192-4.65c-19.08-4.218-29.424-9.12-29.424-22.944 0-14.094 13.134-23.2 33.462-23.2 18.966 0 35.658 7.044 45.942 19.362l22.008-17.69C954.645 15.51 933.273.21 899.583.21c-38.064 0-65.694 21.648-65.694 51.48 0 34.044 27.87 44.436 52.152 49.686l23.52 5.172c18.594 4.038 30.978 9.576 30.978 23.454 0 14.916-13.422 23.46-36.816 23.46-25.518 0-44.808-12.534-52.89-25.17l-24.15 17.388c12.438 17.046 38.64 35.028 75.486 35.028"
+                fill="white"
+              />
+            </svg>
+          </NavLink>
+          <Hamburger />
+          <div
+            className="accordion"
+          >
+            <div
+              className="accordionItem"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <div
+                className="accordionParent"
+              >
+                <PublicTypeComponent>
+                  What we offer
+                </PublicTypeComponent>
+                <AccordionToggleIcon />
+              </div>
+              <div
+                className="accordionChildren"
+              >
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/why-ethos/"
+                    >
+                      Why Ethos
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/why-ethos/"
+                    >
+                      Why Ethos
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/why-ethos/"
+                    >
+                      Why Ethos
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/why-ethos/"
+                    >
+                      Why Ethos
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/why-ethos/"
+                    >
+                      Why Ethos
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+              </div>
+            </div>
+            <div
+              className="accordionItem"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <div
+                className="accordionParent"
+              >
+                <PublicTypeComponent>
+                  Life insurance basics
+                </PublicTypeComponent>
+                <AccordionToggleIcon />
+              </div>
+              <div
+                className="accordionChildren"
+              />
+            </div>
+            <div
+              className="accordionItem"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <div
+                className="accordionParent"
+              >
+                <PublicTypeComponent>
+                  Why Ethos
+                </PublicTypeComponent>
+                <AccordionToggleIcon />
+              </div>
+              <div
+                className="accordionChildren"
+              />
+            </div>
+            <div
+              className="accordionItem"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <div
+                className="accordionParent"
+              >
+                <PublicTypeComponent>
+                  Help Center
+                </PublicTypeComponent>
+                <AccordionToggleIcon />
+              </div>
+              <div
+                className="accordionChildren"
+              />
+            </div>
+          </div>
+          <div
+            class="belowAccordion"
+          >
+            <div
+              class="belowAccordionItem"
+            >
+              <NavLink
+                href="/term"
+              >
+                <PublicTypeComponent>
+                  Get covered
+                </PublicTypeComponent>
+              </NavLink>
+            </div>
+            <div
+              class="belowAccordionItem"
+            >
+              <NavLink
+                LinkComponent={null}
+                href="/login/"
+              >
+                <PublicTypeComponent>
+                  Account
+                </PublicTypeComponent>
+              </NavLink>
+            </div>
+            <div
+              class="belowAccordionItem"
+            >
+              <NavLink
+                href="/search/"
+              >
+                <PublicTypeComponent>
+                  Search
+                </PublicTypeComponent>
+              </NavLink>
+            </div>
+          </div>
+        </div>
+        <NavLink
+          className="phoneLogoFancy"
+          href="/"
+        >
+          <div
+            aria-label="Ethos"
+            role="img"
+            style={
+              Object {
+                "height": 16,
+                "position": "relative",
+                "width": 86.6,
+              }
+            }
+          >
+            <svg
+              alt=""
+              className="letter fancyE"
+              viewBox="0 0 971.997 180.498"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                ethos-logo-E
+              </title>
+              <path
+                d="M0 2.845v175.23h129.318v-29.208H29.202v-43.806h86.988V75.859H29.202V32.047h100.116V2.845H0z"
+              />
+            </svg>
+            <svg
+              alt=""
+              className="letter fancyT"
+              viewBox="0 0 971.997 180.498"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                ethos-logo-T
+              </title>
+              <path
+                d="M184.573 2.845v29.202h58.416v146.028h29.202V32.047h58.41V2.845H184.573z"
+              />
+            </svg>
+            <svg
+              alt=""
+              className="letter fancyH"
+              viewBox="0 0 971.997 180.498"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                ethos-logo-H
+              </title>
+              <path
+                d="M505.833 2.845v73.014h-87.612V2.845h-29.208v175.23h29.208v-73.014h87.612v73.014h29.202V2.845h-29.202z"
+              />
+            </svg>
+            <svg
+              alt=""
+              className="letter fancyO"
+              viewBox="0 0 971.997 180.498"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                ethos-logo-O
+              </title>
+              <path
+                d="M758.521 19.368a63.8 63.8 0 0 0-90.227 0c-3.6 3.606-11.1 12.036-13.662 16.188a63.725 63.725 0 0 1 87.894 87.378l.984-.984c4.272-2.592 11.322-8.664 15.012-12.354a63.8 63.8 0 0 0 0-90.227"
+              />
+              <path
+                d="M650.356 127.535c-25.068-25.068-40.422-71.178-12.132-119.922L625 20.837a93.374 93.374 0 1 0 132.054 132.048l13.224-13.224c-46.422 26.988-92.616 15.18-119.922-12.126"
+              />
+            </svg>
+            <svg
+              alt=""
+              className="letter fancyS"
+              viewBox="0 0 971.997 180.498"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                ethos-logo-S
+              </title>
+              <path
+                d="M902.169 180.71c42.42 0 69.828-21.018 69.828-53.55 0-30.5-21.438-41.532-56.034-49.428l-21.192-4.65c-19.08-4.218-29.424-9.12-29.424-22.944 0-14.094 13.134-23.2 33.462-23.2 18.966 0 35.658 7.044 45.942 19.362l22.008-17.69C954.645 15.51 933.273.21 899.583.21c-38.064 0-65.694 21.648-65.694 51.48 0 34.044 27.87 44.436 52.152 49.686l23.52 5.172c18.594 4.038 30.978 9.576 30.978 23.454 0 14.916-13.422 23.46-36.816 23.46-25.518 0-44.808-12.534-52.89-25.17l-24.15 17.388c12.438 17.046 38.64 35.028 75.486 35.028"
+              />
+            </svg>
+          </div>
+        </NavLink>
+        <a
+          className="cta-button show-when-scrolled"
+          href="/term"
+          onClick={[Function]}
+        >
+          <PublicButtonComponent>
+            Check my price
+          </PublicButtonComponent>
+        </a>
+        <NavLink
+          className="searchIcon"
+          href="/search/"
+        >
+          <SearchIcon />
+        </NavLink>
+      </div>
+      <div
+        className="laptopAndUp"
+      >
+        <div
+          className="laptopAndUpContainer"
+        >
+          <div
+            className="flex itemsCenter"
+          >
+            <NavLink
+              href="/"
+            >
+              <svg
+                className="logo"
+                viewBox="0 0 971.997 180.498"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title>
+                  Ethos Logo
+                </title>
+                <path
+                  d="M184.573 2.845v29.202h58.416v146.028h29.202V32.047h58.41V2.845H184.573zM0 2.845v175.23h129.318v-29.208H29.202v-43.806h86.988V75.859H29.202V32.047h100.116V2.845H0zm505.833 0v73.014h-87.612V2.845h-29.208v175.23h29.208v-73.014h87.612v73.014h29.202V2.845h-29.202zm252.688 16.523a63.8 63.8 0 0 0-90.228 0c-3.6 3.606-11.1 12.036-13.662 16.188a63.725 63.725 0 0 1 87.894 87.378l.984-.984c4.272-2.592 11.322-8.664 15.012-12.354a63.8 63.8 0 0 0 0-90.228"
+                />
+                <path
+                  d="M650.356 127.535c-25.068-25.068-40.422-71.178-12.132-119.922L625 20.837a93.374 93.374 0 0 0 132.054 132.048l13.224-13.224c-46.422 26.988-92.616 15.18-119.922-12.126m251.813 53.175c42.42 0 69.828-21.018 69.828-53.55 0-30.5-21.438-41.532-56.034-49.428l-21.192-4.65c-19.08-4.218-29.424-9.12-29.424-22.944 0-14.094 13.134-23.2 33.462-23.2 18.966 0 35.658 7.044 45.942 19.362l22.008-17.69C954.645 15.51 933.273.21 899.583.21c-38.064 0-65.694 21.648-65.694 51.48 0 34.044 27.87 44.436 52.152 49.686l23.52 5.172c18.594 4.038 30.978 9.576 30.978 23.454 0 14.916-13.422 23.46-36.816 23.46-25.518 0-44.808-12.534-52.89-25.17l-24.15 17.388c12.438 17.046 38.64 35.028 75.486 35.028"
+                />
+              </svg>
+            </NavLink>
+            <div
+              className="dropdownNav"
+            >
+              <div
+                className="dropdownNavParent"
+              >
+                <PublicTypeComponent>
+                  What we offer
+                </PublicTypeComponent>
+                <div
+                  className="dropdownNavChildren"
+                >
+                  <HorizontallyPaddedContainer
+                    element="div"
+                  >
+                    <NavLink
+                      href="/insurance/term-life-insurance/"
+                    >
+                      <PublicTypeComponent>
+                        Our plans
+                      </PublicTypeComponent>
+                      <PublicSpacerComponent />
+                      <PublicTypeComponent
+                        color="GraySecondary"
+                      >
+                        Learn more about term life insurance and the plans and options you have available.
+                      </PublicTypeComponent>
+                    </NavLink>
+                    <div
+                      className="dropdownNavChild"
+                    >
+                      <PublicTypeComponent>
+                        <NavLink
+                          href="/why-ethos/"
+                        >
+                          Why Ethos
+                        </NavLink>
+                      </PublicTypeComponent>
+                    </div>
+                    <div
+                      className="dropdownNavChild"
+                    >
+                      <PublicTypeComponent>
+                        <NavLink
+                          href="/why-ethos/"
+                        >
+                          Why Ethos
+                        </NavLink>
+                      </PublicTypeComponent>
+                    </div>
+                    <div
+                      className="dropdownNavChild"
+                    >
+                      <PublicTypeComponent>
+                        <NavLink
+                          href="/why-ethos/"
+                        >
+                          Why Ethos
+                        </NavLink>
+                      </PublicTypeComponent>
+                    </div>
+                    <div
+                      className="dropdownNavChild"
+                    >
+                      <PublicTypeComponent>
+                        <NavLink
+                          href="/why-ethos/"
+                        >
+                          Why Ethos
+                        </NavLink>
+                      </PublicTypeComponent>
+                    </div>
+                    <div
+                      className="dropdownNavChild"
+                    >
+                      <PublicTypeComponent>
+                        <NavLink
+                          href="/why-ethos/"
+                        >
+                          Why Ethos
+                        </NavLink>
+                      </PublicTypeComponent>
+                    </div>
+                  </HorizontallyPaddedContainer>
+                </div>
+              </div>
+              <div
+                className="dropdownNavParent"
+              >
+                <PublicTypeComponent>
+                  Life insurance basics
+                </PublicTypeComponent>
+                <div
+                  className="dropdownNavChildren"
+                >
+                  <HorizontallyPaddedContainer
+                    element="div"
+                  />
+                </div>
+              </div>
+              <div
+                className="dropdownNavParent"
+              >
+                <PublicTypeComponent>
+                  Why Ethos
+                </PublicTypeComponent>
+                <div
+                  className="dropdownNavChildren"
+                >
+                  <HorizontallyPaddedContainer
+                    element="div"
+                  />
+                </div>
+              </div>
+              <div
+                className="dropdownNavParent"
+              >
+                <PublicTypeComponent>
+                  Help Center
+                </PublicTypeComponent>
+                <div
+                  className="dropdownNavChildren"
+                >
+                  <HorizontallyPaddedContainer
+                    element="div"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="flex itemsCenter"
+          >
+            <NavLink
+              className="searchIcon"
+              href="/search/"
+            >
+              <SearchIcon />
+            </NavLink>
+            <NavLink
+              LinkComponent={null}
+              className="accountIcon"
+              href="/login/"
+            >
+              <AccountIcon />
+            </NavLink>
+            <div
+              className="cta"
+            >
+              <a
+                className="cta-button "
+                href="/term"
+                onClick={[Function]}
+              >
+                <PublicButtonComponent>
+                  Check my price
+                </PublicButtonComponent>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ScrollDetector>
+  </div>
+</div>
+`;

--- a/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
+++ b/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
@@ -67,9 +67,9 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                 >
                   <PublicTypeComponent>
                     <NavLink
-                      href="/why-ethos/"
+                      href="/life/ethos-term-insurance/"
                     >
-                      Why Ethos
+                      What is term life insurance and how much does it cost?
                     </NavLink>
                   </PublicTypeComponent>
                 </div>
@@ -78,9 +78,9 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                 >
                   <PublicTypeComponent>
                     <NavLink
-                      href="/why-ethos/"
+                      href="/how-it-works/"
                     >
-                      Why Ethos
+                      How our application process works
                     </NavLink>
                   </PublicTypeComponent>
                 </div>
@@ -89,9 +89,9 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                 >
                   <PublicTypeComponent>
                     <NavLink
-                      href="/why-ethos/"
+                      href="/life/who-needs-life-insurance/"
                     >
-                      Why Ethos
+                      Do I need life insurance?
                     </NavLink>
                   </PublicTypeComponent>
                 </div>
@@ -100,9 +100,9 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                 >
                   <PublicTypeComponent>
                     <NavLink
-                      href="/why-ethos/"
+                      href="/life/how-choose-right-type-life-insurance/"
                     >
-                      Why Ethos
+                      Choosing your coverage amount and term length
                     </NavLink>
                   </PublicTypeComponent>
                 </div>
@@ -111,9 +111,9 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                 >
                   <PublicTypeComponent>
                     <NavLink
-                      href="/why-ethos/"
+                      href="/app/needs/"
                     >
-                      Why Ethos
+                      Coverage calculator
                     </NavLink>
                   </PublicTypeComponent>
                 </div>
@@ -178,10 +178,10 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
             </div>
           </div>
           <div
-            class="belowAccordion"
+            className="belowAccordion"
           >
             <div
-              class="belowAccordionItem"
+              className="belowAccordionItem"
             >
               <NavLink
                 href="/term"
@@ -192,7 +192,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
               </NavLink>
             </div>
             <div
-              class="belowAccordionItem"
+              className="belowAccordionItem"
             >
               <NavLink
                 LinkComponent={null}
@@ -204,7 +204,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
               </NavLink>
             </div>
             <div
-              class="belowAccordionItem"
+              className="belowAccordionItem"
             >
               <NavLink
                 href="/search/"
@@ -360,73 +360,85 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                   <HorizontallyPaddedContainer
                     element="div"
                   >
-                    <NavLink
-                      href="/insurance/term-life-insurance/"
+                    <div
+                      className="dropdownNavChildrenInner"
                     >
-                      <PublicTypeComponent>
-                        Our plans
-                      </PublicTypeComponent>
-                      <PublicSpacerComponent />
-                      <PublicTypeComponent
-                        color="GraySecondary"
+                      <div
+                        className="dropdownNavChildrenCta"
                       >
-                        Learn more about term life insurance and the plans and options you have available.
-                      </PublicTypeComponent>
-                    </NavLink>
-                    <div
-                      className="dropdownNavChild"
-                    >
-                      <PublicTypeComponent>
                         <NavLink
-                          href="/why-ethos/"
+                          href="/insurance/term-life-insurance/"
                         >
-                          Why Ethos
+                          <PublicTypeComponent>
+                            Our plans
+                          </PublicTypeComponent>
+                          <PublicSpacerComponent />
+                          <PublicTypeComponent
+                            color="GraySecondary"
+                          >
+                            Learn more about term life insurance and the plans and options you have available.
+                          </PublicTypeComponent>
                         </NavLink>
-                      </PublicTypeComponent>
-                    </div>
-                    <div
-                      className="dropdownNavChild"
-                    >
-                      <PublicTypeComponent>
-                        <NavLink
-                          href="/why-ethos/"
+                      </div>
+                      <div
+                        className="dropdownNavChildrenItems"
+                      >
+                        <div
+                          className="dropdownNavChild"
                         >
-                          Why Ethos
-                        </NavLink>
-                      </PublicTypeComponent>
-                    </div>
-                    <div
-                      className="dropdownNavChild"
-                    >
-                      <PublicTypeComponent>
-                        <NavLink
-                          href="/why-ethos/"
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/life/ethos-term-insurance/"
+                            >
+                              What is term life insurance and how much does it cost?
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
                         >
-                          Why Ethos
-                        </NavLink>
-                      </PublicTypeComponent>
-                    </div>
-                    <div
-                      className="dropdownNavChild"
-                    >
-                      <PublicTypeComponent>
-                        <NavLink
-                          href="/why-ethos/"
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/how-it-works/"
+                            >
+                              How our application process works
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
                         >
-                          Why Ethos
-                        </NavLink>
-                      </PublicTypeComponent>
-                    </div>
-                    <div
-                      className="dropdownNavChild"
-                    >
-                      <PublicTypeComponent>
-                        <NavLink
-                          href="/why-ethos/"
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/life/who-needs-life-insurance/"
+                            >
+                              Do I need life insurance?
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
                         >
-                          Why Ethos
-                        </NavLink>
-                      </PublicTypeComponent>
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/life/how-choose-right-type-life-insurance/"
+                            >
+                              Choosing your coverage amount and term length
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/app/needs/"
+                            >
+                              Coverage calculator
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                      </div>
                     </div>
                   </HorizontallyPaddedContainer>
                 </div>
@@ -442,7 +454,18 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                 >
                   <HorizontallyPaddedContainer
                     element="div"
-                  />
+                  >
+                    <div
+                      className="dropdownNavChildrenInner"
+                    >
+                      <div
+                        className="dropdownNavChildrenCta"
+                      />
+                      <div
+                        className="dropdownNavChildrenItems"
+                      />
+                    </div>
+                  </HorizontallyPaddedContainer>
                 </div>
               </div>
               <div
@@ -456,7 +479,18 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                 >
                   <HorizontallyPaddedContainer
                     element="div"
-                  />
+                  >
+                    <div
+                      className="dropdownNavChildrenInner"
+                    >
+                      <div
+                        className="dropdownNavChildrenCta"
+                      />
+                      <div
+                        className="dropdownNavChildrenItems"
+                      />
+                    </div>
+                  </HorizontallyPaddedContainer>
                 </div>
               </div>
               <div
@@ -470,7 +504,18 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                 >
                   <HorizontallyPaddedContainer
                     element="div"
-                  />
+                  >
+                    <div
+                      className="dropdownNavChildrenInner"
+                    >
+                      <div
+                        className="dropdownNavChildrenCta"
+                      />
+                      <div
+                        className="dropdownNavChildrenItems"
+                      />
+                    </div>
+                  </HorizontallyPaddedContainer>
                 </div>
               </div>
             </div>

--- a/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
+++ b/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
@@ -136,7 +136,63 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
               </div>
               <div
                 className="accordionChildren"
-              />
+              >
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/life/term-group-whole/"
+                    >
+                      What are the main types of life insurance and how do they work?
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/life/underwriting-explained/"
+                    >
+                      What is underwriting and how long does it take?
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/life/pick-beneficiary/"
+                    >
+                      Choosing your beneficiary
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/life/who-needs-sp/"
+                    >
+                      What if I don't work?
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/life/employer-sponsored-life-insurance/"
+                    >
+                      Is my life insurance through work enough?
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+              </div>
             </div>
             <div
               className="accordionItem"
@@ -155,7 +211,63 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
               </div>
               <div
                 className="accordionChildren"
-              />
+              >
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/about/"
+                    >
+                      Our mission
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/reviews/"
+                    >
+                      Reviews
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/life/customer-stories/"
+                    >
+                      Customer stories
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/life/ethosforgood/"
+                    >
+                      Ethos for Good
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/friends/"
+                    >
+                      Refer a friend
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+              </div>
             </div>
             <div
               className="accordionItem"
@@ -174,7 +286,63 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
               </div>
               <div
                 className="accordionChildren"
-              />
+              >
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/faq/life-insurance-basics/"
+                    >
+                      Questions about life insurance
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/faq/ethos/"
+                    >
+                      Questions about Ethos
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/faq/application/"
+                    >
+                      Questions about your application
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/faq/policy/"
+                    >
+                      Questions about your policy
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+                <div
+                  className="accordionChild"
+                >
+                  <PublicTypeComponent>
+                    <NavLink
+                      href="/contact-us/"
+                    >
+                      Contact us
+                    </NavLink>
+                  </PublicTypeComponent>
+                </div>
+              </div>
             </div>
           </div>
           <div
@@ -488,10 +656,98 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                     >
                       <div
                         className="dropdownNavChildrenCta"
-                      />
+                      >
+                        <NavLink
+                          href="/life/life-insurance-basics/"
+                        >
+                          <PublicTypeComponent>
+                            <span>
+                              Life insurance 101
+                            </span>
+                            <DropdownLinkIcon />
+                          </PublicTypeComponent>
+                          <PublicSpacerComponent />
+                          <PublicTypeComponent
+                            color="GraySecondary"
+                          >
+                            Wondering where to start? We’ve broken down the essentials for you.
+                          </PublicTypeComponent>
+                        </NavLink>
+                      </div>
                       <div
                         className="dropdownNavChildrenItems"
-                      />
+                      >
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/life/term-group-whole/"
+                            >
+                              <span>
+                                What are the main types of life insurance and how do they work?
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/life/underwriting-explained/"
+                            >
+                              <span>
+                                What is underwriting and how long does it take?
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/life/pick-beneficiary/"
+                            >
+                              <span>
+                                Choosing your beneficiary
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/life/who-needs-sp/"
+                            >
+                              <span>
+                                What if I don't work?
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/life/employer-sponsored-life-insurance/"
+                            >
+                              <span>
+                                Is my life insurance through work enough?
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                      </div>
                     </div>
                   </HorizontallyPaddedContainer>
                 </div>
@@ -518,10 +774,98 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                     >
                       <div
                         className="dropdownNavChildrenCta"
-                      />
+                      >
+                        <NavLink
+                          href="/why-ethos/"
+                        >
+                          <PublicTypeComponent>
+                            <span>
+                              The Ethos Difference
+                            </span>
+                            <DropdownLinkIcon />
+                          </PublicTypeComponent>
+                          <PublicSpacerComponent />
+                          <PublicTypeComponent
+                            color="GraySecondary"
+                          >
+                            We put people before profit. Find out how we bring our policyholders the best experience possible.
+                          </PublicTypeComponent>
+                        </NavLink>
+                      </div>
                       <div
                         className="dropdownNavChildrenItems"
-                      />
+                      >
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/about/"
+                            >
+                              <span>
+                                Our mission
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/reviews/"
+                            >
+                              <span>
+                                Reviews
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/life/customer-stories/"
+                            >
+                              <span>
+                                Customer stories
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/life/ethosforgood/"
+                            >
+                              <span>
+                                Ethos for Good
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/friends/"
+                            >
+                              <span>
+                                Refer a friend
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                      </div>
                     </div>
                   </HorizontallyPaddedContainer>
                 </div>
@@ -548,10 +892,98 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                     >
                       <div
                         className="dropdownNavChildrenCta"
-                      />
+                      >
+                        <NavLink
+                          href="/faq/"
+                        >
+                          <PublicTypeComponent>
+                            <span>
+                              FAQ
+                            </span>
+                            <DropdownLinkIcon />
+                          </PublicTypeComponent>
+                          <PublicSpacerComponent />
+                          <PublicTypeComponent
+                            color="GraySecondary"
+                          >
+                            Life insurance can be complicated, but don’t worry. We’re here to help answer your questions.
+                          </PublicTypeComponent>
+                        </NavLink>
+                      </div>
                       <div
                         className="dropdownNavChildrenItems"
-                      />
+                      >
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/faq/life-insurance-basics/"
+                            >
+                              <span>
+                                Questions about life insurance
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/faq/ethos/"
+                            >
+                              <span>
+                                Questions about Ethos
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/faq/application/"
+                            >
+                              <span>
+                                Questions about your application
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/faq/policy/"
+                            >
+                              <span>
+                                Questions about your policy
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                        <div
+                          className="dropdownNavChild"
+                        >
+                          <PublicTypeComponent>
+                            <NavLink
+                              href="/contact-us/"
+                            >
+                              <span>
+                                Contact us
+                              </span>
+                              <DropdownLinkIcon />
+                            </NavLink>
+                          </PublicTypeComponent>
+                        </div>
+                      </div>
                     </div>
                   </HorizontallyPaddedContainer>
                 </div>

--- a/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
+++ b/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
@@ -353,6 +353,11 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
               >
                 <PublicTypeComponent>
                   What we offer
+                  <span
+                    className="dropdownNavParentIcon"
+                  >
+                    <DropdownParentIcon />
+                  </span>
                 </PublicTypeComponent>
                 <div
                   className="dropdownNavChildren"
@@ -370,7 +375,10 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                           href="/insurance/term-life-insurance/"
                         >
                           <PublicTypeComponent>
-                            Our plans
+                            <span>
+                              Our plans
+                            </span>
+                            <DropdownLinkIcon />
                           </PublicTypeComponent>
                           <PublicSpacerComponent />
                           <PublicTypeComponent
@@ -390,7 +398,10 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                             <NavLink
                               href="/life/ethos-term-insurance/"
                             >
-                              What is term life insurance and how much does it cost?
+                              <span>
+                                What is term life insurance and how much does it cost?
+                              </span>
+                              <DropdownLinkIcon />
                             </NavLink>
                           </PublicTypeComponent>
                         </div>
@@ -401,7 +412,10 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                             <NavLink
                               href="/how-it-works/"
                             >
-                              How our application process works
+                              <span>
+                                How our application process works
+                              </span>
+                              <DropdownLinkIcon />
                             </NavLink>
                           </PublicTypeComponent>
                         </div>
@@ -412,7 +426,10 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                             <NavLink
                               href="/life/who-needs-life-insurance/"
                             >
-                              Do I need life insurance?
+                              <span>
+                                Do I need life insurance?
+                              </span>
+                              <DropdownLinkIcon />
                             </NavLink>
                           </PublicTypeComponent>
                         </div>
@@ -423,7 +440,10 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                             <NavLink
                               href="/life/how-choose-right-type-life-insurance/"
                             >
-                              Choosing your coverage amount and term length
+                              <span>
+                                Choosing your coverage amount and term length
+                              </span>
+                              <DropdownLinkIcon />
                             </NavLink>
                           </PublicTypeComponent>
                         </div>
@@ -434,7 +454,10 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
                             <NavLink
                               href="/app/needs/"
                             >
-                              Coverage calculator
+                              <span>
+                                Coverage calculator
+                              </span>
+                              <DropdownLinkIcon />
                             </NavLink>
                           </PublicTypeComponent>
                         </div>
@@ -448,6 +471,11 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
               >
                 <PublicTypeComponent>
                   Life insurance basics
+                  <span
+                    className="dropdownNavParentIcon"
+                  >
+                    <DropdownParentIcon />
+                  </span>
                 </PublicTypeComponent>
                 <div
                   className="dropdownNavChildren"
@@ -473,6 +501,11 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
               >
                 <PublicTypeComponent>
                   Why Ethos
+                  <span
+                    className="dropdownNavParentIcon"
+                  >
+                    <DropdownParentIcon />
+                  </span>
                 </PublicTypeComponent>
                 <div
                   className="dropdownNavChildren"
@@ -498,6 +531,11 @@ exports[`<UniversalNavbarExpanded> matches snapshot with no arguments 1`] = `
               >
                 <PublicTypeComponent>
                   Help Center
+                  <span
+                    className="dropdownNavParentIcon"
+                  >
+                    <DropdownParentIcon />
+                  </span>
                 </PublicTypeComponent>
                 <div
                   className="dropdownNavChildren"

--- a/src/components/UniversalNavbarExpanded/constants.js
+++ b/src/components/UniversalNavbarExpanded/constants.js
@@ -30,34 +30,35 @@ export const LINKS = {
         cta: {
           href: '/insurance/term-life-insurance/',
           title: 'Our plans',
-          subcopy: 'Learn more about term life insurance and the plans and options you have available.',
+          subcopy:
+            'Learn more about term life insurance and the plans and options you have available.',
           id: uuidv4(),
         },
         items: [
           {
             id: uuidv4(),
-            href: '/why-ethos/',
-            title: 'Why Ethos',
+            href: '/life/ethos-term-insurance/',
+            title: 'What is term life insurance and how much does it cost?',
           },
           {
             id: uuidv4(),
-            href: '/why-ethos/',
-            title: 'Why Ethos',
+            href: '/how-it-works/',
+            title: 'How our application process works',
           },
           {
             id: uuidv4(),
-            href: '/why-ethos/',
-            title: 'Why Ethos',
+            href: '/life/who-needs-life-insurance/',
+            title: 'Do I need life insurance?',
           },
           {
             id: uuidv4(),
-            href: '/why-ethos/',
-            title: 'Why Ethos',
+            href: '/life/how-choose-right-type-life-insurance/',
+            title: 'Choosing your coverage amount and term length',
           },
           {
             id: uuidv4(),
-            href: '/why-ethos/',
-            title: 'Why Ethos',
+            href: '/app/needs/',
+            title: 'Coverage calculator',
           },
         ],
       },

--- a/src/components/UniversalNavbarExpanded/constants.js
+++ b/src/components/UniversalNavbarExpanded/constants.js
@@ -65,18 +65,127 @@ export const LINKS = {
     },
     {
       id: uuidv4(),
-      href: '/life/life-insurance-basics/',
+      href: null,
       title: 'Life insurance basics',
+      subnav: {
+        cta: {
+          href: '/life/life-insurance-basics/',
+          title: 'Life insurance 101',
+          subcopy:
+            'Wondering where to start? We’ve broken down the essentials for you.',
+          id: uuidv4(),
+        },
+        items: [
+          {
+            id: uuidv4(),
+            href: '/life/term-group-whole/',
+            title:
+              'What are the main types of life insurance and how do they work?',
+          },
+          {
+            id: uuidv4(),
+            href: '/life/underwriting-explained/',
+            title: 'What is underwriting and how long does it take?',
+          },
+          {
+            id: uuidv4(),
+            href: '/life/pick-beneficiary/',
+            title: 'Choosing your beneficiary',
+          },
+          {
+            id: uuidv4(),
+            href: '/life/who-needs-sp/',
+            title: "What if I don't work?",
+          },
+          {
+            id: uuidv4(),
+            href: '/life/employer-sponsored-life-insurance/',
+            title: 'Is my life insurance through work enough?',
+          },
+        ],
+      },
     },
     {
       id: uuidv4(),
-      href: '/why-ethos/',
+      href: null,
       title: 'Why Ethos',
+      subnav: {
+        cta: {
+          href: '/why-ethos/',
+          title: 'The Ethos Difference',
+          subcopy:
+            'We put people before profit. Find out how we bring our policyholders the best experience possible.',
+          id: uuidv4(),
+        },
+        items: [
+          {
+            id: uuidv4(),
+            href: '/about/',
+            title: 'Our mission',
+          },
+          {
+            id: uuidv4(),
+            href: '/reviews/',
+            title: 'Reviews',
+          },
+          {
+            id: uuidv4(),
+            href: '/life/customer-stories/',
+            title: 'Customer stories',
+          },
+          {
+            id: uuidv4(),
+            href: '/life/ethosforgood/',
+            title: 'Ethos for Good',
+          },
+          {
+            id: uuidv4(),
+            href: '/friends/',
+            title: 'Refer a friend',
+          },
+        ],
+      },
     },
     {
       id: uuidv4(),
-      href: '/faq/',
+      href: null,
       title: 'Help Center',
+      subnav: {
+        cta: {
+          href: '/faq/',
+          title: 'FAQ',
+          subcopy:
+            'Life insurance can be complicated, but don’t worry. We’re here to help answer your questions.',
+          id: uuidv4(),
+        },
+        items: [
+          {
+            id: uuidv4(),
+            href: '/faq/life-insurance-basics/',
+            title: 'Questions about life insurance',
+          },
+          {
+            id: uuidv4(),
+            href: '/faq/ethos/',
+            title: 'Questions about Ethos',
+          },
+          {
+            id: uuidv4(),
+            href: '/faq/application/',
+            title: 'Questions about your application',
+          },
+          {
+            id: uuidv4(),
+            href: '/faq/policy/',
+            title: 'Questions about your policy',
+          },
+          {
+            id: uuidv4(),
+            href: '/contact-us/',
+            title: 'Contact us',
+          },
+        ],
+      },
     },
   ],
 }

--- a/src/components/UniversalNavbarExpanded/constants.js
+++ b/src/components/UniversalNavbarExpanded/constants.js
@@ -1,0 +1,81 @@
+import uuidv4 from 'uuid/v4'
+export const LINKS = {
+  // These are used e.g. in the logo, icons and bottom of mobile nav:
+  INDEX: { href: '/' },
+  TERM: {
+    href: '/term',
+    title: 'Get covered',
+  },
+  // TALK: {
+  //     id: uuidv4(),
+  //     href: '/',
+  //     title: 'Talk to us',
+  //   },
+  ACCOUNT: {
+    href: '/login/',
+    title: 'Account',
+  },
+  SEARCH: {
+    href: '/search/',
+    title: 'Search',
+  },
+
+  // These are the main top level link and their subnav items
+  NAVLINKS: [
+    {
+      id: uuidv4(),
+      href: null,
+      title: 'What we offer',
+      subnav: {
+        cta: {
+          href: '/insurance/term-life-insurance/',
+          title: 'Our plans',
+          subcopy: 'Learn more about term life insurance and the plans and options you have available.',
+          id: uuidv4(),
+        },
+        items: [
+          {
+            id: uuidv4(),
+            href: '/why-ethos/',
+            title: 'Why Ethos',
+          },
+          {
+            id: uuidv4(),
+            href: '/why-ethos/',
+            title: 'Why Ethos',
+          },
+          {
+            id: uuidv4(),
+            href: '/why-ethos/',
+            title: 'Why Ethos',
+          },
+          {
+            id: uuidv4(),
+            href: '/why-ethos/',
+            title: 'Why Ethos',
+          },
+          {
+            id: uuidv4(),
+            href: '/why-ethos/',
+            title: 'Why Ethos',
+          },
+        ],
+      },
+    },
+    {
+      id: uuidv4(),
+      href: '/life/life-insurance-basics/',
+      title: 'Life insurance basics',
+    },
+    {
+      id: uuidv4(),
+      href: '/why-ethos/',
+      title: 'Why Ethos',
+    },
+    {
+      id: uuidv4(),
+      href: '/faq/',
+      title: 'Help Center',
+    },
+  ],
+}

--- a/src/components/UniversalNavbarExpanded/constants.js
+++ b/src/components/UniversalNavbarExpanded/constants.js
@@ -4,7 +4,7 @@ export const LINKS = {
   INDEX: { href: '/' },
   TERM: {
     href: '/term',
-    title: 'Get covered',
+    title: 'Check my price',
   },
   // TALK: {
   //     id: uuidv4(),

--- a/src/components/design-system.css
+++ b/src/components/design-system.css
@@ -246,7 +246,7 @@ a:hover {
    * Region:
    * Fancy animated scroll behavior
    */
-@media (max-width: 599px) {
+@media (max-width: 899px) {
   .letter:not(.fancyO) {
     transition-property: all;
     transition-timing-function: ease-in-out;

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -11,6 +11,15 @@ declare class UniversalNavbar extends React.Component {
 }
 export { UniversalNavbar }
 
+declare class UniversalNavbarExpanded extends React.Component {
+  state: {
+    showMobileMenu: boolean
+  }
+  toggleHamburger: () => void
+  render(): JSX.Element
+}
+export { UniversalNavbarExpanded }
+
 export { Layout } from './Layout/index.js'
 
 // TODO -- DELETE THIS -- NOT GOING TO EXPORT DEPRECATED MEDIA

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -45,6 +45,7 @@ export {
   Link,
 } from './Type'
 export { UniversalNavbar } from './UniversalNavbar/UniversalNavbar'
+export { UniversalNavbarExpanded } from './UniversalNavbarExpanded/UniversalNavbarExpanded'
 export { ValueProps } from './ValueProps'
 export { ZipInput } from './ZipInput'
 export { Modal } from './Modal'


### PR DESCRIPTION
- [x] Bump version!

**Description:**
- Disclaimer: This work is a bit rushed so there is a lit of fast follow items documented at the bottom of the description which are being targeted for deployment Wednesday. They will increase the code quality and readability as well as address some minor design QA concerns. 
- Stakeholders are pushing to get this live in it's current state today (March 2nd). They've sat through a manual QA with me where we tested all the features on a CMS deploy preview.
- Mono should not be impacted until EDS version is bumped and even then nothing should visibly change.
- [Asana Task](https://app.asana.com/0/1116481661798430/1158569544825133/f)
- Adds `UniversalNavbarExpanded` for use on CMS in place of `UniversalNavbar`.
- The _very large diff deltas_ are explained in part by the new component's core .js and .scss files taking up ~750 new lines and the .snap adding ~1000 new lines.

**Is this a new component? Please review these reminders:**
It's an extended version of an existing component. The plan is to test this extended version on CMS and eventually consolidate with the existing component for use on both Mono & CMS. For now they share some assets but the extended version has a different set of core component files.

- [x] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [x] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
> Yes but it's not fully correct. Non-blocking.
- [x] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?

**Referencing PR or Branch (e.g. in CMS or monorepo):**
- https://deploy-preview-2781--ethos-cms.netlify.com/
- https://github.com/getethos/cms/pull/2781

**Screenshots:**
![Screen Shot 2020-03-02 at 5 25 55 PM](https://user-images.githubusercontent.com/4285270/75733740-e7b7ce80-5caa-11ea-95f2-896138dd8435.png)
![Screen Shot 2020-03-02 at 5 25 39 PM](https://user-images.githubusercontent.com/4285270/75733742-e8506500-5caa-11ea-9a8a-4136b5294ebe.png)
![Screen Shot 2020-03-02 at 5 25 27 PM](https://user-images.githubusercontent.com/4285270/75733743-e8e8fb80-5caa-11ea-87a7-deaadb7965d4.png)
![Screen Shot 2020-03-02 at 5 25 18 PM](https://user-images.githubusercontent.com/4285270/75733744-e8e8fb80-5caa-11ea-96d3-2ef58278c6f8.png)
![Screen Shot 2020-03-02 at 5 25 13 PM](https://user-images.githubusercontent.com/4285270/75733746-e9819200-5caa-11ea-8eaf-f5052c5d108e.png)
![Screen Shot 2020-03-02 at 5 24 56 PM](https://user-images.githubusercontent.com/4285270/75733747-e9819200-5caa-11ea-8eef-63de08620ce4.png)
![Screen Shot 2020-03-02 at 5 24 51 PM](https://user-images.githubusercontent.com/4285270/75733748-ea1a2880-5caa-11ea-98ee-27c6b7792738.png)
![Screen Shot 2020-03-02 at 5 24 44 PM](https://user-images.githubusercontent.com/4285270/75733749-ea1a2880-5caa-11ea-87d9-68f9156a3383.png)

**Fast Follow ToDos**
Will add review comments that are not resolved below to this list.
Also includes sub-tasks from the Asana ticket prefixed with `3/2/20 QA`
- Proper typescript types export.
```
// TODO: Dry up this prop usage for NavLink
// LinkComponent={
//   link.href !== '/login/'
//     ? LinkComponent
//     : null
// }

// TODO: more spacing var usage in scss
// TODO: less nesting in scss
// TODO: replace white with color var in scss
// TODO: 504px that's an odd value
// TODO: alternate caret weight for DropdownParentIcon pre:hover
// TODO: 'talk to us' CTA integration once Kustomer is implemented
// TODO: adjust width of bottom forest border on parent links
// TODO: smallest laptop size, lower width between subitems w/shorter text
// TODO: set subnav height to largest
// TODO: arrow on same line as individual link
// TODO: replace blue outline on focus with cleaner white underline
// TODO: remove clickability of right side of accordion submenu
// TODO: 3/2/20 QA: Add 1px stroke (#000000 20%) beneath default navbar and underneath dropdown when it's open (low priority)
// TODO: 3/2/20 QA: Reduce padding between "check my price" CTA and hamburger icon on scrolled mobile nav (low priority)
// TODO: 3/2/20 QA: Side arrow breaks to new line for one of the menu items on laptop size (low priority)
// TODO: right 44px override not working for scrolled CTA in navbar on mobile
// TODO:  Create a constant for the 13 keycode
// TODO:  Do an array and join(' ') like in the other components for classNames
// TODO:  Make a helper function that checks for /login/
// TODO:  Split main file into separate components
// TODO:  Update test descriptions / more tests
// TODO:  Implement lodash/get usage for nested props
// TODO:  FancyAnimatedLogo functional component
// TODO:  use .map instead of checking for .length > 0 (2 places)
// TODO:  z index variables
// TODO:  JS Docs
// TODO:  more code commenting in general
// TODO:  PropTypes review
// TODO:  LINKS constant passed in from CMS

// TODO: convert from class to hook?
```