### PR TITLE
v1.1.104

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.103",
+  "version": "1.1.104",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",


### PR DESCRIPTION
In the hustle and bustle of #274 I forgot to merge master before `yarn version` and didn't bump to the newest version number. This PR bumps from v1.1.103 to v1.1.104. 

The real 103 hit before #274 was merged: https://github.com/getethos/ethos-design-system/commit/c34a46ab8ddc35d87ed54ea8c3c62f5d722ee668