### PR TITLE
Type2 Transition - Phases 3/4

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ If you have a Figma spec that uses the "new" `Type` styles, your designer should
 
 Type2 components are available for use in production. Be aware that some components no longer resize on smaller viewports and a reduced number of weights are available.
 
+Since the only weight for Cambon is now 500, Medium500 has been added as an alias for Book500, to ease memory strain on developers and only having to remember one 500 weight name for both font families. Book500 remains backwards compatible for Type2.
+
 New/existing weights:
 ```
 Sans.Medium500

--- a/README.md
+++ b/README.md
@@ -138,9 +138,26 @@ As of Q1 2020 we're undergoing a transition to make some new `Type` components a
 
 If you have a Figma spec that uses the "new" `Type` styles, your designer should be able to let you know which components to use from `Type2`. They share the same name as Type components but are suffixed with `2` and usually smaller than their original `Type` counterpart.
 
-**There are currently no `Type2` components available for use in production!**
-**`TitleSmall2` is for demonstrative purposes only.**
-This notice will be removed from the README once a working set of Type2 components has been established. It will be replaced with contributing and deprecation instructions.
+Type2 components are available for use in production. Be aware that some components no longer resize on smaller viewports and a reduced number of weights are available.
+
+New/existing weights:
+```
+Sans.Medium500
+Sans.Regular400
+Serif.Book500 / Serif.Medium500 (same thing)
+```
+
+Deprecated weights:
+```
+Serif.Demi600
+Serif.Regular400
+*.Light300
+```
+
+Deprecated sizes:
+`Footnote` (use `Caption` instead)
+`TitleXXL`
+`TitleXL.Sans` (`Serif` still available)
 
 The core functionality of `Type` has been migrated to `TypeBase` as we transition. Ideally in the later quarters of 2020 we will begin to deprecate the original `Type` component and move all typography components already in use to `Type2`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.162",
+  "version": "1.1.164",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.164",
+  "version": "1.1.165",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.161",
+  "version": "1.1.162",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Body.md
+++ b/src/components/Body.md
@@ -1,4 +1,28 @@
 ```jsx
+;<>
+  <Body.Regular400 color="BrandSalamander">
+    Body is in the process of being deprecated, please avoid introducing new instances!
+  </Body.Regular400>
+  <br />
+  <Body.Medium500>
+    <a href="/#/Components/Body2">Body2</a> is now available as part of Type2!
+  </Body.Medium500>
+  <br />
+  <Body.Regular400>
+    Check with your Figma designer to see if you can use Type2!
+    <br />
+    What is Type2 you ask? <br />
+    <a
+      href="https://github.com/getethos/ethos-design-system#typography-type-vs-type2-vs-typebase"
+      target="_blank"
+    >
+      Ask and you shall receive! README#Typography: Type vs Type2 vs TypeBase
+    </a>
+  </Body.Regular400>
+</>
+```
+
+```jsx
 <Body.Regular400>
   We offer modern, ethical life insurance to protect the life you're building
   and the people you love

--- a/src/components/Body2.js
+++ b/src/components/Body2.js
@@ -1,0 +1,14 @@
+import { TypeBase, TypeFoundry } from './TypeBase/TypeBase.js'
+
+export const Body2 = {
+  Regular400: TypeFoundry({
+    subtype: TypeBase.SUBTYPES.BODY2,
+    typeface: TypeBase.TYPEFACES.THEINHARDT,
+    weight: TypeBase.WEIGHTS.REGULAR_400,
+  }),
+  Medium500: TypeFoundry({
+    subtype: TypeBase.SUBTYPES.BODY2,
+    typeface: TypeBase.TYPEFACES.THEINHARDT,
+    weight: TypeBase.WEIGHTS.MEDIUM_500,
+  }),
+}

--- a/src/components/Body2.md
+++ b/src/components/Body2.md
@@ -1,0 +1,29 @@
+```jsx
+<Body2.Regular400>
+  We offer modern, ethical life insurance to protect the life you're building
+  and the people you love
+</Body2.Regular400>
+```
+
+```jsx
+<Body2.Regular400 element="label">I should be a label element</Body2.Regular400>
+```
+
+```jsx
+<Body2.Medium500>
+  We offer modern, ethical life insurance to protect the life you're building
+  and the people you love
+</Body2.Medium500>
+```
+
+```jsx
+import { COLORS } from './Colors'
+;<>
+  <Body2.Regular400 color={COLORS.BRAND_FOREST}>
+    Brand Forest color
+  </Body2.Regular400>
+  <Body2.Regular400 color={COLORS.BRAND_SALAMANDER}>
+    Brand Salamander color
+  </Body2.Regular400>
+</>
+```

--- a/src/components/Caption.md
+++ b/src/components/Caption.md
@@ -1,13 +1,48 @@
 ```jsx
-<Caption.Regular400>We offer modern, ethical life insurance to protect the life you're building and the people you love</Caption.Regular400>
+import { Body } from './Body'
+;<>
+  <Body.Regular400 color="BrandSalamander">
+    Caption is in the process of being deprecated, please avoid introducing new
+    instances!
+  </Body.Regular400>
+  <br />
+  <Body.Medium500>
+    <a href="/#/Components/Caption2">Caption2</a> is now available as part of
+    Type2!
+  </Body.Medium500>
+  <br />
+  <Body.Regular400>
+    Check with your Figma designer to see if you can use Type2!
+    <br />
+    What is Type2 you ask? <br />
+    <a
+      href="https://github.com/getethos/ethos-design-system#typography-type-vs-type2-vs-typebase"
+      target="_blank"
+    >
+      Ask and you shall receive! README#Typography: Type vs Type2 vs TypeBase
+    </a>
+  </Body.Regular400>
+</>
 ```
 
 ```jsx
-<Caption.Medium500>We offer modern, ethical life insurance to protect the life you're building and the people you love</Caption.Medium500>
+<Caption.Regular400>
+  We offer modern, ethical life insurance to protect the life you're building
+  and the people you love
+</Caption.Regular400>
+```
+
+```jsx
+<Caption.Medium500>
+  We offer modern, ethical life insurance to protect the life you're building
+  and the people you love
+</Caption.Medium500>
 ```
 
 This example configures the caption to be a label with "all-caps":
 
 ```jsx
-<Caption.Medium500 allCaps={true} element='label'>All-Caps Label</Caption.Medium500>
+<Caption.Medium500 allCaps={true} element="label">
+  All-Caps Label
+</Caption.Medium500>
 ```

--- a/src/components/Caption2.js
+++ b/src/components/Caption2.js
@@ -1,0 +1,14 @@
+import { TypeBase, TypeFoundry } from './TypeBase/TypeBase.js'
+
+export const Caption2 = {
+  Regular400: TypeFoundry({
+    subtype: TypeBase.SUBTYPES.CAPTION2,
+    typeface: TypeBase.TYPEFACES.THEINHARDT,
+    weight: TypeBase.WEIGHTS.REGULAR_400,
+  }),
+  Medium500: TypeFoundry({
+    subtype: TypeBase.SUBTYPES.CAPTION2,
+    typeface: TypeBase.TYPEFACES.THEINHARDT,
+    weight: TypeBase.WEIGHTS.MEDIUM_500,
+  }),
+}

--- a/src/components/Caption2.md
+++ b/src/components/Caption2.md
@@ -1,0 +1,13 @@
+```jsx
+<Caption2.Regular400>We offer modern, ethical life insurance to protect the life you're building and the people you love</Caption2.Regular400>
+```
+
+```jsx
+<Caption2.Medium500>We offer modern, ethical life insurance to protect the life you're building and the people you love</Caption2.Medium500>
+```
+
+This example configures the caption to be a label with "all-caps":
+
+```jsx
+<Caption2.Medium500 allCaps={true} element='label'>All-Caps Label</Caption2.Medium500>
+```

--- a/src/components/Footnote.md
+++ b/src/components/Footnote.md
@@ -1,7 +1,42 @@
 ```jsx
-<Footnote.Regular400>We offer modern, ethical life insurance to protect the life you're building and the people you love</Footnote.Regular400>
+import { Body } from './Body'
+;<>
+  <Body.Regular400 color="BrandSalamander">
+    Footnote is in the process of being deprecated, please avoid introducing new
+    instances!
+  </Body.Regular400>
+  <br />
+  <Body.Medium500>
+    No more Footnote component, see similar sizes: <br />
+    <a href="/#/Components/Caption2">Caption2</a> <br />
+    <a href="/#/Components/Body2">Body2</a> <br />
+    <a href="/#/Components/TitleSmall2">TitleSmall2</a>
+  </Body.Medium500>
+  <br />
+  <Body.Regular400>
+    Check with your Figma designer to see if you can use Type2!
+    <br />
+    What is Type2 you ask? <br />
+    <a
+      href="https://github.com/getethos/ethos-design-system#typography-type-vs-type2-vs-typebase"
+      target="_blank"
+    >
+      Ask and you shall receive! README#Typography: Type vs Type2 vs TypeBase
+    </a>
+  </Body.Regular400>
+</>
 ```
 
 ```jsx
-<Footnote.Medium500>We offer modern, ethical life insurance to protect the life you're building and the people you love</Footnote.Medium500>
+<Footnote.Regular400>
+  We offer modern, ethical life insurance to protect the life you're building
+  and the people you love
+</Footnote.Regular400>
+```
+
+```jsx
+<Footnote.Medium500>
+  We offer modern, ethical life insurance to protect the life you're building
+  and the people you love
+</Footnote.Medium500>
 ```

--- a/src/components/Type/TitleLarge.md
+++ b/src/components/Type/TitleLarge.md
@@ -1,23 +1,62 @@
 ```jsx
-<TitleLarge.Serif.Book500>We offer modern, ethical life insurance</TitleLarge.Serif.Book500>
+import { Body } from '../Body'
+;<>
+  <Body.Regular400 color="BrandSalamander">
+    TitleLarge is in the process of being deprecated, please avoid introducing
+    new instances!
+  </Body.Regular400>
+  <br />
+  <Body.Medium500>
+    <a href="/#/Components/TitleLarge2">TitleLarge2</a> is now available as part
+    of Type2!
+  </Body.Medium500>
+  <br />
+  <Body.Regular400>
+    Check with your Figma designer to see if you can use Type2!
+    <br />
+    What is Type2 you ask? <br />
+    <a
+      href="https://github.com/getethos/ethos-design-system#typography-type-vs-type2-vs-typebase"
+      target="_blank"
+    >
+      Ask and you shall receive! README#Typography: Type vs Type2 vs TypeBase
+    </a>
+  </Body.Regular400>
+</>
 ```
 
 ```jsx
-<TitleLarge.Serif.Regular400>We offer modern, ethical life insurance</TitleLarge.Serif.Regular400>
+<TitleLarge.Serif.Book500>
+  We offer modern, ethical life insurance
+</TitleLarge.Serif.Book500>
 ```
 
 ```jsx
-<TitleLarge.Serif.Demi600>We offer modern, ethical life insurance</TitleLarge.Serif.Demi600>
+<TitleLarge.Serif.Regular400>
+  We offer modern, ethical life insurance
+</TitleLarge.Serif.Regular400>
 ```
 
 ```jsx
-<TitleLarge.Sans.Medium500>We offer modern, ethical life insurance</TitleLarge.Sans.Medium500>
+<TitleLarge.Serif.Demi600>
+  We offer modern, ethical life insurance
+</TitleLarge.Serif.Demi600>
 ```
 
 ```jsx
-<TitleLarge.Sans.Regular400>We offer modern, ethical life insurance</TitleLarge.Sans.Regular400>
+<TitleLarge.Sans.Medium500>
+  We offer modern, ethical life insurance
+</TitleLarge.Sans.Medium500>
 ```
 
 ```jsx
-<TitleLarge.Sans.Light300>We offer modern, ethical life insurance</TitleLarge.Sans.Light300>
+<TitleLarge.Sans.Regular400>
+  We offer modern, ethical life insurance
+</TitleLarge.Sans.Regular400>
+```
+
+```jsx
+<TitleLarge.Sans.Light300>
+  We offer modern, ethical life insurance
+</TitleLarge.Sans.Light300>
 ```

--- a/src/components/Type/TitleMedium.md
+++ b/src/components/Type/TitleMedium.md
@@ -1,4 +1,29 @@
 ```jsx
+import { Body } from '../Body'
+;<>
+  <Body.Regular400 color="BrandSalamander">
+    TitleMedium is in the process of being deprecated, please avoid introducing new instances!
+  </Body.Regular400>
+  <br />
+  <Body.Medium500>
+   <a href="/#/Components/TitleMedium2">TitleMedium2</a> is now available as part of Type2!
+  </Body.Medium500>
+  <br />
+  <Body.Regular400>
+    Check with your Figma designer to see if you can use Type2!
+    <br />
+    What is Type2 you ask? <br />
+    <a
+      href="https://github.com/getethos/ethos-design-system#typography-type-vs-type2-vs-typebase"
+      target="_blank"
+    >
+      Ask and you shall receive! README#Typography: Type vs Type2 vs TypeBase
+    </a>
+  </Body.Regular400>
+</>
+```
+
+```jsx
 <TitleMedium.Serif.Book500>We offer modern, ethical life insurance</TitleMedium.Serif.Book500>
 ```
 

--- a/src/components/Type/TitleSmall.md
+++ b/src/components/Type/TitleSmall.md
@@ -1,28 +1,68 @@
 ```jsx
-<TitleSmall.Serif.Book500>We offer modern, ethical life insurance</TitleSmall.Serif.Book500>
+import { Body } from '../Body'
+;<>
+  <Body.Regular400 color="BrandSalamander">
+    TitleSmall is in the process of being deprecated, please avoid introducing
+    new instances!
+  </Body.Regular400>
+  <br />
+  <Body.Medium500>
+    <a href="/#/Components/TitleSmall2">TitleSmall2</a> is now available as part
+    of Type2!
+  </Body.Medium500>
+  <br />
+  <Body.Regular400>
+    Check with your Figma designer to see if you can use Type2!
+    <br />
+    What is Type2 you ask? <br />
+    <a
+      href="https://github.com/getethos/ethos-design-system#typography-type-vs-type2-vs-typebase"
+      target="_blank"
+    >
+      Ask and you shall receive! README#Typography: Type vs Type2 vs TypeBase
+    </a>
+  </Body.Regular400>
+</>
 ```
 
 ```jsx
-<TitleSmall.Serif.Regular400>We offer modern, ethical life insurance</TitleSmall.Serif.Regular400>
+<TitleSmall.Serif.Book500>
+  We offer modern, ethical life insurance
+</TitleSmall.Serif.Book500>
 ```
 
 ```jsx
-<TitleSmall.Serif.Demi600>We offer modern, ethical life insurance</TitleSmall.Serif.Demi600>
+<TitleSmall.Serif.Regular400>
+  We offer modern, ethical life insurance
+</TitleSmall.Serif.Regular400>
 ```
 
 ```jsx
-<TitleSmall.Sans.Medium500>We offer modern, ethical life insurance</TitleSmall.Sans.Medium500>
+<TitleSmall.Serif.Demi600>
+  We offer modern, ethical life insurance
+</TitleSmall.Serif.Demi600>
 ```
 
 ```jsx
-<TitleSmall.Sans.Regular400>We offer modern, ethical life insurance</TitleSmall.Sans.Regular400>
+<TitleSmall.Sans.Medium500>
+  We offer modern, ethical life insurance
+</TitleSmall.Sans.Medium500>
 ```
 
 ```jsx
-<TitleSmall.Sans.Light300>We offer modern, ethical life insurance</TitleSmall.Sans.Light300>
+<TitleSmall.Sans.Regular400>
+  We offer modern, ethical life insurance
+</TitleSmall.Sans.Regular400>
 ```
 
 ```jsx
-<TitleSmall.Sans.Regular400 element='label'>I should be a label element. Inspect me to see :)</TitleSmall.Sans.Regular400>
+<TitleSmall.Sans.Light300>
+  We offer modern, ethical life insurance
+</TitleSmall.Sans.Light300>
 ```
 
+```jsx
+<TitleSmall.Sans.Regular400 element="label">
+  I should be a label element. Inspect me to see :)
+</TitleSmall.Sans.Regular400>
+```

--- a/src/components/Type/TitleXLarge.md
+++ b/src/components/Type/TitleXLarge.md
@@ -1,23 +1,62 @@
 ```jsx
-<TitleXLarge.Serif.Book500>We offer modern, ethical life insurance</TitleXLarge.Serif.Book500>
+import { Body } from '../Body'
+;<>
+  <Body.Regular400 color="BrandSalamander">
+    TitleXLarge is in the process of being deprecated, please avoid introducing
+    new instances!
+  </Body.Regular400>
+  <br />
+  <Body.Medium500>
+    <a href="/#/Components/TitleXLarge2">TitleXLarge2</a> is now available as
+    part of Type2!
+  </Body.Medium500>
+  <br />
+  <Body.Regular400>
+    Check with your Figma designer to see if you can use Type2!
+    <br />
+    What is Type2 you ask? <br />
+    <a
+      href="https://github.com/getethos/ethos-design-system#typography-type-vs-type2-vs-typebase"
+      target="_blank"
+    >
+      Ask and you shall receive! README#Typography: Type vs Type2 vs TypeBase
+    </a>
+  </Body.Regular400>
+</>
 ```
 
 ```jsx
-<TitleXLarge.Serif.Regular400>We offer modern, ethical life insurance</TitleXLarge.Serif.Regular400>
+<TitleXLarge.Serif.Book500>
+  We offer modern, ethical life insurance
+</TitleXLarge.Serif.Book500>
 ```
 
 ```jsx
-<TitleXLarge.Serif.Demi600>We offer modern, ethical life insurance</TitleXLarge.Serif.Demi600>
+<TitleXLarge.Serif.Regular400>
+  We offer modern, ethical life insurance
+</TitleXLarge.Serif.Regular400>
 ```
 
 ```jsx
-<TitleXLarge.Sans.Medium500>We offer modern, ethical life insurance</TitleXLarge.Sans.Medium500>
+<TitleXLarge.Serif.Demi600>
+  We offer modern, ethical life insurance
+</TitleXLarge.Serif.Demi600>
 ```
 
 ```jsx
-<TitleXLarge.Sans.Regular400>We offer modern, ethical life insurance</TitleXLarge.Sans.Regular400>
+<TitleXLarge.Sans.Medium500>
+  We offer modern, ethical life insurance
+</TitleXLarge.Sans.Medium500>
 ```
 
 ```jsx
-<TitleXLarge.Sans.Light300>We offer modern, ethical life insurance</TitleXLarge.Sans.Light300>
+<TitleXLarge.Sans.Regular400>
+  We offer modern, ethical life insurance
+</TitleXLarge.Sans.Regular400>
+```
+
+```jsx
+<TitleXLarge.Sans.Light300>
+  We offer modern, ethical life insurance
+</TitleXLarge.Sans.Light300>
 ```

--- a/src/components/Type/TitleXXLarge.md
+++ b/src/components/Type/TitleXXLarge.md
@@ -1,23 +1,63 @@
 ```jsx
-<TitleXXLarge.Serif.Book500>We offer modern, ethical life insurance</TitleXXLarge.Serif.Book500>
+import { Body } from '../Body'
+;<>
+  <Body.Regular400 color="BrandSalamander">
+    TitleXXLarge is in the process of being deprecated, please avoid introducing
+    new instances!
+  </Body.Regular400>
+  <br />
+  <Body.Medium500>
+    <a href="/#/Components/TitleXLarge2">TitleXLarge2</a>/
+    <a href="/#/Components/TitleLarge2">TitleLarge2</a> is now available as part
+    of Type2! No more XXL!
+  </Body.Medium500>
+  <br />
+  <Body.Regular400>
+    Check with your Figma designer to see if you can use Type2!
+    <br />
+    What is Type2 you ask? <br />
+    <a
+      href="https://github.com/getethos/ethos-design-system#typography-type-vs-type2-vs-typebase"
+      target="_blank"
+    >
+      Ask and you shall receive! README#Typography: Type vs Type2 vs TypeBase
+    </a>
+  </Body.Regular400>
+</>
 ```
 
 ```jsx
-<TitleXXLarge.Serif.Regular400>We offer modern, ethical life insurance</TitleXXLarge.Serif.Regular400>
+<TitleXXLarge.Serif.Book500>
+  We offer modern, ethical life insurance
+</TitleXXLarge.Serif.Book500>
 ```
 
 ```jsx
-<TitleXXLarge.Serif.Demi600>We offer modern, ethical life insurance</TitleXXLarge.Serif.Demi600>
+<TitleXXLarge.Serif.Regular400>
+  We offer modern, ethical life insurance
+</TitleXXLarge.Serif.Regular400>
 ```
 
 ```jsx
-<TitleXXLarge.Sans.Medium500>We offer modern, ethical life insurance</TitleXXLarge.Sans.Medium500>
+<TitleXXLarge.Serif.Demi600>
+  We offer modern, ethical life insurance
+</TitleXXLarge.Serif.Demi600>
 ```
 
 ```jsx
-<TitleXXLarge.Sans.Regular400>We offer modern, ethical life insurance</TitleXXLarge.Sans.Regular400>
+<TitleXXLarge.Sans.Medium500>
+  We offer modern, ethical life insurance
+</TitleXXLarge.Sans.Medium500>
 ```
 
 ```jsx
-<TitleXXLarge.Sans.Light300>We offer modern, ethical life insurance</TitleXXLarge.Sans.Light300>
+<TitleXXLarge.Sans.Regular400>
+  We offer modern, ethical life insurance
+</TitleXXLarge.Sans.Regular400>
+```
+
+```jsx
+<TitleXXLarge.Sans.Light300>
+  We offer modern, ethical life insurance
+</TitleXXLarge.Sans.Light300>
 ```

--- a/src/components/Type2/Blueprint.js
+++ b/src/components/Type2/Blueprint.js
@@ -81,6 +81,8 @@
  * 5. Rollout deprecation strategy and encourage developers to stop using legacy Type entirely and
  *    actively replace legacy components with Type2 components.
  *
+ *    Add any customizations specific to Type2 for developer ease of use.
+ *
  * 6. Once deprecation is complete, remove legacy Type (it will 'live on' through BaseType) and
  *    rename Type2 to Type.
  *
@@ -90,8 +92,9 @@
  * --------------------------
  * (March 18) 1
  * (March 19) 1 -> 2
+ * (April 10) 2 -> 3 -> 4
  *
- *  1 |  [-2-]  |  3  |  4  |  5  |  6
+ *  1 |  2  |  3  |  [4]  |  5  |  6
  */
 
 /** Steps for consumers to migrate from Type to TypeBase

--- a/src/components/Type2/Blueprint.js
+++ b/src/components/Type2/Blueprint.js
@@ -41,6 +41,10 @@
  * font families, since it's the only weight for Cambon in Type2. Easier to remember if Medium500
  * is the same weight name across both families.
  *
+ * CSS for font sizes could be dried up if font size calculation can be removed. Do we need sass math?
+ * Font size values could also be variables.
+ *
+ *
  *
  * Specifications from design
  * --------------------------

--- a/src/components/Type2/Blueprint.js
+++ b/src/components/Type2/Blueprint.js
@@ -34,6 +34,13 @@
  *   - Less rigidity for passing extra properties like className
  *   - ???
  *
+ * Should we drop weight param from Cambon now that there is only * one weight? Probably not for
+ * consistency of including a weight when using a comonent.
+ *
+ * Book500 backwards compatibility added but would like to use Medium500 going forward across both
+ * font families, since it's the only weight for Cambon in Type2. Easier to remember if Medium500
+ * is the same weight name across both families.
+ *
  *
  * Specifications from design
  * --------------------------
@@ -59,7 +66,7 @@
  *    This should be deployable on it's own to consumers to prove there is no regression.
  *
  * 2. Fork BaseType and build Type2 with a single component POC, deployable to consumers.
- *	  Build a Type2 root component that extends TypeBase.
+ *    Build a Type2 root component that extends TypeBase.
  *
  *    When a new component is available in Type2, EDS should warn the consumer to check if they
  *    can switch if it sees them implement an instance of the matching legacy Type component.

--- a/src/components/Type2/TitleLarge2.js
+++ b/src/components/Type2/TitleLarge2.js
@@ -1,0 +1,28 @@
+import { TypeBase, TypeFoundry } from '../TypeBase/TypeBase.js'
+
+export const TitleLarge2 = {
+  Sans: {
+    Medium500: TypeFoundry({
+      subtype: TypeBase.SUBTYPES.TITLE_LARGE2,
+      typeface: TypeBase.TYPEFACES.THEINHARDT,
+      weight: TypeBase.WEIGHTS.MEDIUM_500,
+    }),
+    Regular400: TypeFoundry({
+      subtype: TypeBase.SUBTYPES.TITLE_LARGE2,
+      typeface: TypeBase.TYPEFACES.THEINHARDT,
+      weight: TypeBase.WEIGHTS.REGULAR_400,
+    }),
+  },
+  Serif: {
+    Medium500: TypeFoundry({
+      subtype: TypeBase.SUBTYPES.TITLE_LARGE2,
+      typeface: TypeBase.TYPEFACES.CAMBON,
+      weight: TypeBase.WEIGHTS.MEDIUM_500,
+    }),
+    Book500: TypeFoundry({
+      subtype: TypeBase.SUBTYPES.TITLE_LARGE2,
+      typeface: TypeBase.TYPEFACES.CAMBON,
+      weight: TypeBase.WEIGHTS.BOOK_500,
+    }),
+  },
+}

--- a/src/components/Type2/TitleLarge2.md
+++ b/src/components/Type2/TitleLarge2.md
@@ -1,0 +1,20 @@
+```jsx
+<TitleLarge2.Serif.Medium500>We offer modern, ethical life insurance</TitleLarge2.Serif.Medium500>
+```
+
+```jsx
+<TitleLarge2.Serif.Book500>We offer modern, ethical life insurance</TitleLarge2.Serif.Book500>
+```
+
+```jsx
+<TitleLarge2.Sans.Medium500>We offer modern, ethical life insurance</TitleLarge2.Sans.Medium500>
+```
+
+```jsx
+<TitleLarge2.Sans.Regular400>We offer modern, ethical life insurance</TitleLarge2.Sans.Regular400>
+```
+
+```jsx
+<TitleLarge2.Sans.Regular400 element='label'>I should be a label element. Inspect me to see :)</TitleLarge2.Sans.Regular400>
+```
+

--- a/src/components/Type2/TitleMedium2.js
+++ b/src/components/Type2/TitleMedium2.js
@@ -1,0 +1,28 @@
+import { TypeBase, TypeFoundry } from '../TypeBase/TypeBase.js'
+
+export const TitleMedium2 = {
+  Sans: {
+    Medium500: TypeFoundry({
+      subtype: TypeBase.SUBTYPES.TITLE_MEDIUM2,
+      typeface: TypeBase.TYPEFACES.THEINHARDT,
+      weight: TypeBase.WEIGHTS.MEDIUM_500,
+    }),
+    Regular400: TypeFoundry({
+      subtype: TypeBase.SUBTYPES.TITLE_MEDIUM2,
+      typeface: TypeBase.TYPEFACES.THEINHARDT,
+      weight: TypeBase.WEIGHTS.REGULAR_400,
+    }),
+  },
+  Serif: {
+    Medium500: TypeFoundry({
+      subtype: TypeBase.SUBTYPES.TITLE_MEDIUM2,
+      typeface: TypeBase.TYPEFACES.CAMBON,
+      weight: TypeBase.WEIGHTS.MEDIUM_500,
+    }),
+    Book500: TypeFoundry({
+      subtype: TypeBase.SUBTYPES.TITLE_MEDIUM2,
+      typeface: TypeBase.TYPEFACES.CAMBON,
+      weight: TypeBase.WEIGHTS.BOOK_500,
+    }),
+  },
+}

--- a/src/components/Type2/TitleMedium2.md
+++ b/src/components/Type2/TitleMedium2.md
@@ -1,0 +1,20 @@
+```jsx
+<TitleMedium2.Serif.Medium500>We offer modern, ethical life insurance</TitleMedium2.Serif.Medium500>
+```
+
+```jsx
+<TitleMedium2.Serif.Book500>We offer modern, ethical life insurance</TitleMedium2.Serif.Book500>
+```
+
+```jsx
+<TitleMedium2.Sans.Medium500>We offer modern, ethical life insurance</TitleMedium2.Sans.Medium500>
+```
+
+```jsx
+<TitleMedium2.Sans.Regular400>We offer modern, ethical life insurance</TitleMedium2.Sans.Regular400>
+```
+
+```jsx
+<TitleMedium2.Sans.Regular400 element='label'>I should be a label element. Inspect me to see :)</TitleMedium2.Sans.Regular400>
+```
+

--- a/src/components/Type2/TitleSmall2.js
+++ b/src/components/Type2/TitleSmall2.js
@@ -1,12 +1,28 @@
 import { TypeBase, TypeFoundry } from '../TypeBase/TypeBase.js'
 
-// Currently drastically different than existing TitleSmall for testing purposes
 export const TitleSmall2 = {
   Sans: {
-    Light300: TypeFoundry({
-      subtype: TypeBase.SUBTYPES.TITLE_MEDIUM,
+    Medium500: TypeFoundry({
+      subtype: TypeBase.SUBTYPES.TITLE_SMALL2,
       typeface: TypeBase.TYPEFACES.THEINHARDT,
       weight: TypeBase.WEIGHTS.MEDIUM_500,
+    }),
+    Regular400: TypeFoundry({
+      subtype: TypeBase.SUBTYPES.TITLE_SMALL2,
+      typeface: TypeBase.TYPEFACES.THEINHARDT,
+      weight: TypeBase.WEIGHTS.REGULAR_400,
+    }),
+  },
+  Serif: {
+    Medium500: TypeFoundry({
+      subtype: TypeBase.SUBTYPES.TITLE_SMALL2,
+      typeface: TypeBase.TYPEFACES.CAMBON,
+      weight: TypeBase.WEIGHTS.MEDIUM_500,
+    }),
+    Book500: TypeFoundry({
+      subtype: TypeBase.SUBTYPES.TITLE_SMALL2,
+      typeface: TypeBase.TYPEFACES.CAMBON,
+      weight: TypeBase.WEIGHTS.BOOK_500,
     }),
   },
 }

--- a/src/components/Type2/TitleSmall2.md
+++ b/src/components/Type2/TitleSmall2.md
@@ -1,3 +1,20 @@
 ```jsx
-<TitleSmall2.Sans.Light300>Test TitleSmall2.Sans.Light30 - not small or light!</TitleSmall2.Sans.Light300>
+<TitleSmall2.Serif.Medium500>We offer modern, ethical life insurance</TitleSmall2.Serif.Medium500>
 ```
+
+```jsx
+<TitleSmall2.Serif.Book500>We offer modern, ethical life insurance</TitleSmall2.Serif.Book500>
+```
+
+```jsx
+<TitleSmall2.Sans.Medium500>We offer modern, ethical life insurance</TitleSmall2.Sans.Medium500>
+```
+
+```jsx
+<TitleSmall2.Sans.Regular400>We offer modern, ethical life insurance</TitleSmall2.Sans.Regular400>
+```
+
+```jsx
+<TitleSmall2.Sans.Regular400 element='label'>I should be a label element. Inspect me to see :)</TitleSmall2.Sans.Regular400>
+```
+

--- a/src/components/Type2/TitleXLarge2.js
+++ b/src/components/Type2/TitleXLarge2.js
@@ -1,0 +1,16 @@
+import { TypeBase, TypeFoundry } from '../TypeBase/TypeBase.js'
+
+export const TitleXLarge2 = {
+  Serif: {
+    Medium500: TypeFoundry({
+      subtype: TypeBase.SUBTYPES.TITLE_XLARGE2,
+      typeface: TypeBase.TYPEFACES.CAMBON,
+      weight: TypeBase.WEIGHTS.MEDIUM_500,
+    }),
+    Book500: TypeFoundry({
+      subtype: TypeBase.SUBTYPES.TITLE_XLARGE2,
+      typeface: TypeBase.TYPEFACES.CAMBON,
+      weight: TypeBase.WEIGHTS.BOOK_500,
+    }),
+  },
+}

--- a/src/components/Type2/TitleXLarge2.md
+++ b/src/components/Type2/TitleXLarge2.md
@@ -1,0 +1,12 @@
+```jsx
+<TitleXLarge2.Serif.Medium500>We offer modern, ethical life insurance</TitleXLarge2.Serif.Medium500>
+```
+
+```jsx
+<TitleXLarge2.Serif.Book500>We offer modern, ethical life insurance</TitleXLarge2.Serif.Book500>
+```
+
+```jsx
+<TitleXLarge2.Serif.Medium500 element='label'>I should be a label element. Inspect me to see :)</TitleXLarge2.Serif.Medium500>
+```
+

--- a/src/components/Type2/index.js
+++ b/src/components/Type2/index.js
@@ -1,5 +1,5 @@
 export { TitleSmall2 } from './TitleSmall2.js'
 export { TitleMedium2 } from './TitleMedium2.js'
 export { TitleLarge2 } from './TitleLarge2.js'
-// export { TitleXLarge } from './TitleXLarge.js'
+export { TitleXLarge2 } from './TitleXLarge2.js'
 // export { TitleXXLarge } from './TitleXXLarge.js'

--- a/src/components/Type2/index.js
+++ b/src/components/Type2/index.js
@@ -1,5 +1,5 @@
 export { TitleSmall2 } from './TitleSmall2.js'
-// export { TitleMedium } from './TitleMedium.js'
+export { TitleMedium2 } from './TitleMedium2.js'
 // export { TitleLarge } from './TitleLarge.js'
 // export { TitleXLarge } from './TitleXLarge.js'
 // export { TitleXXLarge } from './TitleXXLarge.js'

--- a/src/components/Type2/index.js
+++ b/src/components/Type2/index.js
@@ -1,3 +1,5 @@
+export { Caption2 } from '../Caption2.js'
+export { Body2 } from '../Body2.js'
 export { TitleSmall2 } from './TitleSmall2.js'
 export { TitleMedium2 } from './TitleMedium2.js'
 export { TitleLarge2 } from './TitleLarge2.js'

--- a/src/components/Type2/index.js
+++ b/src/components/Type2/index.js
@@ -1,5 +1,5 @@
 export { TitleSmall2 } from './TitleSmall2.js'
 export { TitleMedium2 } from './TitleMedium2.js'
-// export { TitleLarge } from './TitleLarge.js'
+export { TitleLarge2 } from './TitleLarge2.js'
 // export { TitleXLarge } from './TitleXLarge.js'
 // export { TitleXXLarge } from './TitleXXLarge.js'

--- a/src/components/TypeBase/TypeBase.js
+++ b/src/components/TypeBase/TypeBase.js
@@ -96,6 +96,8 @@ TypeBase.SUBTYPES = {
   TITLE_XLARGE: 'TitleXLarge',
   TITLE_XXLARGE: 'TitleXXLarge',
   // Type2
+  CAPTION2: 'Caption2',
+  BODY2: 'Body2',
   TITLE_SMALL2: 'TitleSmall2',
   TITLE_MEDIUM2: 'TitleMedium2',
   TITLE_LARGE2: 'TitleLarge2',

--- a/src/components/TypeBase/TypeBase.js
+++ b/src/components/TypeBase/TypeBase.js
@@ -86,6 +86,7 @@ export const TypeBase = ({
 }
 
 TypeBase.SUBTYPES = {
+  // Original Type
   CAPTION: 'Caption', // smallest
   FOOTNOTE: 'Footnote',
   BODY: 'Body', // default
@@ -94,6 +95,11 @@ TypeBase.SUBTYPES = {
   TITLE_LARGE: 'TitleLarge',
   TITLE_XLARGE: 'TitleXLarge',
   TITLE_XXLARGE: 'TitleXXLarge',
+  // Type2
+  TITLE_SMALL2: 'TitleSmall2',
+  TITLE_MEDIUM2: 'TitleMedium2',
+  TITLE_LARGE2: 'TitleLarge2',
+  TITLE_XLARGE2: 'TitleXLarge2',
 }
 
 TypeBase.TYPEFACES = {

--- a/src/components/TypeBase/TypeBase.module.scss
+++ b/src/components/TypeBase/TypeBase.module.scss
@@ -482,4 +482,14 @@ h6,
     letter-spacing: -0.0275em;
   }
 }
+
+.TitleXLarge2 {
+  &.Cambon {
+    $font-size: 60;
+    $line-height: 64;
+    font-size: $font-size * 1px;
+    line-height: $line-height / $font-size;
+    letter-spacing: -0.034em;
+  }
+}
 /* ------------------------ Close Type2 ------------------------ */

--- a/src/components/TypeBase/TypeBase.module.scss
+++ b/src/components/TypeBase/TypeBase.module.scss
@@ -16,7 +16,11 @@
 .TitleMedium,
 .TitleLarge,
 .TitleXLarge,
-.TitleXXLarge {
+.TitleXXLarge,
+.TitleSmall2,
+.TitleMedium2,
+.TitleLarge2,
+.TitleXLarge2 {
   /* Brand colors */
 
   &.BrandForest {
@@ -122,7 +126,11 @@ h6,
 .TitleMedium,
 .TitleLarge,
 .TitleXLarge,
-.TitleXXLarge {
+.TitleXXLarge,
+.TitleSmall2,
+.TitleMedium2,
+.TitleLarge2,
+.TitleXLarge2 {
   margin: 0;
 }
 
@@ -397,3 +405,52 @@ h6,
     }
   }
 }
+
+/* ------------------------ Start Type2 ------------------------ */
+.TitleSmall2 {
+  &.Theinhardt {
+    $font-size: 20;
+    $line-height: 26;
+    font-size: $font-size * 1px;
+    line-height: $line-height / $font-size;
+    letter-spacing: 0.001em;
+  }
+
+  &.Cambon {
+    $font-size: 24.5;
+    $line-height: 28;
+    font-size: $font-size * 1px;
+    line-height: $line-height / $font-size;
+    letter-spacing: -0.017em;
+  }
+}
+
+.TitleMedium2 {
+  &.Theinhardt {
+    @include for-phone-only {
+      /* TitleSmall2 */
+      $font-size: 20;
+      $line-height: 26;
+      font-size: $font-size * 1px;
+      line-height: $line-height / $font-size;
+      letter-spacing: 0.001em;
+    }
+
+    @include for-tablet-and-up {
+      $font-size: 24;
+      $line-height: 32;
+      font-size: $font-size * 1px;
+      line-height: $line-height / $font-size;
+      letter-spacing: -0.0125em;
+    }
+  }
+
+  &.Cambon {
+    $font-size: 32;
+    $line-height: 36;
+    font-size: $font-size * 1px;
+    line-height: $line-height / $font-size;
+    letter-spacing: -0.022em;
+  }
+}
+/* ------------------------ Close Type2 ------------------------ */

--- a/src/components/TypeBase/TypeBase.module.scss
+++ b/src/components/TypeBase/TypeBase.module.scss
@@ -17,6 +17,8 @@
 .TitleLarge,
 .TitleXLarge,
 .TitleXXLarge,
+.Caption2,
+.Body2,
 .TitleSmall2,
 .TitleMedium2,
 .TitleLarge2,
@@ -394,7 +396,13 @@ h6,
 .TitleMedium,
 .TitleLarge,
 .TitleXLarge,
-.TitleXXLarge {
+.TitleXXLarge,
+.Caption2,
+.Body2,
+.TitleSmall2,
+.TitleMedium2,
+.TitleLarge2,
+.TitleXLarge2 {
   a {
     &,
     &:active,
@@ -407,6 +415,26 @@ h6,
 }
 
 /* ------------------------ Start Type2 ------------------------ */
+.Caption2 {
+  &.Theinhardt {
+    $font-size: 14;
+    $line-height: 16;
+    font-size: $font-size * 1px;
+    line-height: $line-height / $font-size;
+    letter-spacing: 0.0045em;
+  }
+}
+
+.Body2 {
+  &.Theinhardt {
+    $font-size: 17.5;
+    $line-height: 24;
+    font-size: $font-size * 1px;
+    line-height: $line-height / $font-size;
+    letter-spacing: 0;
+  }
+}
+
 .TitleSmall2 {
   &.Theinhardt {
     $font-size: 20;

--- a/src/components/TypeBase/TypeBase.module.scss
+++ b/src/components/TypeBase/TypeBase.module.scss
@@ -428,7 +428,7 @@ h6,
 .TitleMedium2 {
   &.Theinhardt {
     @include for-phone-only {
-      /* TitleSmall2 */
+      /* Matches TitleSmall2 all viewports*/
       $font-size: 20;
       $line-height: 26;
       font-size: $font-size * 1px;
@@ -451,6 +451,35 @@ h6,
     font-size: $font-size * 1px;
     line-height: $line-height / $font-size;
     letter-spacing: -0.022em;
+  }
+}
+
+.TitleLarge2 {
+  &.Theinhardt {
+    @include for-phone-only {
+      /* Matches TitleMedium2 for-tablet-and-up */
+      $font-size: 24;
+      $line-height: 32;
+      font-size: $font-size * 1px;
+      line-height: $line-height / $font-size;
+      letter-spacing: -0.0125em;
+    }
+
+    @include for-tablet-and-up {
+      $font-size: 28;
+      $line-height: 36;
+      font-size: $font-size * 1px;
+      line-height: $line-height / $font-size;
+      letter-spacing: -0.016em;
+    }
+  }
+
+  &.Cambon {
+    $font-size: 43.5;
+    $line-height: 48;
+    font-size: $font-size * 1px;
+    line-height: $line-height / $font-size;
+    letter-spacing: -0.0275em;
   }
 }
 /* ------------------------ Close Type2 ------------------------ */

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -901,6 +901,7 @@ export { TitleXXLarge } from './Type/TitleXXLarge.js'
 export { TitleSmall2 } from './Type2/TitleSmall2.js'
 export { TitleMedium2 } from './Type2/TitleMedium2.js'
 export { TitleLarge2 } from './Type2/TitleLarge2.js'
+export { TitleXLarge2 } from './Type2/TitleXLarge2.js'
 
 ////////////////////////////
 // ---- NORA EXPORTS ---- //

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -899,6 +899,7 @@ export { TitleXXLarge } from './Type/TitleXXLarge.js'
 
 // Type2
 export { TitleSmall2 } from './Type2/TitleSmall2.js'
+export { TitleMedium2 } from './Type2/TitleMedium2.js'
 
 ////////////////////////////
 // ---- NORA EXPORTS ---- //

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -900,6 +900,7 @@ export { TitleXXLarge } from './Type/TitleXXLarge.js'
 // Type2
 export { TitleSmall2 } from './Type2/TitleSmall2.js'
 export { TitleMedium2 } from './Type2/TitleMedium2.js'
+export { TitleLarge2 } from './Type2/TitleLarge2.js'
 
 ////////////////////////////
 // ---- NORA EXPORTS ---- //

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -898,6 +898,8 @@ export { TitleXLarge } from './Type/TitleXLarge.js'
 export { TitleXXLarge } from './Type/TitleXXLarge.js'
 
 // Type2
+export { Caption2 } from './Caption2.js'
+export { Body2 } from './Body2.js'
 export { TitleSmall2 } from './Type2/TitleSmall2.js'
 export { TitleMedium2 } from './Type2/TitleMedium2.js'
 export { TitleLarge2 } from './Type2/TitleLarge2.js'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -48,7 +48,7 @@ export {
   TitleXXLarge,
   Link,
 } from './Type'
-export { TitleSmall2, TitleMedium2 } from './Type2'
+export { TitleSmall2, TitleMedium2, TitleLarge2 } from './Type2'
 export { UniversalNavbar } from './UniversalNavbar/UniversalNavbar'
 export { UniversalNavbarExpanded } from './UniversalNavbarExpanded/UniversalNavbarExpanded'
 export { ValueProps } from './ValueProps'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -48,7 +48,14 @@ export {
   TitleXXLarge,
   Link,
 } from './Type'
-export { TitleSmall2, TitleMedium2, TitleLarge2, TitleXLarge2 } from './Type2'
+export {
+  Caption2,
+  Body2,
+  TitleSmall2,
+  TitleMedium2,
+  TitleLarge2,
+  TitleXLarge2,
+} from './Type2'
 export { UniversalNavbar } from './UniversalNavbar/UniversalNavbar'
 export { UniversalNavbarExpanded } from './UniversalNavbarExpanded/UniversalNavbarExpanded'
 export { ValueProps } from './ValueProps'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -48,7 +48,7 @@ export {
   TitleXXLarge,
   Link,
 } from './Type'
-export { TitleSmall2, TitleMedium2, TitleLarge2 } from './Type2'
+export { TitleSmall2, TitleMedium2, TitleLarge2, TitleXLarge2 } from './Type2'
 export { UniversalNavbar } from './UniversalNavbar/UniversalNavbar'
 export { UniversalNavbarExpanded } from './UniversalNavbarExpanded/UniversalNavbarExpanded'
 export { ValueProps } from './ValueProps'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -48,7 +48,7 @@ export {
   TitleXXLarge,
   Link,
 } from './Type'
-export { TitleSmall2 } from './Type2'
+export { TitleSmall2, TitleMedium2 } from './Type2'
 export { UniversalNavbar } from './UniversalNavbar/UniversalNavbar'
 export { UniversalNavbarExpanded } from './UniversalNavbarExpanded/UniversalNavbarExpanded'
 export { ValueProps } from './ValueProps'


### PR DESCRIPTION
**Todo**
- [x] Add wishlist item note: https://github.com/getethos/ethos-design-system/pull/318#discussion_r407003430
- [x] Add note re: PR feedback https://github.com/getethos/ethos-design-system/pull/318#issuecomment-612299969

**Description:**
- [Asana Task](https://app.asana.com/0/1116481661798430/1162971424036361/f)
- Adds the following components with their Type2 defined weights, font sizes, line heights and letter spacing.
  - Body2
  - Caption2
  - TitleSmall2
  - TitleMedium2
  - TitleLarge2
  - TitleXLarge2
- Open to discussing the Medium500/Book500 alias, see changes to README and Blueprint.js for context.
- I've asked Design if it's possible to get phone viewport mapping for the 7 `Not in use on Phone` cells in column D on the [spreadsheet here](https://docs.google.com/spreadsheets/d/1LiKYSuW5Lfh24OjT8e0WgNLcxuAZrFlbzmw_NJjUNOo/edit?usp=sharing). IMO it would be nice to have resizing fallbacks.

**Is this a new component? Please review these reminders:**
- [x] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [x] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [x] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**
- See in action on WIP CMS PR: 
  -- [deploy preview](https://deploy-preview-2930--ethos-cms.netlify.com/demo/EstimateWidget/)
  -- [code ref](https://github.com/getethos/cms/pull/2930/files#diff-fbd7d7f85b80ec6aff30aa7d02565246R149)

**Screenshots:**
<img width="1151" alt="Screen Shot 2020-04-10 at 4 16 24 PM" src="https://user-images.githubusercontent.com/4285270/79028855-a8e92400-7b46-11ea-942f-f081ffe21089.png">
<img width="1167" alt="Screen Shot 2020-04-10 at 4 16 18 PM" src="https://user-images.githubusercontent.com/4285270/79028860-ac7cab00-7b46-11ea-8790-7fbc58bd5404.png">
<img width="1166" alt="Screen Shot 2020-04-10 at 4 16 07 PM" src="https://user-images.githubusercontent.com/4285270/79028861-ad154180-7b46-11ea-8945-599921e89904.png">
<img width="1104" alt="Screen Shot 2020-04-10 at 5 32 49 PM" src="https://user-images.githubusercontent.com/4285270/79031080-55c89e80-7b51-11ea-90b8-1f0f088447a8.png">
