### PR TITLE
UniversalNavbarExpanded PropType comments & currentPage renames

### DIFF
--- a/src/components/UniversalNavbarExpanded/MobileNav/AccordionNav.js
+++ b/src/components/UniversalNavbarExpanded/MobileNav/AccordionNav.js
@@ -24,8 +24,8 @@ import styles from './AccordionNav.module.scss'
  *
  * @param {string} extraClass - Extra top level class
  * @param {object} links - URLs and text
- * @param {boolean} navVisible - Condition to check before executing samePageFunction
- * @param {function} samePageFunction - Function to execute when navigating to link of present page
+ * @param {boolean} navVisible - Condition to check before executing currentPageFunction
+ * @param {function} currentPageFunction - Function to execute when navigating to link of present page
  * @param {object} LinkComponent - Agnotistic Reach and React Router Link (ex. Gatsby's <Link>)
  *
  * @return {JSX.Element}
@@ -34,7 +34,7 @@ const AccordionNav = ({
   extraClass,
   links,
   navVisible,
-  samePageFunction,
+  currentPageFunction,
   LinkComponent,
 }) => {
   const [activeAccordionItem, setActiveAccordionItem] = useState(false)
@@ -93,9 +93,9 @@ const AccordionNav = ({
               <TitleSmall.Sans.Light300>
                 <NavLink
                   href={get(link, 'subnav.cta.href')}
-                  samePageAwareness={true}
-                  samePageFunction={(e) => samePageFunction(e)}
-                  samePageCondition={navVisible}
+                  currentPageAwareness={true}
+                  currentPageFunction={(e) => currentPageFunction(e)}
+                  currentPageCondition={navVisible}
                   LinkComponent={LinkComponent}
                 >
                   {get(link, 'subnav.cta.title')}
@@ -107,9 +107,9 @@ const AccordionNav = ({
                 <TitleSmall.Sans.Light300>
                   <NavLink
                     href={link.href}
-                    samePageAwareness={true}
-                    samePageFunction={(e) => samePageFunction(e)}
-                    samePageCondition={navVisible}
+                    currentPageAwareness={true}
+                    currentPageFunction={(e) => currentPageFunction(e)}
+                    currentPageCondition={navVisible}
                     LinkComponent={LinkComponent}
                   >
                     {link.title}
@@ -128,7 +128,7 @@ AccordionNav.propTypes = {
   extraClass: PropTypes.string,
   links: PropTypes.object.isRequired,
   navVisible: PropTypes.bool,
-  samePageFunction: PropTypes.func,
+  currentPageFunction: PropTypes.func,
   LinkComponent: PropTypes.object,
 }
 

--- a/src/components/UniversalNavbarExpanded/MobileNav/MobileNav.js
+++ b/src/components/UniversalNavbarExpanded/MobileNav/MobileNav.js
@@ -116,9 +116,9 @@ const MobileNav = ({
           <NavLink
             className={styles.phoneLogo}
             href={logoHref}
-            samePageAwareness={true}
-            samePageFunction={(e) => toggleHamburger(e)}
-            samePageCondition={showMobileMenu}
+            currentPageAwareness={true}
+            currentPageFunction={(e) => toggleHamburger(e)}
+            currentPageCondition={showMobileMenu}
             LinkComponent={LinkComponent}
           >
             {LogoWhite({ className: styles.logo })}
@@ -127,24 +127,24 @@ const MobileNav = ({
           <AccordionNav
             extraClass={styles.accordion}
             links={links}
-            samePageFunction={(e) => toggleHamburger(e)}
+            currentPageFunction={(e) => toggleHamburger(e)}
             navVisible={showMobileMenu}
             LinkComponent={LinkComponent}
           />
           <SecondaryLinks
             links={secondaryLinksLinks}
             className={styles.secondaryLinks}
-            samePageFunction={(e) => toggleHamburger(e)}
-            samePageCondition={showMobileMenu}
+            currentPageFunction={(e) => toggleHamburger(e)}
+            currentPageCondition={showMobileMenu}
             LinkComponent={LinkComponent}
           />
         </div>
         <NavLink
           className={styles.phoneLogoFancy}
           href={logoHref}
-          samePageAwareness={true}
-          samePageFunction={(e) => toggleHamburger(e)}
-          samePageCondition={showMobileMenu}
+          currentPageAwareness={true}
+          currentPageFunction={(e) => toggleHamburger(e)}
+          currentPageCondition={showMobileMenu}
           LinkComponent={LinkComponent}
         >
           <FancyAnimatedLogo />

--- a/src/components/UniversalNavbarExpanded/MobileNav/SecondaryLinks.js
+++ b/src/components/UniversalNavbarExpanded/MobileNav/SecondaryLinks.js
@@ -15,8 +15,8 @@ import styles from './SecondaryLinks.module.scss'
  *
  * @param {array} links - URLs and text
  * @param {string} className - Extra top level class
- * @param {boolean} samePageCondition - Condition to check before executing samePageFunction
- * @param {function} samePageFunction - Function to execute when navigating to link of present page
+ * @param {boolean} currentPageCondition - Condition to check before executing currentPageFunction
+ * @param {function} currentPageFunction - Function to execute when navigating to link of present page
  * @param {object} LinkComponent - Agnotistic Reach and React Router Link (ex. Gatsby's <Link>)
  *
  * @return {JSX.Element}
@@ -24,8 +24,8 @@ import styles from './SecondaryLinks.module.scss'
 const SecondaryLinks = ({
   links,
   className,
-  samePageCondition,
-  samePageFunction,
+  currentPageCondition,
+  currentPageFunction,
   LinkComponent,
 }) => {
   const classes = [styles.secondaryLinks]
@@ -41,9 +41,9 @@ const SecondaryLinks = ({
         >
           <NavLink
             href={link.href}
-            samePageFunction={(e) => samePageFunction(e)}
-            samePageCondition={samePageCondition}
-            samePageAwareness={true}
+            currentPageFunction={(e) => currentPageFunction(e)}
+            currentPageCondition={currentPageCondition}
+            currentPageAwareness={true}
             LinkComponent={LinkComponent}
           >
             <TitleMedium.Sans.Regular400>
@@ -59,8 +59,8 @@ const SecondaryLinks = ({
 SecondaryLinks.propTypes = {
   links: PropTypes.array.isRequired,
   className: PropTypes.string,
-  samePageCondition: PropTypes.bool,
-  samePageFunction: PropTypes.func,
+  currentPageCondition: PropTypes.bool,
+  currentPageFunction: PropTypes.func,
   LinkComponent: PropTypes.object,
 }
 

--- a/src/components/UniversalNavbarExpanded/NavLink.js
+++ b/src/components/UniversalNavbarExpanded/NavLink.js
@@ -16,8 +16,8 @@ import { preventCurrentPageNavigation } from '../../helpers/preventCurrentPageNa
  * @param {string|object} className - Optional className
  * @param {string} key - Unique differentiator for multiple instances of component (hint: uuid)
  * @param {string} href - URL for the link
- * @param {boolean} samePageAwareness - Enable an onClick & onKeyPress listener
- * @param {function} samePageFunction - Use with samePageAwareness to handle onClick & onKeyPress
+ * @param {boolean} currentPageAwareness - Enable an onClick & onKeyPress listener
+ * @param {function} currentPageFunction - Use with currentPageAwareness to handle onClick & onKeyPress
  * @param {object} component - Agnotistic Reach and React Router Link (ex. Gatsby's <Link>)
  * @param {ReactNode} children - Children to render within the link
  *
@@ -27,13 +27,13 @@ const NavLink = ({
   className,
   key,
   href,
-  samePageAwareness,
-  samePageFunction,
-  samePageCondition,
+  currentPageAwareness,
+  currentPageFunction,
+  currentPageCondition,
   LinkComponent,
   children,
 }) => {
-  if (samePageAwareness) {
+  if (currentPageAwareness) {
     return (
       <BaseNavLink
         className={className || null}
@@ -45,8 +45,8 @@ const NavLink = ({
             event: e,
             href: href,
             keyPress: false,
-            samePageFunction: samePageFunction,
-            samePageCondition: samePageCondition,
+            currentPageFunction: currentPageFunction,
+            currentPageCondition: currentPageCondition,
           })
         }}
         onKeyPress={(e) =>
@@ -54,8 +54,8 @@ const NavLink = ({
             event: e,
             href: href,
             keyPress: true,
-            samePageFunction: samePageFunction,
-            samePageCondition: samePageCondition,
+            currentPageFunction: currentPageFunction,
+            currentPageCondition: currentPageCondition,
           })
         }
       >
@@ -81,9 +81,9 @@ NavLink.propTypes = {
   className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   key: PropTypes.string,
   href: PropTypes.string.isRequired,
-  samePageAwareness: PropTypes.bool,
-  samePageFunction: PropTypes.func,
-  samePageCondition: PropTypes.bool,
+  currentPageAwareness: PropTypes.bool,
+  currentPageFunction: PropTypes.func,
+  currentPageCondition: PropTypes.bool,
   LinkComponent: PropTypes.object,
   children: PropTypes.node.isRequired,
 }

--- a/src/components/UniversalNavbarExpanded/SampleContent.js
+++ b/src/components/UniversalNavbarExpanded/SampleContent.js
@@ -25,7 +25,6 @@ export const CMS_LINKS = {
   NAVLINKS: [
     {
       id: 'NAVLINKS_MOCK_ID_1',
-      href: null,
       title: 'What we offer',
       subnav: {
         cta: {
@@ -66,7 +65,6 @@ export const CMS_LINKS = {
     },
     {
       id: 'NAVLINKS_MOCK_ID_8',
-      href: null,
       title: 'Life insurance basics',
       subnav: {
         cta: {
@@ -108,7 +106,6 @@ export const CMS_LINKS = {
     },
     {
       id: 'NAVLINKS_MOCK_ID_15',
-      href: null,
       title: 'Why Ethos',
       subnav: {
         cta: {
@@ -149,7 +146,6 @@ export const CMS_LINKS = {
     },
     {
       id: 'NAVLINKS_MOCK_ID_22',
-      href: null,
       title: 'Help Center',
       subnav: {
         cta: {

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -119,18 +119,32 @@ UniversalNavbarExpanded.propTypes = {
     INDEX: PropTypes.shape({
       href: PropTypes.string,
     }),
+    /** CTA button link & text { href: string, title: string } */
     CTA: PropTypes.shape({
       href: PropTypes.string,
       title: PropTypes.string,
     }),
+    /** Account link & text { href: string, title: string } */
     ACCOUNT: PropTypes.shape({
       href: PropTypes.string,
       title: PropTypes.string,
     }),
+    /** Search link & text { href: string, title: string } */
     SEARCH: PropTypes.shape({
       href: PropTypes.string,
       title: PropTypes.string,
     }),
+    /** Navigation URLs, ids & copy. Use the following shape:
+     * {
+     *   href: string,
+     *   title: string,
+     *   id: string,
+     *   subnav: {
+     *     cta: { href: string, title: string, id: string, subcopy: string },
+     *     items: array[{ href: string, title: string, id: string }],
+     *   }
+     * }
+     */
     NAVLINKS: PropTypes.arrayOf(
       PropTypes.shape({
         href: PropTypes.string,

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -141,7 +141,7 @@ UniversalNavbarExpanded.propTypes = {
      *   id: string,
      *   subnav: {
      *     cta: { href: string, title: string, id: string, subcopy: string },
-     *     items: array[{ href: string, title: string, id: string }],
+     *     items: array[{ href: string, title: string, id: string }]
      *   }
      * }
      */

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -134,9 +134,8 @@ UniversalNavbarExpanded.propTypes = {
       href: PropTypes.string,
       title: PropTypes.string,
     }),
-    /** Navigation URLs, ids & copy. Use the following shape:
+    /** Navigation URLs, ids & copy. Use the following shape for each array element:
      * {
-     *   href: string,
      *   title: string,
      *   id: string,
      *   subnav: {
@@ -147,7 +146,6 @@ UniversalNavbarExpanded.propTypes = {
      */
     NAVLINKS: PropTypes.arrayOf(
       PropTypes.shape({
-        href: PropTypes.string,
         title: PropTypes.string,
         id: PropTypes.string,
         subnav: PropTypes.shape({

--- a/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
+++ b/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
@@ -30,7 +30,6 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
             },
             "NAVLINKS": Array [
               Object {
-                "href": null,
                 "id": "NAVLINKS_MOCK_ID_1",
                 "subnav": Object {
                   "cta": Object {
@@ -70,7 +69,6 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                 "title": "What we offer",
               },
               Object {
-                "href": null,
                 "id": "NAVLINKS_MOCK_ID_8",
                 "subnav": Object {
                   "cta": Object {
@@ -110,7 +108,6 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                 "title": "Life insurance basics",
               },
               Object {
-                "href": null,
                 "id": "NAVLINKS_MOCK_ID_15",
                 "subnav": Object {
                   "cta": Object {
@@ -150,7 +147,6 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                 "title": "Why Ethos",
               },
               Object {
-                "href": null,
                 "id": "NAVLINKS_MOCK_ID_22",
                 "subnav": Object {
                   "cta": Object {
@@ -258,7 +254,6 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                   },
                   "NAVLINKS": Array [
                     Object {
-                      "href": null,
                       "id": "NAVLINKS_MOCK_ID_1",
                       "subnav": Object {
                         "cta": Object {
@@ -298,7 +293,6 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                       "title": "What we offer",
                     },
                     Object {
-                      "href": null,
                       "id": "NAVLINKS_MOCK_ID_8",
                       "subnav": Object {
                         "cta": Object {
@@ -338,7 +332,6 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                       "title": "Life insurance basics",
                     },
                     Object {
-                      "href": null,
                       "id": "NAVLINKS_MOCK_ID_15",
                       "subnav": Object {
                         "cta": Object {
@@ -378,7 +371,6 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                       "title": "Why Ethos",
                     },
                     Object {
-                      "href": null,
                       "id": "NAVLINKS_MOCK_ID_22",
                       "subnav": Object {
                         "cta": Object {

--- a/src/helpers/preventCurrentPageNavigation.js
+++ b/src/helpers/preventCurrentPageNavigation.js
@@ -1,8 +1,7 @@
 import { isEnterKeyPress } from './isEnterKeyPress'
 
 /**
- * Helper function to provide event handling for a user attempting to navigate
- * to the same page that they're already on.
+ * Helper function to provide event handling for a user attempting to navigate to the current page.
  *
  * In the code below we strip forward slashes from the path and href that we're comparing.
  * This is done to account for query parameters being appended without a trailing slash.
@@ -14,8 +13,8 @@ import { isEnterKeyPress } from './isEnterKeyPress'
  * @param {object} event - Event triggered by user interaction
  * @param {string} href - Relative URL for the link being clicked to cross check with window.location
  * @param {boolean} keyPress - Enable an onClick & onKeyPress listener
- * @param {function} samePageFunction - Function to execute when navigating to link of present page
- * @param {boolean} samePageCondition - Condition to check before executing samePageFunction
+ * @param {function} currentPageFunction - Function to execute when navigating to link of present page
+ * @param {boolean} currentPageCondition - Condition to check before executing currentPageFunction
  *
  * @return {void}
  */
@@ -23,12 +22,12 @@ export const preventCurrentPageNavigation = ({
   event,
   href,
   keyPress,
-  samePageFunction,
-  samePageCondition,
+  currentPageFunction,
+  currentPageCondition,
 }) => {
   if (
     typeof window === 'undefined' ||
-    !samePageCondition ||
+    !currentPageCondition ||
     (keyPress && !isEnterKeyPress(event))
   ) {
     return
@@ -48,6 +47,6 @@ export const preventCurrentPageNavigation = ({
   }
   if (path === strippedHref) {
     event.preventDefault()
-    samePageFunction()
+    currentPageFunction()
   }
 }

--- a/src/helpers/preventCurrentPageNavigation.test.js
+++ b/src/helpers/preventCurrentPageNavigation.test.js
@@ -41,8 +41,8 @@ describe('preventCurrentPageNavigation helper', () => {
       event: clickEvent,
       href: href,
       keyPress: false,
-      samePageFunction: testFunc,
-      samePageCondition: true,
+      currentPageFunction: testFunc,
+      currentPageCondition: true,
     })
     expect(testFunc).toHaveBeenCalled()
   })
@@ -55,8 +55,8 @@ describe('preventCurrentPageNavigation helper', () => {
       event: clickEvent,
       href: href,
       keyPress: false,
-      samePageFunction: testFunc,
-      samePageCondition: true,
+      currentPageFunction: testFunc,
+      currentPageCondition: true,
     })
     expect(testFunc).toHaveBeenCalled()
   })
@@ -69,8 +69,8 @@ describe('preventCurrentPageNavigation helper', () => {
       event: clickEvent,
       href: href,
       keyPress: false,
-      samePageFunction: testFunc,
-      samePageCondition: true,
+      currentPageFunction: testFunc,
+      currentPageCondition: true,
     })
     expect(testFunc).toHaveBeenCalled()
   })
@@ -83,8 +83,8 @@ describe('preventCurrentPageNavigation helper', () => {
       event: clickEvent,
       href: href,
       keyPress: false,
-      samePageFunction: testFunc,
-      samePageCondition: true,
+      currentPageFunction: testFunc,
+      currentPageCondition: true,
     })
     expect(testFunc).toHaveBeenCalled()
   })
@@ -97,8 +97,8 @@ describe('preventCurrentPageNavigation helper', () => {
       event: clickEvent,
       href: href,
       keyPress: false,
-      samePageFunction: testFunc,
-      samePageCondition: true,
+      currentPageFunction: testFunc,
+      currentPageCondition: true,
     })
     expect(testFunc).toHaveBeenCalled()
   })
@@ -112,8 +112,8 @@ describe('preventCurrentPageNavigation helper', () => {
       event: clickEvent,
       href: href,
       keyPress: false,
-      samePageFunction: testFunc,
-      samePageCondition: true,
+      currentPageFunction: testFunc,
+      currentPageCondition: true,
     })
     expect(testFunc).toHaveBeenCalled()
   })
@@ -124,8 +124,8 @@ describe('preventCurrentPageNavigation helper', () => {
       event: keyPressEvent,
       href: href,
       keyPress: true,
-      samePageFunction: testFunc,
-      samePageCondition: true,
+      currentPageFunction: testFunc,
+      currentPageCondition: true,
     })
     expect(testFunc).toHaveBeenCalled()
   })
@@ -137,20 +137,20 @@ describe('preventCurrentPageNavigation helper', () => {
       event: clickEvent,
       href: href,
       keyPress: false,
-      samePageFunction: testFunc,
-      samePageCondition: true,
+      currentPageFunction: testFunc,
+      currentPageCondition: true,
     })
     expect(testFunc).not.toHaveBeenCalled()
   })
 
-  it('should not fire for false samePageCondition', () => {
+  it('should not fire for false currentPageCondition', () => {
     const testFunc = jest.fn()
     preventCurrentPageNavigation({
       event: clickEvent,
       href: href,
       keyPress: false,
-      samePageFunction: testFunc,
-      samePageCondition: false,
+      currentPageFunction: testFunc,
+      currentPageCondition: false,
     })
     expect(testFunc).not.toHaveBeenCalled()
   })
@@ -161,8 +161,8 @@ describe('preventCurrentPageNavigation helper', () => {
       event: wrongKeyPressEvent,
       href: href,
       keyPress: true,
-      samePageFunction: testFunc,
-      samePageCondition: false,
+      currentPageFunction: testFunc,
+      currentPageCondition: false,
     })
     expect(testFunc).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
**Description:**
- Follow up to #279
- Renames some properties based on recent changes to helper name.
- Adds prop type comments to UniversalNavbarExpanded

**Screenshots:**
![Screen Shot 2020-03-06 at 2 14 59 PM](https://user-images.githubusercontent.com/4285270/76126779-e3dec180-5fb4-11ea-8a04-49d0282ddf56.png)
![Screen Shot 2020-03-06 at 2 15 44 PM](https://user-images.githubusercontent.com/4285270/76126819-fce77280-5fb4-11ea-9d91-1470b3a35d7c.png)
![Screen Shot 2020-03-06 at 2 15 36 PM](https://user-images.githubusercontent.com/4285270/76126821-fe189f80-5fb4-11ea-8c97-a5163d08f0e1.png)
