### PR TITLE
[WIP] Flexgrid no horizontal padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.143",
+  "version": "1.1.144",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.144",
+  "version": "1.1.145",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/FlexGrid/FlexCol.js
+++ b/src/components/FlexGrid/FlexCol.js
@@ -6,6 +6,8 @@ import { ColumnSizeType, ViewportSizeType } from './types'
 import styles from './FlexCol.module.scss'
 
 const propTypes = {
+  /** nopad - opt out of any horizontal left or right padding on columns */
+  nopad: PropTypes.bool,
   /** xs - number of units when viewport is "extra small" */
   xs: ColumnSizeType,
   /** sm - number of units when viewport is "small" */

--- a/src/components/FlexGrid/FlexCol.js
+++ b/src/components/FlexGrid/FlexCol.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import createProps from './createProps'
 import getClass from './classNames'
 import { ColumnSizeType, ViewportSizeType } from './types'
+import styles from './FlexCol.module.scss'
 
 const propTypes = {
   /** xs - number of units when viewport is "extra small" */
@@ -69,6 +70,10 @@ function getColClassNames(props) {
 
   if (props.last) {
     extraClasses.push(getClass('last-' + props.last))
+  }
+
+  if (props.nopad) {
+    extraClasses.push(styles.NoHorizontalPadding)
   }
 
   return Object.keys(props)

--- a/src/components/FlexGrid/FlexCol.module.scss
+++ b/src/components/FlexGrid/FlexCol.module.scss
@@ -1,0 +1,4 @@
+.NoHorizontalPadding {
+  padding-left: 0;
+  padding-right: 0;
+}

--- a/src/components/FlexGrid/FlexGrid.md
+++ b/src/components/FlexGrid/FlexGrid.md
@@ -49,3 +49,27 @@ import { FlexCol } from './FlexCol.js'
   </FlexRow>
 </FlexGrid>
 ```
+
+
+Opt out of horizontal padding
+
+```jsx
+import { FlexRow } from './FlexRow.js'
+import { FlexCol } from './FlexCol.js'
+;<FlexGrid fluid>
+  <FlexRow>
+    <FlexCol nopad sm={2} style={{ border: '1px solid #f7cac9' }}>
+      <p>First column</p>
+    </FlexCol>
+    <FlexCol nopad sm={2} smOffset={1} style={{ border: '1px solid #39cccc' }}>
+      <p>Second column</p>
+    </FlexCol>
+    <FlexCol nopad sm={2} smOffset={1} style={{ border: '1px solid #7fdbff' }}>
+      <p>Third column</p>
+    </FlexCol>
+    <FlexCol nopad sm={2} smOffset={1} style={{ border: '1px solid #ff6f61' }}>
+      <p>Fourth column</p>
+    </FlexCol>
+  </FlexRow>
+</FlexGrid>
+```

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -88,6 +88,7 @@ export interface RowProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export interface ColProps extends HTMLAttributes<HTMLDivElement> {
+  nopad?: boolean
   readonly xs?: ColumnSizeType
   readonly sm?: ColumnSizeType
   readonly md?: ColumnSizeType

--- a/src/components/index.tests.tsx
+++ b/src/components/index.tests.tsx
@@ -169,7 +169,7 @@ class FlexGridTest extends React.Component<any, any> {
     return (
       <FlexGrid>
         <FlexRow>
-          <FlexCol xs={12} sm={4} lg={6}>
+          <FlexCol nopad xs={12} sm={4} lg={6}>
             <p>Hi</p>
           </FlexCol>
         </FlexRow>


### PR DESCRIPTION
# NEW DIRECTION: gonna try another pass at all this--we'll pull in flexboxgrid2.css and I'll just refactor that to do it's thing without the auto magical gutters

[flexboxgrid2.css](https://github.com/evgenyrodionov/flexboxgrid2/blob/master/src/flexboxgrid2.css)


Gonna leave this open a bit longer, but, likely I'll be deleting and going with:
https://github.com/getethos/ethos-design-system/pull/305


**Description:**

- [Asana Task](https://app.asana.com/0/1150068311310825/1167426142339121/f)
-

**Is this a new component? Please review these reminders: **

_Please pick one and delete options that are not relevant:_

- [ ] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [ ] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [ ] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**

-

**Screenshots:**
