### PR TITLE
Portal document reference follow up

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.166",
+  "version": "1.1.167",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Portal/Portal.js
+++ b/src/components/Portal/Portal.js
@@ -14,10 +14,6 @@ import PropTypes from 'prop-types'
  * @return {HTMLElement} - The DOM node to use as the Portal target
  */
 function usePortal(id) {
-  if (typeof document === 'undefined' || !document) {
-    return
-  }
-
   const [isAttached, setIsAttached] = useState(false)
   const elRef = useRef(
     document.getElementById(id) || document.createElement('div')
@@ -63,6 +59,10 @@ function usePortal(id) {
  * @return {React.ReactPortal}
  */
 export const Portal = ({ id, children }) => {
+  if (typeof document === 'undefined' || !document) {
+    return
+  }
+
   const root = usePortal(id)
 
   return createPortal(children, root)

--- a/src/components/Portal/Portal.js
+++ b/src/components/Portal/Portal.js
@@ -60,7 +60,7 @@ function usePortal(id) {
  */
 export const Portal = ({ id, children }) => {
   if (typeof document === 'undefined' || !document) {
-    return
+    return null
   }
 
   const root = usePortal(id)


### PR DESCRIPTION
**Description:**
- Might have jumped the gun on #319, as I'm still seeing errors on CMS.
- Needed to move `return` up one level and add `null`.
- Checked this branch on a CMS deploy before assuming it resolves the issue (should have done that the first go round...).
- Resolved build off this branch: https://app.netlify.com/sites/ethos-cms/deploys/5e94d59824db1900072ace3a
- Failed build off of v1.1.166 from #319: https://app.netlify.com/sites/ethos-cms/deploys/5e94cf4c417e930006053bd9
- Demo of `Modal` which uses `Portal`: https://5e94d59824db1900072ace3a--ethos-cms.netlify.com/demo/EstimateWidget/ (fill out, click continue, click Save Estimates to see Modal)
![Screen Shot 2020-04-13 at 2 20 26 PM](https://user-images.githubusercontent.com/4285270/79162376-fdccaa80-7d91-11ea-9b53-82c942746f91.png)
