### PR TITLE
Check for document before referencing in Portal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.165",
+  "version": "1.1.166",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Portal/Portal.js
+++ b/src/components/Portal/Portal.js
@@ -14,6 +14,10 @@ import PropTypes from 'prop-types'
  * @return {HTMLElement} - The DOM node to use as the Portal target
  */
 function usePortal(id) {
+  if (typeof document === 'undefined' || !document) {
+    return
+  }
+
   const [isAttached, setIsAttached] = useState(false)
   const elRef = useRef(
     document.getElementById(id) || document.createElement('div')


### PR DESCRIPTION
**Description:**
- Prevents `Portal` component from trying to reference `document` before it's defined.
- No asana task.
- CMS builds are breaking on the latest version of EDS, `document` is being referenced while Gatsby is building. 
- Errors out on: `error "document" is not available during server side rendering`
- [Gatsby documentation on this issue](https://www.gatsbyjs.org/docs/debugging-html-builds/)

**Is this a new component? Please review these reminders:**
Existing component.
- [x] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [x] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [x] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**
- https://github.com/getethos/cms/pull/2930

**Screenshots:**
<img width="1333" alt="Screen Shot 2020-04-13 at 12 53 22 PM" src="https://user-images.githubusercontent.com/4285270/79155309-c6580100-7d85-11ea-9e91-ce57abe76e9a.png">

**Full error log**
```
11:27:30 AM: failed Building static HTML for pages - 28.680s
11:27:30 AM: error "document" is not available during server side rendering.
11:27:30 AM:   17 |   const [isAttached, setIsAttached] = useState(false)
11:27:30 AM:   18 |   const elRef = useRef(
11:27:30 AM: > 19 |     document.getElementById(id) || document.createElement('div')
11:27:30 AM:      |     ^
11:27:30 AM:   20 |   )
11:27:30 AM:   21 |
11:27:30 AM:   22 |   useEffect(() => {
11:27:30 AM: 
11:27:30 AM:   WebpackError: ReferenceError: document is not defined
11:27:30 AM:   
11:27:30 AM:   - Portal.js:19 usePortal
11:27:30 AM:     node_modules/ethos-design-system/src/components/Portal/Portal.js:19:5
11:27:30 AM:   
11:27:30 AM:   - Portal.js:62 Portal
11:27:30 AM:     node_modules/ethos-design-system/src/components/Portal/Portal.js:62:16
11:27:30 AM:   
11:27:30 AM: 
11:27:31 AM: error Command failed with exit code 1.
```
ref: `https://app.netlify.com/sites/ethos-cms/deploys/5e94adb1583a08000635fbf3`