### PR TITLE
Data grid's keydown listener competing with popover listener bugz

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.172",
+  "version": "1.1.173",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.173",
+  "version": "1.1.174",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/AsyncTypeahead/AsyncTypeahead.js
+++ b/src/components/AsyncTypeahead/AsyncTypeahead.js
@@ -137,6 +137,7 @@ export const AsyncTypeahead = ({
         onClick: setShow,
         onKeyDown: (ev) =>
           handlePopoverNavigation({
+            autoopenOnFocus: true,
             ev,
             items: entities,
             onChange,

--- a/src/hooks/usePopoverNavigation.js
+++ b/src/hooks/usePopoverNavigation.js
@@ -17,6 +17,7 @@ const usePopoverNavigation = () => {
    * active and selected item indexes
    */
   const handlePopoverNavigation = ({
+    autoopenOnFocus,
     ev,
     items,
     onChange,
@@ -55,7 +56,8 @@ const usePopoverNavigation = () => {
         // Prevents input cursor from jumping
         ev.preventDefault()
         // if options closed and we're attempting to trigger opening w/down arrow
-        if (!showPopover) {
+        // but only if we've opted in with autoopenOnFocus
+        if (!showPopover && autoopenOnFocus) {
           setShowPopover(true)
         }
         if (activeOption < items.length - 1) {

--- a/src/nora/components/KabobMenu/KabobMenuContainer.js
+++ b/src/nora/components/KabobMenu/KabobMenuContainer.js
@@ -73,11 +73,13 @@ export const KabobMenuContainer = ({
     const elements = getFocusableElements(popoverTrapRef.current)
     if (isOpen && elements.length > 0) {
       elements[0].focus()
-      document.body.addEventListener('keydown', handleOnKeyDown)
+      popoverTrapRef.current.addEventListener('keydown', handleOnKeyDown)
     }
     return () => {
       prevFocusedEl.focus()
-      document.body.removeEventListener('keydown', handleOnKeyDown)
+      if (popoverTrapRef && popoverTrapRef.current) {
+        popoverTrapRef.current.removeEventListener('keydown', handleOnKeyDown)
+      }
     }
   }, [popoverTrapRef, isOpen])
 

--- a/src/nora/components/KabobMenu/KabobMenuContainer.js
+++ b/src/nora/components/KabobMenu/KabobMenuContainer.js
@@ -1,9 +1,10 @@
-import React, { useState } from 'react'
+import React, { useLayoutEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { Options } from '../../../components/index'
 import { KabobMenu } from './index'
 import useScrollItemIntoView from '../../../hooks/useScrollItemIntoView'
 import usePopoverNavigation from '../../../hooks/usePopoverNavigation'
+import { getFocusableElements } from '../../../hooks/a11y/useTrapFocus'
 
 export const KabobMenuContainer = ({
   focusRef,
@@ -15,6 +16,11 @@ export const KabobMenuContainer = ({
   setLastSelected,
   popoverContainerClasses,
 }) => {
+  /**
+   * If we're using the data grid, we'll get tab index and focus ref as the grid, ultimately, needs to be able to
+   * place focus on the kebob trigger button. However, once we've opened the menu, we need to temporarly sever the
+   * grid's focus control, essentially, trapping focus in the popover dropdown until it's been closed.
+   */
   const tabIndexResolved = tabIndex ? tabIndex : null
   const focusRefResolved = focusRef ? focusRef : null
   const [activeOption, setActiveOption] = useState(0)
@@ -36,6 +42,45 @@ export const KabobMenuContainer = ({
     setActiveOption(index)
   }
 
+  const handleOnKeyDown = (ev) => {
+    /**
+     * Edge case:
+     * If we've been passed in a focus ref (focusRefResolved), we're presumably being used from within the
+     * data grid. So, ugly as it may be, we need to temporarily prevent the data grid's keydown listener
+     * from receiving keydown events until the popover options are no longer opened.
+     */
+    if (focusRefResolved && isOpen) {
+      ev.stopPropagation()
+    }
+
+    handlePopoverNavigation({
+      ev: ev,
+      items: items,
+      onChange: handleOnChange,
+      optionsRefs: optionsRefs,
+      activeOption: activeOption,
+      setActiveOption: setActiveOption,
+      scrollItemIntoView: scrollItemIntoView,
+      showPopover: isOpen,
+      setShowPopover: setIsOpen,
+      setSelectedAndActiveOptions: setSelectedAndActiveOptions,
+    })
+  }
+
+  const popoverTrapRef = React.useRef()
+  useLayoutEffect(() => {
+    const prevFocusedEl = document.activeElement
+    const elements = getFocusableElements(popoverTrapRef.current)
+    if (isOpen && elements.length > 0) {
+      elements[0].focus()
+      document.body.addEventListener('keydown', handleOnKeyDown)
+    }
+    return () => {
+      prevFocusedEl.focus()
+      document.body.removeEventListener('keydown', handleOnKeyDown)
+    }
+  }, [popoverTrapRef, isOpen])
+
   return (
     <KabobMenu
       focusRef={focusRefResolved}
@@ -43,20 +88,7 @@ export const KabobMenuContainer = ({
       onClick={() => {
         setIsOpen(!isOpen)
       }}
-      onKeyDown={(ev) =>
-        handlePopoverNavigation({
-          ev: ev,
-          items: items,
-          onChange: handleOnChange,
-          optionsRefs: optionsRefs,
-          activeOption: activeOption,
-          setActiveOption: setActiveOption,
-          scrollItemIntoView: scrollItemIntoView,
-          showPopover: isOpen,
-          setShowPopover: setIsOpen,
-          setSelectedAndActiveOptions: setSelectedAndActiveOptions,
-        })
-      }
+      onKeyDown={(ev) => handleOnKeyDown(ev)}
     >
       {isOpen ? (
         <ul className={popoverContainerClasses}>


### PR DESCRIPTION
**Description:**

- [Asana Task](https://app.asana.com/0/1150068311310825/1170387956248380/f)
- Fix issue with kabob and data grid competing for focus

![image](https://user-images.githubusercontent.com/142403/79921057-50d3dc80-83e6-11ea-8d1d-57b5e30727c0.png)

- Fix issue where when you navigate down from Grid after already having focus on the Kabob's trigger button, it would open that popover (even though we're now on the next trigger button down by 1 row)

![image](https://user-images.githubusercontent.com/142403/79921041-46194780-83e6-11ea-96bd-16107cadfeb9.png)

___

- [x] Bumped the yarn version?

**Manual Testing:**
I have a dirty Nora branch where I've been verifying all these changes in the data grid. This fixed the two bugs 🙌 