### PR TITLE
Tooltip Refactor for Customizability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.151",
+  "version": "1.1.152",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.152",
+  "version": "1.1.153",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.153",
+  "version": "1.1.154",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -18,6 +18,7 @@ const DESC_ID = 'mobile-modal-description'
 export const Tooltip = ({
   label,
   placement,
+  popperBoxStyles = '',
   details,
   inline,
   children,
@@ -111,6 +112,7 @@ export const Tooltip = ({
                 innerRef={ref}
                 visible={tooltipVisible}
                 details={details}
+                popperBoxStyles={popperBoxStyles}
                 {...rest}
               />
             )}
@@ -202,6 +204,8 @@ Tooltip.propTypes = {
   label: PropTypes.string.isRequired,
   /** Boolean used to change Tooltip reference element to `display: inline-block;` */
   inline: PropTypes.bool,
+  /** String for overriding default tooltip box styles. You can, for example override the white background color with this. */
+  popperBoxStyles: PropTypes.string,
   /** Tooltip description */
   details: PropTypes.string.isRequired,
   /** String that sets what Element the tooltip events should trigger against, can be `'viewport'`, `'scrollParent'` or`'window'`*/
@@ -214,6 +218,7 @@ const PopperContent = ({
   innerRef,
   visible,
   style,
+  popperBoxStyles = '',
   placement,
   arrowProps,
   scheduleUpdate,
@@ -243,7 +248,8 @@ const PopperContent = ({
   }, [position])
 
   const contentBoxClasses = [
-    styles.contentBox,
+    popperBoxStyles,
+    styles.popperContentBox,
     visible && isPositioned ? styles.visible : styles.hidden,
   ]
 
@@ -277,6 +283,7 @@ PopperContent.propTypes = {
   innerRef: PropTypes.func,
   visible: PropTypes.bool,
   style: PropTypes.object,
+  popperBoxStyles: PropTypes.string,
   placement: PropTypes.string,
   arrowProps: PropTypes.object,
   scheduleUpdate: PropTypes.func,

--- a/src/components/Tooltip/Tooltip.md
+++ b/src/components/Tooltip/Tooltip.md
@@ -5,7 +5,6 @@
 To use a placeholder in its most basic form and with all defaults: provide two properties to the component, `label` and `details`
 
 ```jsx
-import React, { useRef, useState, useEffect } from 'react'
 import styles from './TooltipExamples.module.scss'
 ;<>
   <div className={styles.basicExample}>
@@ -22,7 +21,6 @@ CSS Module styles (see `tipStyles` below for example).
 
 ```jsx
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import React, { useRef, useState, useEffect } from 'react'
 import styles from './TooltipExamples.module.scss'
 import tipStyles from './Tooltip.module.scss'
 ;<>
@@ -40,7 +38,6 @@ import tipStyles from './Tooltip.module.scss'
 Customize the **Starting** position of a Tooltip
 
 ```jsx
-import React, { useRef, useState, useEffect } from 'react'
 import styles from './TooltipExamples.module.scss'
 ;<>
   <div className={styles.centeredExample}>
@@ -61,7 +58,6 @@ This property will allow you to set what element the Tooltips event should activ
 Setting the `boundariesElement` to `'scrollParent'` will make the tooltip flip against the first scrollable parent element. To always flip Tooltips against the outermost scroll use `viewport` or `window`.
 
 ```jsx
-import React, { useRef, useState, useEffect } from 'react'
 import styles from './TooltipExamples.module.scss'
 ;<>
   <div className={styles.staticOuterDiv}>
@@ -82,7 +78,6 @@ import styles from './TooltipExamples.module.scss'
 ### `inline`
 
 ```jsx
-import React, { useRef, useState, useEffect } from 'react'
 import styles from './TooltipExamples.module.scss'
 ;<>
   <div className={styles.basicExample}>

--- a/src/components/Tooltip/Tooltip.md
+++ b/src/components/Tooltip/Tooltip.md
@@ -9,10 +9,31 @@ import React, { useRef, useState, useEffect } from 'react'
 import styles from './TooltipExamples.module.scss'
 ;<>
   <div className={styles.basicExample}>
-    Basic Tootlip <Tooltip label="Flip" details="Hi!" />
+    Basic Tooltip <Tooltip label="Flip" details="Hi!" />
   </div>
 </>
 ```
+
+### Children
+
+If you don't want to use the default information 'i' SVG icon, you can suppy your own
+custom children and wrap those within the tooltip. You can even steal the tooltip's own
+CSS Module styles (see `tipStyles` below for example).
+
+```jsx
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import React, { useRef, useState, useEffect } from 'react'
+import styles from './TooltipExamples.module.scss'
+import tipStyles from './Tooltip.module.scss'
+;<>
+  <div className={styles.basicExample}>
+    <Tooltip popperBoxStyles={styles.CustomTipExample} label="burger icon" details="Burgers are so tasty!" placement={'right'} >
+        <FontAwesomeIcon icon={['far', 'hamburger']} className={tipStyles.icon} />
+    </Tooltip>
+  </div>
+</>
+```
+
 
 ### `placement`
 

--- a/src/components/Tooltip/Tooltip.module.scss
+++ b/src/components/Tooltip/Tooltip.module.scss
@@ -22,39 +22,6 @@
 }
 
 .popperContainer {
-  .contentBox {
-    @include for-phone-only {
-      display: none;
-    }
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    margin: var(--Space-12);
-    text-align: left;
-    width: max-content;
-    max-width: 320px;
-    background-color: white;
-    padding: var(--Space-24);
-    box-shadow: var(--BoxShadow-Outer-light);
-    color: var(--GrayDarkHover--translucent);
-    transition: var(--transition-default);
-
-    &.noTransition {
-      transition: unset;
-    }
-
-    &.visible {
-      opacity: 1;
-      visibility: visible;
-    }
-
-    &.hidden {
-      opacity: 0;
-      visibility: hidden;
-    }
-  }
-
   .arrow {
     position: absolute;
     width: var(--Space-12);
@@ -107,6 +74,39 @@
       height: 0;
       border-style: solid;
     }
+  }
+}
+
+.popperContentBox {
+  @include for-phone-only {
+    display: none;
+  }
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: var(--Space-12);
+  text-align: left;
+  width: max-content;
+  max-width: 320px;
+  background-color: white;
+  padding: var(--Space-24);
+  box-shadow: var(--BoxShadow-Outer-light);
+  color: var(--GrayDarkHover--translucent);
+  transition: var(--transition-default);
+
+  &.noTransition {
+    transition: unset;
+  }
+
+  &.visible {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  &.hidden {
+    opacity: 0;
+    visibility: hidden;
   }
 }
 

--- a/src/components/Tooltip/TooltipExamples.module.scss
+++ b/src/components/Tooltip/TooltipExamples.module.scss
@@ -24,3 +24,9 @@
   align-items: center;
   height: 200px;
 }
+
+.CustomTipExample {
+  background-color: #0d1f40;
+  border-radius: 3px;
+  color: white;
+}

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -361,7 +361,8 @@ export declare namespace ValueProps {
           header: string
           subHeader: string
           alt?: undefined
-        })[]
+        }
+    )[]
   }
 }
 
@@ -482,7 +483,10 @@ export declare const useGridSorting: (
   rowsRefs: any
   columnRefs: any[]
   sortedRows: any
-  compareBy: (key: string | number, sortMethod?: (a: any, b: any) => 1 | 0 | -1) => (a: any, b: any) => 1 | 0 | -1
+  compareBy: (
+    key: string | number,
+    sortMethod?: (a: any, b: any) => 1 | 0 | -1
+  ) => (a: any, b: any) => 1 | 0 | -1
   setSortState: (key: string | number) => void
   updateRowsRefs: (sortedRowsCopy: any) => void
   getSortIcon: (key: string | number) => JSX.Element
@@ -668,7 +672,13 @@ export declare const ZipInput: {
   }
 }
 
-export declare function Form({ children, config }: { children: React.ReactNode; config: any }): JSX.Element
+export declare function Form({
+  children,
+  config,
+}: {
+  children: React.ReactNode
+  config: any
+}): JSX.Element
 export declare namespace Form {
   var propTypes: {
     children: React.ReactNode
@@ -923,7 +933,16 @@ interface NoraButtonProps {
 }
 
 export declare const NoraButton: {
-  ({ children, disabled, type, name, onClick, role, className, ...rest }: NoraButtonProps): JSX.Element
+  ({
+    children,
+    disabled,
+    type,
+    name,
+    onClick,
+    role,
+    className,
+    ...rest
+  }: NoraButtonProps): JSX.Element
   propTypes: {
     children: React.ReactNode
     'data-tid': string
@@ -981,7 +1000,15 @@ export declare const IconLink: {
 }
 
 export declare const Icon: {
-  ({ iconPrefix, iconName, className }: { iconPrefix: string; iconName: string; className?: string }): JSX.Element
+  ({
+    iconPrefix,
+    iconName,
+    className,
+  }: {
+    iconPrefix: string
+    iconName: string
+    className?: string
+  }): JSX.Element
   propTypes: {
     props: any
   }
@@ -1138,7 +1165,13 @@ export declare const NoraCheckboxInput: {
 }
 
 export declare const Snack: {
-  ({ children, classNameSkin }: { children: React.ReactNode; classNameSkin: string }): JSX.Element
+  ({
+    children,
+    classNameSkin,
+  }: {
+    children: React.ReactNode
+    classNameSkin: string
+  }): JSX.Element
   propTypes: {
     props: any
   }

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -361,8 +361,7 @@ export declare namespace ValueProps {
           header: string
           subHeader: string
           alt?: undefined
-        }
-    )[]
+        })[]
   }
 }
 
@@ -483,10 +482,7 @@ export declare const useGridSorting: (
   rowsRefs: any
   columnRefs: any[]
   sortedRows: any
-  compareBy: (
-    key: string | number,
-    sortMethod?: (a: any, b: any) => 1 | 0 | -1
-  ) => (a: any, b: any) => 1 | 0 | -1
+  compareBy: (key: string | number, sortMethod?: (a: any, b: any) => 1 | 0 | -1) => (a: any, b: any) => 1 | 0 | -1
   setSortState: (key: string | number) => void
   updateRowsRefs: (sortedRowsCopy: any) => void
   getSortIcon: (key: string | number) => JSX.Element
@@ -522,6 +518,7 @@ export declare const Tooltip: {
     placement,
     label,
     inline,
+    popperBoxStyles,
     details,
     boundariesElement,
     children,
@@ -530,6 +527,7 @@ export declare const Tooltip: {
     label: string
     inline?: boolean
     details: string
+    popperBoxStyles?: string
     boundariesElement?: 'viewport' | 'scrollParent' | 'window'
     children?: React.ReactNode
   }): JSX.Element
@@ -538,6 +536,7 @@ export declare const Tooltip: {
     label: string
     inline?: boolean
     details: string
+    popperBoxStyles?: string
     boundariesElement?: 'viewport' | 'scrollParent' | 'window'
     children?: React.ReactNode
   }
@@ -669,13 +668,7 @@ export declare const ZipInput: {
   }
 }
 
-export declare function Form({
-  children,
-  config,
-}: {
-  children: React.ReactNode
-  config: any
-}): JSX.Element
+export declare function Form({ children, config }: { children: React.ReactNode; config: any }): JSX.Element
 export declare namespace Form {
   var propTypes: {
     children: React.ReactNode
@@ -930,16 +923,7 @@ interface NoraButtonProps {
 }
 
 export declare const NoraButton: {
-  ({
-    children,
-    disabled,
-    type,
-    name,
-    onClick,
-    role,
-    className,
-    ...rest
-  }: NoraButtonProps): JSX.Element
+  ({ children, disabled, type, name, onClick, role, className, ...rest }: NoraButtonProps): JSX.Element
   propTypes: {
     children: React.ReactNode
     'data-tid': string
@@ -997,15 +981,7 @@ export declare const IconLink: {
 }
 
 export declare const Icon: {
-  ({
-    iconPrefix,
-    iconName,
-    className,
-  }: {
-    iconPrefix: string
-    iconName: string
-    className?: string
-  }): JSX.Element
+  ({ iconPrefix, iconName, className }: { iconPrefix: string; iconName: string; className?: string }): JSX.Element
   propTypes: {
     props: any
   }
@@ -1162,13 +1138,7 @@ export declare const NoraCheckboxInput: {
 }
 
 export declare const Snack: {
-  ({
-    children,
-    classNameSkin,
-  }: {
-    children: React.ReactNode
-    classNameSkin: string
-  }): JSX.Element
+  ({ children, classNameSkin }: { children: React.ReactNode; classNameSkin: string }): JSX.Element
   propTypes: {
     props: any
   }


### PR DESCRIPTION
**Description:**

- [Asana Task](https://app.asana.com/0/0/1169062204585500/f)
- Refactor EDS Tooltip -- it's unclear how to opt out of the the information icons ('i' in circle) and we need to point to Nora's icon instead

- [x] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**
https://github.com/getethos/ethos/pull/2752 will pull this in once ready

**Screenshots:**

Adds a Children section to the example. After reading through the code I figured out that you can in fact override the information circle icon by just passing in children and wrapping with the tooltip tag. But, there were no examples of how to do so. Also, I needed a way to override the `PopperContent` box styles and so I:

- renamed `.contentBox` to `.popperContentBox` and had to put it at top level of CSS Module so we can override it
- added a `popperBoxStyles` prop which does this overriding

![image](https://user-images.githubusercontent.com/142403/77988678-c958e900-72d1-11ea-9636-c3127d339a85.png)


I've already tested pulling into Nora and it's working:

![image](https://user-images.githubusercontent.com/142403/78064478-addbf580-7346-11ea-8345-c00817985aa3.png)

