### PR TITLE
FloatingDrawerContentSelector prop for Drawers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.127",
+  "version": "1.1.128",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.125",
+  "version": "1.1.126",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.126",
+  "version": "1.1.127",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/setupCoreJsPollyfills.js
+++ b/setupCoreJsPollyfills.js
@@ -1,2 +1,4 @@
 import 'core-js/stable'
 import 'regenerator-runtime/runtime'
+// Aditional polyfills
+import './src/helpers/matches.js'

--- a/src/components/Drawer/Drawer.js
+++ b/src/components/Drawer/Drawer.js
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
 import { Portal } from '../Portal'
-import useOutsideClick from '../../hooks/a11y/useOutsideClick'
+import useOutsideClickIgnoreSelector from '../../hooks/a11y/useOutsideClickIgnoreSelector'
 import useOutsideEscape from '../../hooks/a11y/useOutsideEscape'
 import useHideAriaSiblings from '../../hooks/a11y/useHideAriaSiblings'
 import useTrapFocus from '../../hooks/a11y/useTrapFocus'
@@ -13,6 +13,7 @@ const DrawerContent = ({
   isOpen,
   position,
   className,
+  floatingDrawerContentSelector,
   ...rest
 }) => {
   const drawerRef = useRef(null)
@@ -24,7 +25,9 @@ const DrawerContent = ({
 
   classes = className ? `${className} ${classes}` : classes
 
-  useOutsideClick(drawerRef, () => onDismiss(false))
+  useOutsideClickIgnoreSelector(drawerRef, floatingDrawerContentSelector, () =>
+    onDismiss(false)
+  )
   useOutsideEscape(drawerRef, () => onDismiss(false))
   useTrapFocus(drawerRef, isOpen)
   useHideAriaSiblings(drawerRef, isOpen)
@@ -49,6 +52,7 @@ DrawerContent.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   position: PropTypes.oneOf(['left', 'right']),
   className: PropTypes.string,
+  floatingDrawerContentSelector: PropTypes.string,
   'data-tid': PropTypes.string,
 }
 
@@ -60,6 +64,7 @@ export const Drawer = ({
   onDismiss,
   isOpen,
   position,
+  floatingDrawerContentSelector,
   floatingDrawerContentRenderer,
   className,
   ...rest
@@ -81,6 +86,7 @@ export const Drawer = ({
           isOpen={isOpen}
           position={position}
           className={className}
+          floatingDrawerContentSelector={floatingDrawerContentSelector}
           {...rest}
         >
           {children}
@@ -105,6 +111,8 @@ Drawer.propTypes = {
   className: PropTypes.string,
   /** optional renderer for rendering floating items e.g. a floating action button */
   floatingDrawerContentRenderer: PropTypes.func,
+  /** selector for floating button to be rendered so we don't consider it an "outside click" */
+  floatingDrawerContentSelector: PropTypes.string,
   /** data attribute for testing */
   'data-tid': PropTypes.string,
 }

--- a/src/components/Drawer/Drawer.js
+++ b/src/components/Drawer/Drawer.js
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
 import { Portal } from '../Portal'
-import useOutsideClickIgnoreSelector from '../../hooks/a11y/useOutsideClickIgnoreSelector'
+import useOutsideClickIgnoreSelectors from '../../hooks/a11y/useOutsideClickIgnoreSelectors'
 import useOutsideEscape from '../../hooks/a11y/useOutsideEscape'
 import useHideAriaSiblings from '../../hooks/a11y/useHideAriaSiblings'
 import useTrapFocus from '../../hooks/a11y/useTrapFocus'
@@ -13,7 +13,7 @@ const DrawerContent = ({
   isOpen,
   position,
   className,
-  floatingDrawerContentSelector,
+  ignoredSelectors,
   ...rest
 }) => {
   const drawerRef = useRef(null)
@@ -25,7 +25,7 @@ const DrawerContent = ({
 
   classes = className ? `${className} ${classes}` : classes
 
-  useOutsideClickIgnoreSelector(drawerRef, floatingDrawerContentSelector, () =>
+  useOutsideClickIgnoreSelectors(drawerRef, ignoredSelectors, () =>
     onDismiss(false)
   )
   useOutsideEscape(drawerRef, () => onDismiss(false))
@@ -52,7 +52,7 @@ DrawerContent.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   position: PropTypes.oneOf(['left', 'right']),
   className: PropTypes.string,
-  floatingDrawerContentSelector: PropTypes.string,
+  ignoredSelectors: PropTypes.arrayOf(PropTypes.string),
   'data-tid': PropTypes.string,
 }
 
@@ -64,7 +64,7 @@ export const Drawer = ({
   onDismiss,
   isOpen,
   position,
-  floatingDrawerContentSelector,
+  ignoredSelectors,
   floatingDrawerContentRenderer,
   className,
   ...rest
@@ -86,7 +86,7 @@ export const Drawer = ({
           isOpen={isOpen}
           position={position}
           className={className}
-          floatingDrawerContentSelector={floatingDrawerContentSelector}
+          ignoredSelectors={ignoredSelectors}
           {...rest}
         >
           {children}
@@ -112,7 +112,7 @@ Drawer.propTypes = {
   /** optional renderer for rendering floating items e.g. a floating action button */
   floatingDrawerContentRenderer: PropTypes.func,
   /** selector for floating button to be rendered so we don't consider it an "outside click" */
-  floatingDrawerContentSelector: PropTypes.string,
+  ignoredSelectors: PropTypes.arrayOf(PropTypes.string),
   /** data attribute for testing */
   'data-tid': PropTypes.string,
 }

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -987,7 +987,7 @@ export declare const Drawer: {
     isOpen,
     position,
     className,
-    floatingDrawerContentSelector,
+    ignoredSelectors,
     floatingDrawerContentRenderer,
     ...rest
   }: {
@@ -996,7 +996,7 @@ export declare const Drawer: {
     isOpen: boolean
     position?: string
     className?: string
-    floatingDrawerContentSelector?: string
+    ignoredSelectors?: string[]
     floatingDrawerContentRenderer?: any
     'data-tid'?: string
   }): JSX.Element
@@ -1014,7 +1014,7 @@ export declare const NoraDrawer: {
     labelCopy,
     closeCopy,
     floatingDrawerContentRenderer,
-    floatingDrawerContentSelector,
+    ignoredSelectors,
     drawerClasses,
   }: {
     children: React.ReactNode
@@ -1025,7 +1025,7 @@ export declare const NoraDrawer: {
     position?: string
     drawerClasses?: string
     floatingDrawerContentRenderer?: any
-    floatingDrawerContentSelector?: string
+    ignoredSelectors?: string[]
   }): JSX.Element
   propTypes: {
     props: any

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -987,6 +987,7 @@ export declare const Drawer: {
     isOpen,
     position,
     className,
+    floatingDrawerContentSelector,
     floatingDrawerContentRenderer,
     ...rest
   }: {
@@ -995,6 +996,7 @@ export declare const Drawer: {
     isOpen: boolean
     position?: string
     className?: string
+    floatingDrawerContentSelector?: string
     floatingDrawerContentRenderer?: any
     'data-tid'?: string
   }): JSX.Element
@@ -1012,6 +1014,7 @@ export declare const NoraDrawer: {
     labelCopy,
     closeCopy,
     floatingDrawerContentRenderer,
+    floatingDrawerContentSelector,
     drawerClasses,
   }: {
     children: React.ReactNode
@@ -1022,6 +1025,7 @@ export declare const NoraDrawer: {
     position?: string
     drawerClasses?: string
     floatingDrawerContentRenderer?: any
+    floatingDrawerContentSelector?: string
   }): JSX.Element
   propTypes: {
     props: any

--- a/src/helpers/matches.js
+++ b/src/helpers/matches.js
@@ -1,0 +1,9 @@
+/**
+ * Element.matches() polyfill (simple version)
+ * https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill
+ */
+if (!Element.prototype.matches) {
+  Element.prototype.matches =
+    Element.prototype.msMatchesSelector ||
+    Element.prototype.webkitMatchesSelector
+}

--- a/src/hooks/a11y/useOutsideClickIgnoreSelector.js
+++ b/src/hooks/a11y/useOutsideClickIgnoreSelector.js
@@ -1,0 +1,38 @@
+import { useLayoutEffect } from 'react'
+
+/**
+ * Hook handles a click outside the targeted component
+ *
+ * @public
+ *
+ * @param {React.MutableRefObject<HTMLElement | null>} ref - the component's ref
+ * @param {() => void} handler - a callback that fires when an outside click is detected
+ *
+ * @return {void}
+ */
+function useOutsideClickIgnoreSelector(ref, ignoreSelector, handler) {
+  const handleClickOutside = (e) => {
+    console.log('floatingDrawerContentSelector. e.target: ', e.target)
+    let isIgnoredElement = false
+    if (e.target.classList && e.target.classList.contains(ignoreSelector)) {
+      isIgnoredElement = true
+    }
+    if (!isIgnoredElement && ref.current && !ref.current.contains(e.target)) {
+      handler.call(this, [e])
+    }
+  }
+
+  useLayoutEffect(() => {
+    // Bind the event listener
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('touchstart', handleClickOutside)
+
+    return () => {
+      // Unbind the event listener on clean up
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('touchstart', handleClickOutside)
+    }
+  }, [])
+}
+
+export default useOutsideClickIgnoreSelector

--- a/src/hooks/a11y/useOutsideClickIgnoreSelector.js
+++ b/src/hooks/a11y/useOutsideClickIgnoreSelector.js
@@ -1,11 +1,12 @@
 import { useLayoutEffect } from 'react'
 
 /**
- * Hook handles a click outside the targeted component
+ * Hook handles a click outside the targeted component or ignored selector
  *
  * @public
  *
  * @param {React.MutableRefObject<HTMLElement | null>} ref - the component's ref
+ * @param {String} ignoreSelector - the selector to ignore when we consider outside clicks
  * @param {() => void} handler - a callback that fires when an outside click is detected
  *
  * @return {void}

--- a/src/hooks/a11y/useOutsideClickIgnoreSelector.js
+++ b/src/hooks/a11y/useOutsideClickIgnoreSelector.js
@@ -12,7 +12,6 @@ import { useLayoutEffect } from 'react'
  */
 function useOutsideClickIgnoreSelector(ref, ignoreSelector, handler) {
   const handleClickOutside = (e) => {
-    console.log('floatingDrawerContentSelector. e.target: ', e.target)
     let isIgnoredElement = false
     if (e.target.classList && e.target.classList.contains(ignoreSelector)) {
       isIgnoredElement = true

--- a/src/hooks/a11y/useOutsideClickIgnoreSelectors.js
+++ b/src/hooks/a11y/useOutsideClickIgnoreSelectors.js
@@ -1,5 +1,4 @@
 import { useLayoutEffect } from 'react'
-import matches from '../../helpers/matches.js'
 
 /**
  * Hook handles a click outside the targeted component or ignored selector

--- a/src/hooks/a11y/useOutsideClickIgnoreSelectors.js
+++ b/src/hooks/a11y/useOutsideClickIgnoreSelectors.js
@@ -1,4 +1,5 @@
 import { useLayoutEffect } from 'react'
+import matches from '../../helpers/matches.js'
 
 /**
  * Hook handles a click outside the targeted component or ignored selector
@@ -6,16 +7,20 @@ import { useLayoutEffect } from 'react'
  * @public
  *
  * @param {React.MutableRefObject<HTMLElement | null>} ref - the component's ref
- * @param {String} ignoreSelector - the selector to ignore when we consider outside clicks
+ * @param {Array} of selectors to ignore - selectors to ignore when we consider outside clicks
  * @param {() => void} handler - a callback that fires when an outside click is detected
  *
  * @return {void}
  */
-function useOutsideClickIgnoreSelector(ref, ignoreSelector, handler) {
+function useOutsideClickIgnoreSelectors(ref, ignoredSelectors, handler) {
   const handleClickOutside = (e) => {
     let isIgnoredElement = false
-    if (e.target.classList && e.target.classList.contains(ignoreSelector)) {
-      isIgnoredElement = true
+    if (ignoredSelectors) {
+      for (let sel of ignoredSelectors) {
+        if (e.target.matches(sel)) {
+          isIgnoredElement = true
+        }
+      }
     }
     if (!isIgnoredElement && ref.current && !ref.current.contains(e.target)) {
       handler.call(this, [e])
@@ -35,4 +40,4 @@ function useOutsideClickIgnoreSelector(ref, ignoreSelector, handler) {
   }, [])
 }
 
-export default useOutsideClickIgnoreSelector
+export default useOutsideClickIgnoreSelectors

--- a/src/hooks/a11y/useOutsideClickIgnoreSelectors.test.js
+++ b/src/hooks/a11y/useOutsideClickIgnoreSelectors.test.js
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react-hooks'
+import useOutsideClickIgnoreSelectors from './useOutsideClickIgnoreSelectors'
+import { act, fireEvent } from '@testing-library/react'
+
+describe('useOutsideClickIgnoreSelectors', () => {
+  it('should fire handler when outside click captured on element that is not the ref or ignored', () => {
+    const refEl = document.createElement('div')
+    const ref = { current: refEl }
+    document.body.appendChild(refEl)
+
+    let ignoredElement = document.createElement('div')
+    ignoredElement.setAttribute('id', 'el1')
+    document.body.appendChild(ignoredElement)
+
+    let notIgnoredElement = document.createElement('div')
+    document.body.appendChild(notIgnoredElement)
+
+    const handler = jest.fn()
+
+    renderHook(() => useOutsideClickIgnoreSelectors(ref, ['#el1'], handler))
+
+    act(() => {
+      fireEvent.mouseDown(notIgnoredElement)
+    })
+
+    expect(handler).toHaveBeenCalled()
+  })
+
+  it('should not fire handler when outside click captured on an ignored element', () => {
+    const refEl = document.createElement('div')
+    const ref = { current: refEl }
+    document.body.appendChild(refEl)
+
+    let ignoredElement = document.createElement('div')
+    ignoredElement.setAttribute('id', 'el1')
+    document.body.appendChild(ignoredElement)
+    const handler = jest.fn()
+
+    renderHook(() => useOutsideClickIgnoreSelectors(ref, ['#el1'], handler))
+
+    act(() => {
+      fireEvent.mouseDown(ignoredElement)
+    })
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+})

--- a/src/nora/components/NoraDrawer/NoraDrawer.js
+++ b/src/nora/components/NoraDrawer/NoraDrawer.js
@@ -22,7 +22,7 @@ export const NoraDrawer = ({
   labelCopy,
   closeCopy,
   floatingDrawerContentRenderer,
-  floatingDrawerContentSelector,
+  ignoredSelectors,
   drawerClasses,
 }) => {
   return (
@@ -31,7 +31,7 @@ export const NoraDrawer = ({
       onDismiss={onDismiss}
       isOpen={isOpen}
       position={position}
-      floatingDrawerContentSelector={floatingDrawerContentSelector}
+      ignoredSelectors={ignoredSelectors}
       floatingDrawerContentRenderer={floatingDrawerContentRenderer}
     >
       <header className={styles.Header}>
@@ -54,7 +54,7 @@ NoraDrawer.propTypes = {
   labelCopy: PropTypes.string.isRequired,
   closeCopy: PropTypes.string.isRequired,
   drawerClasses: PropTypes.string,
-  floatingDrawerContentSelector: PropTypes.string,
+  ignoredSelectors: PropTypes.arrayOf(PropTypes.string),
   floatingDrawerContentRenderer: PropTypes.func,
 }
 

--- a/src/nora/components/NoraDrawer/NoraDrawer.js
+++ b/src/nora/components/NoraDrawer/NoraDrawer.js
@@ -22,6 +22,7 @@ export const NoraDrawer = ({
   labelCopy,
   closeCopy,
   floatingDrawerContentRenderer,
+  floatingDrawerContentSelector,
   drawerClasses,
 }) => {
   return (
@@ -30,6 +31,7 @@ export const NoraDrawer = ({
       onDismiss={onDismiss}
       isOpen={isOpen}
       position={position}
+      floatingDrawerContentSelector={floatingDrawerContentSelector}
       floatingDrawerContentRenderer={floatingDrawerContentRenderer}
     >
       <header className={styles.Header}>
@@ -52,6 +54,7 @@ NoraDrawer.propTypes = {
   labelCopy: PropTypes.string.isRequired,
   closeCopy: PropTypes.string.isRequired,
   drawerClasses: PropTypes.string,
+  floatingDrawerContentSelector: PropTypes.string,
   floatingDrawerContentRenderer: PropTypes.func,
 }
 

--- a/src/nora/components/NoraDrawer/NoraDrawer.md
+++ b/src/nora/components/NoraDrawer/NoraDrawer.md
@@ -15,6 +15,7 @@ const MyApp = () => {
   const renderFloatingDrawer = () => {
     return (
       <h1
+        id="ignored-selectors-example"
         style={{
           right: '0',
           bottom: '0',
@@ -35,6 +36,7 @@ const MyApp = () => {
         labelCopy="Order Evidences"
         closeCopy="Cancel"
         onDismiss={setIsOpen}
+        ignoredSelectors={['#ignored-selectors-example']}
         floatingDrawerContentRenderer={renderFloatingDrawer}
       >
         <section className={styles.Section}>


### PR DESCRIPTION
This adds the use outside click functionality including the floating action button (footer on the right side drawer) for https://github.com/getethos/ethos/pull/2528/files that was causing issues before the demo