### PR TITLE
Remove extra prop in NoraDrawer type definition

### DIFF
--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -1020,7 +1020,6 @@ export declare const NoraDrawer: {
     onDismiss,
     isOpen,
     position,
-    className,
     labelCopy,
     closeCopy,
   }: {
@@ -1030,7 +1029,6 @@ export declare const NoraDrawer: {
     labelCopy: string
     closeCopy: string
     position?: string
-    className?: string
   }): JSX.Element
   propTypes: {
     props: any


### PR DESCRIPTION
**Description:**

- Noticed this when consuming the `NoraDrawer` in the main app. 
- This is a simple fix and does NOT require a new release.

**Screenshots:**
