### PR TITLE
Update IconLink to take in data-link-id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.131",
+  "version": "1.1.132",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.130",
+  "version": "1.1.131",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -950,6 +950,7 @@ export declare const IconLink: {
     textPosition,
     copy,
     onClick,
+    ...rest
   }: {
     iconPrefix: string
     iconName: string
@@ -959,6 +960,7 @@ export declare const IconLink: {
     textPosition: LinkPositionType
     copy: string
     onClick?: any
+    'data-link-id'?: string
   }): any
   propTypes: {
     props: any

--- a/src/nora/components/IconLink/IconLink.js
+++ b/src/nora/components/IconLink/IconLink.js
@@ -3,13 +3,26 @@ import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 // TODO -- we should probably create a generic Link component :)
-const Link = ({ className, href, onClick, children, target = '_self' }) => {
+const Link = ({
+  className,
+  href,
+  onClick,
+  children,
+  target = '_self',
+  ...rest
+}) => {
   const handleClick = (ev) => {
     ev.preventDefault()
     onClick(ev)
   }
   return (
-    <a href={href} className={className} onClick={handleClick} target={target}>
+    <a
+      href={href}
+      className={className}
+      onClick={handleClick}
+      target={target}
+      data-link-id={rest['data-link-id']}
+    >
       {children}
     </a>
   )
@@ -21,6 +34,7 @@ Link.propTypes = {
   onClick: PropTypes.func,
   children: PropTypes.node,
   target: PropTypes.string,
+  'data-link-id': PropTypes.string,
 }
 
 export const IconLink = ({
@@ -32,10 +46,16 @@ export const IconLink = ({
   textPosition,
   copy,
   onClick,
+  ...rest
 }) => {
   if (textPosition === 'left') {
     return (
-      <Link href="#" className={iconContainerClassName} onClick={onClick}>
+      <Link
+        href="#"
+        className={iconContainerClassName}
+        onClick={onClick}
+        data-link-id={rest['data-link-id']}
+      >
         <span className={textClassName}>{copy}</span>
         <FontAwesomeIcon
           className={iconClassName}
@@ -45,7 +65,12 @@ export const IconLink = ({
     )
   } else {
     return (
-      <Link href="#" className={iconContainerClassName} onClick={onClick}>
+      <Link
+        href="#"
+        className={iconContainerClassName}
+        onClick={onClick}
+        data-link-id={rest['data-link-id']}
+      >
         <FontAwesomeIcon
           className={iconClassName}
           icon={[iconPrefix, iconName]}
@@ -66,5 +91,6 @@ IconLink.propTypes = {
     textPosition: PropTypes.oneOf(['left', 'right']).isRequired,
     copy: PropTypes.string.isRequired,
     onClick: PropTypes.func,
+    'data-link-id': PropTypes.string,
   }),
 }


### PR DESCRIPTION
**Description:**

- While working on the left sidebar, we discovered that we need to be able to pass down a data- attribute to icon links to differentiate them since they are not unique based off of text.
- In other words, we want to be able to avoid this:

![Image 2020-03-13 at 1 31 56 PM](https://user-images.githubusercontent.com/12839832/76670939-a64bdc80-6550-11ea-8406-649feb6e2f3f.png)

**Is this a new component? Please review these reminders: **

_Please pick one and delete options that are not relevant:_

- [ ] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [ ] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [ ] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**

- https://github.com/getethos/ethos/pull/2576

**Screenshots:**
