### PR TITLE
Add rest of nora icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.129",
+  "version": "1.1.130",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/fa.js
+++ b/src/components/fa.js
@@ -18,9 +18,11 @@ import { library } from '@fortawesome/fontawesome-svg-core'
 // REMINDER! each import must be a separate "deep import" as below  //
 //////////////////////////////////////////////////////////////////////
 
+// Nora Icons
 import { faAlignLeft } from '@fortawesome/pro-solid-svg-icons/faAlignLeft'
 import { faCircleNotch } from '@fortawesome/pro-regular-svg-icons/faCircleNotch'
-import { faExclamationTriangle } from '@fortawesome/pro-light-svg-icons/faExclamationTriangle'
+import { faExclamationTriangle as faExclamationTriangleLight } from '@fortawesome/pro-light-svg-icons/faExclamationTriangle'
+import { faExclamationTriangle as faExclamationTriangleSolid } from '@fortawesome/pro-solid-svg-icons/faExclamationTriangle'
 import { faSearch } from '@fortawesome/pro-regular-svg-icons/faSearch'
 import { faAsterisk } from '@fortawesome/pro-light-svg-icons/faAsterisk'
 import { faExchange } from '@fortawesome/pro-regular-svg-icons/faExchange'
@@ -31,31 +33,66 @@ import { faCheckSquare as faCheckSquareSolid } from '@fortawesome/pro-solid-svg-
 import { faWindowClose } from '@fortawesome/pro-light-svg-icons/faWindowClose'
 import { faOctagon } from '@fortawesome/pro-light-svg-icons/faOctagon'
 import { faExternalLink } from '@fortawesome/pro-regular-svg-icons/faExternalLink'
-import { faCheck } from '@fortawesome/pro-light-svg-icons/faCheck'
+import { faCheck as faCheckLight } from '@fortawesome/pro-light-svg-icons/faCheck'
+import { faCheck } from '@fortawesome/pro-regular-svg-icons/faCheck'
 import { faTimes } from '@fortawesome/pro-light-svg-icons/faTimes'
 import { faLayerPlus } from '@fortawesome/pro-light-svg-icons/faLayerPlus'
 import { faChevronLeft } from '@fortawesome/pro-regular-svg-icons/faChevronLeft'
 import { faFileMedicalAlt } from '@fortawesome/pro-light-svg-icons/faFileMedicalAlt'
 import { faTimesCircle } from '@fortawesome/pro-solid-svg-icons/faTimesCircle'
+import { faAward } from '@fortawesome/pro-regular-svg-icons/faAward'
+import { faAddressCard } from '@fortawesome/pro-regular-svg-icons/faAddressCard'
+import { faPencil } from '@fortawesome/pro-regular-svg-icons/faPencil'
+import { faFilePlus } from '@fortawesome/pro-regular-svg-icons/faFilePlus'
+import { faTrashAlt } from '@fortawesome/pro-regular-svg-icons/faTrashAlt'
+import { faTrashAlt as faTrashAltLight } from '@fortawesome/pro-light-svg-icons/faTrashAlt'
+import { faCaretDown } from '@fortawesome/pro-solid-svg-icons/faCaretDown'
+import { faInfoCircle as faInfoCircleLight } from '@fortawesome/pro-light-svg-icons/faInfoCircle'
+import { faPlus } from '@fortawesome/pro-regular-svg-icons/faPlus'
+import { faInfoCircle } from '@fortawesome/pro-regular-svg-icons/faInfoCircle'
+import { faQuestionCircle } from '@fortawesome/pro-regular-svg-icons/faQuestionCircle'
+import { faStethoscope } from '@fortawesome/pro-regular-svg-icons/faStethoscope'
+import { faLockAlt } from '@fortawesome/pro-regular-svg-icons/faLockAlt'
+import { faEdit } from '@fortawesome/pro-regular-svg-icons/faEdit'
+import { faMinusCircle } from '@fortawesome/pro-regular-svg-icons/faMinusCircle'
+import { faSpinnerThird } from '@fortawesome/pro-regular-svg-icons/faSpinnerThird'
 
 library.add(
+  faAddressCard,
   faAlignLeft,
   faAsterisk,
+  faAward,
+  faCaretDown,
   faCheck,
+  faCheckLight,
   faCheckSquare,
   faCheckSquareSolid,
   faChevronLeft,
   faCircleNotch,
   faClock,
+  faEdit,
   faExchange,
-  faExclamationTriangle,
+  faExclamationTriangleLight,
+  faExclamationTriangleSolid,
   faExternalLink,
   faFileMedicalAlt,
+  faFilePlus,
+  faInfoCircle,
+  faInfoCircleLight,
   faLayerPlus,
+  faLockAlt,
+  faMinusCircle,
   faOctagon,
+  faPencil,
+  faPlus,
+  faQuestionCircle,
   faSearch,
+  faSpinnerThird,
+  faStethoscope,
   faTimes,
   faTimesCircle,
+  faTrashAlt,
+  faTrashAltLight,
   faUserCheck,
   faWindowClose
 )

--- a/src/components/fa.js
+++ b/src/components/fa.js
@@ -40,6 +40,7 @@ import { faLayerPlus } from '@fortawesome/pro-light-svg-icons/faLayerPlus'
 import { faChevronLeft } from '@fortawesome/pro-regular-svg-icons/faChevronLeft'
 import { faFileMedicalAlt } from '@fortawesome/pro-light-svg-icons/faFileMedicalAlt'
 import { faTimesCircle } from '@fortawesome/pro-solid-svg-icons/faTimesCircle'
+import { faTimesSquare } from '@fortawesome/pro-solid-svg-icons/faTimesSquare'
 import { faAward } from '@fortawesome/pro-regular-svg-icons/faAward'
 import { faAddressCard } from '@fortawesome/pro-regular-svg-icons/faAddressCard'
 import { faPencil } from '@fortawesome/pro-regular-svg-icons/faPencil'
@@ -48,8 +49,8 @@ import { faTrashAlt } from '@fortawesome/pro-regular-svg-icons/faTrashAlt'
 import { faTrashAlt as faTrashAltLight } from '@fortawesome/pro-light-svg-icons/faTrashAlt'
 import { faCaretDown } from '@fortawesome/pro-solid-svg-icons/faCaretDown'
 import { faInfoCircle as faInfoCircleLight } from '@fortawesome/pro-light-svg-icons/faInfoCircle'
-import { faPlus } from '@fortawesome/pro-regular-svg-icons/faPlus'
 import { faInfoCircle } from '@fortawesome/pro-regular-svg-icons/faInfoCircle'
+import { faPlus } from '@fortawesome/pro-regular-svg-icons/faPlus'
 import { faQuestionCircle } from '@fortawesome/pro-regular-svg-icons/faQuestionCircle'
 import { faStethoscope } from '@fortawesome/pro-regular-svg-icons/faStethoscope'
 import { faLockAlt } from '@fortawesome/pro-regular-svg-icons/faLockAlt'
@@ -91,6 +92,7 @@ library.add(
   faStethoscope,
   faTimes,
   faTimesCircle,
+  faTimesSquare,
   faTrashAlt,
   faTrashAltLight,
   faUserCheck,


### PR DESCRIPTION
**Description:**

- Add rest of Nora icons according to icon sheet
- There are a few icons that are no longer needed, but since it's not quite clear what the game plan for minor UI updates to Nora is, I'm leaving them in for now (impact is minimal as we're doing deep imports).

![image](https://user-images.githubusercontent.com/12839832/76560763-1da14380-645f-11ea-92e5-1265dfc0bc97.png)


**Is this a new component? Please review these reminders: **

_Please pick one and delete options that are not relevant:_

- [ ] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [ ] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [ ] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**

-

**Screenshots:**
