### PR TITLE
Tooltip typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.150",
+  "version": "1.1.151",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -517,6 +517,32 @@ export declare const EmailInput: {
   }
 }
 
+export declare const Tooltip: {
+  ({
+    placement,
+    label,
+    inline,
+    details,
+    boundariesElement,
+    children,
+  }: {
+    placement?: 'top' | 'right' | 'left' | 'bottom' | 'auto'
+    label: string
+    inline?: boolean
+    details: string
+    boundariesElement?: 'viewport' | 'scrollParent' | 'window'
+    children?: React.ReactNode
+  }): JSX.Element
+  propTypes: {
+    placement?: 'top' | 'right' | 'left' | 'bottom' | 'auto'
+    label: string
+    inline?: boolean
+    details: string
+    boundariesElement?: 'viewport' | 'scrollParent' | 'window'
+    children?: React.ReactNode
+  }
+}
+
 export declare const TextMaskedInput: {
   (props: any): JSX.Element
   PUBLIC_PROPS: {

--- a/src/components/index.tests.tsx
+++ b/src/components/index.tests.tsx
@@ -21,6 +21,7 @@ import { RadioButtonGroup } from './index'
 import { Select } from './index'
 import { SearchInput } from './index'
 import { TextMaskedInput } from './index'
+import { Tooltip } from './index'
 import { ValueProps } from './index'
 import { ZipInput } from './index'
 import { UniversalNavbar } from './index'
@@ -330,6 +331,12 @@ class TextMaskedInputTest extends React.Component<any, any> {
         setTouched={setTouchedFn}
       />
     )
+  }
+}
+
+class TooltipTest extends React.Component<any, any> {
+  render() {
+    return <Tooltip label="Flip" details="Hi!" />
   }
 }
 


### PR DESCRIPTION
**Description:**
- [Asana Task](https://app.asana.com/0/1150068311310825/1167333682122591/f)
- This will support the Nora application which needs to pull in Tooltips in a Typescript consumer. It looks like when we added the [Tooltip PR](https://github.com/getethos/ethos-design-system/pull/201) we neglected to add Typescript typings (and I approved it!); in reality I think we were just starting to introduce TS :)

This PR adds those typings

- [x] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?
