### PR TITLE
Remove react-icons usage and replaces with the same required fa icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.149",
+  "version": "1.1.150",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Grid/Grid.md
+++ b/src/components/Grid/Grid.md
@@ -21,7 +21,7 @@ Place focus anywhere just above the data grid and then tab. You've put focus on 
 ```jsx
 import React, { useState } from 'react'
 import uuidv4 from 'uuid/v4'
-import { FaHamburger } from 'react-icons/fa'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Grid } from './Grid.js'
 import { Row } from './Row.js'
 import { Column } from './Column.js'
@@ -204,7 +204,7 @@ function GridExample() {
                     <div className={styles.iconContainer}>
                       {row[col.name]}{' '}
                       {col.name === 'Type' && row[col.name] === 'Food' && (
-                        <FaHamburger className={styles.icon} />
+                        <FontAwesomeIcon icon={['far', 'hamburger']} className={styles.icon} />
                       )}
                     </div>
                   )}
@@ -227,7 +227,7 @@ Here's an example of using `Small` and `Large` on jut the row with _Guitar Lesso
 ```jsx
 import React, { useState } from 'react'
 import uuidv4 from 'uuid/v4'
-import { FaHamburger } from 'react-icons/fa'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Grid } from './Grid'
 import { Row } from './Row'
 import { Column } from './Column'
@@ -416,7 +416,7 @@ function GridSmall() {
                     <div className={styles.iconContainer}>
                       {row[col.name]}{' '}
                       {col.name === 'Type' && row[col.name] === 'Food' && (
-                        <FaHamburger className={styles.icon} />
+                        <FontAwesomeIcon icon={['far', 'hamburger']} className={styles.icon} />
                       )}
                     </div>
                   )}

--- a/src/components/Grid/Pagination.md
+++ b/src/components/Grid/Pagination.md
@@ -3,7 +3,7 @@ Used in tandem with the DataGrid component:
 ```jsx
 import React, { memo, useEffect, useState } from 'react'
 import uuidv4 from 'uuid/v4'
-import { FaHamburger } from 'react-icons/fa'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Grid } from '../Grid/Grid.js'
 import { Row } from '../Grid/Row.js'
 import { Column } from '../Grid/Column.js'
@@ -126,7 +126,7 @@ const LeGrid = ({ rows, columns }) => {
                   <div className={styles.iconContainer}>
                     {row[col.name]}{' '}
                     {col.name === 'Type' && row[col.name] === 'Food' && (
-                      <FaHamburger className={styles.icon} />
+                      <FontAwesomeIcon icon={['far', 'hamburger']} className={styles.icon} />
                     )}
                   </div>
                 )}

--- a/src/components/Grid/useGridSorting.js
+++ b/src/components/Grid/useGridSorting.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { FaSort, FaSortUp, FaSortDown } from 'react-icons/fa'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import styles from './useGridSorting.module.scss'
 
 const DIR = {
@@ -14,14 +14,25 @@ export const useGridSorting = (rows, columns) => {
   const SortIcon = ({ direction }) => {
     let sortIcon
     if (direction === DIR.UP) {
-      sortIcon = <FaSortUp className={[styles.icon, styles.iconUp].join(' ')} />
+      sortIcon = (
+        <FontAwesomeIcon
+          icon={['fas', 'sort-up']}
+          className={[styles.icon, styles.iconUp].join(' ')}
+        />
+      )
     } else if (direction === DIR.DOWN) {
       sortIcon = (
-        <FaSortDown className={[styles.icon, styles.iconDown].join(' ')} />
+        <FontAwesomeIcon
+          icon={['fas', 'sort-down']}
+          className={[styles.icon, styles.iconDown].join(' ')}
+        />
       )
     } else {
       sortIcon = (
-        <FaSort className={[styles.icon, styles.iconDefault].join(' ')} />
+        <FontAwesomeIcon
+          icon={['fas', 'sort']}
+          className={[styles.icon, styles.iconDefault].join(' ')}
+        />
       )
     }
     return sortIcon

--- a/src/components/fa.js
+++ b/src/components/fa.js
@@ -18,6 +18,11 @@ import { library } from '@fortawesome/fontawesome-svg-core'
 // REMINDER! each import must be a separate "deep import" as below  //
 //////////////////////////////////////////////////////////////////////
 
+import { faHamburger } from '@fortawesome/pro-regular-svg-icons/faHamburger'
+import { faSort } from '@fortawesome/pro-solid-svg-icons/faSort'
+import { faSortDown } from '@fortawesome/pro-solid-svg-icons/faSortDown'
+import { faSortUp } from '@fortawesome/pro-solid-svg-icons/faSortUp'
+
 // Nora Icons
 import { faAlignLeft } from '@fortawesome/pro-solid-svg-icons/faAlignLeft'
 import { faCircleNotch } from '@fortawesome/pro-regular-svg-icons/faCircleNotch'
@@ -59,6 +64,10 @@ import { faMinusCircle } from '@fortawesome/pro-regular-svg-icons/faMinusCircle'
 import { faSpinnerThird } from '@fortawesome/pro-regular-svg-icons/faSpinnerThird'
 
 library.add(
+  faHamburger,
+  faSort,
+  faSortDown,
+  faSortUp,
   faAddressCard,
   faAlignLeft,
   faAsterisk,


### PR DESCRIPTION
**Description:**

- [Asana Task](https://app.asana.com/0/1150068311310825/1168090685281633/f)
- Fix EDS react-icons (remove all usages)

_This was blocking some of Cole's Type work so it's sort of a hotfix_

- [x] Bumped the yarn version?
Yes, `v1.1.150`

**Referencing PR or Branch (e.g. in CMS or monorepo):**

- Unblocks https://github.com/getethos/ethos/pull/2672/files

**Screenshots:**

Not shown is _sort down_, but I verified it manually :)

![image](https://user-images.githubusercontent.com/142403/77461567-fed87080-6dbf-11ea-8a88-8baf856f0fec.png)
