### PR TITLE
Remove console.log from text inputs

### DIFF
--- a/src/components/TextAreaInput/TextAreaInput.js
+++ b/src/components/TextAreaInput/TextAreaInput.js
@@ -78,7 +78,6 @@ function PrivateTextAreaInput({
   // which will in turn update the internal form state as to their validity
   useEffect(() => {
     if (!!formChangeHandler && initialValue) {
-      console.log('TextAreaInput useEffect -- calling doValidation')
       doValidation(initialValue, '')
     }
   }, [])

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -84,7 +84,6 @@ function PrivateTextInput({
   // which will in turn update the internal form state as to their validity
   useEffect(() => {
     if (!!formChangeHandler && initialValue) {
-      console.log('TextInput useEffect -- calling doValidation')
       doValidation(initialValue, true)
     }
   }, [])

--- a/src/nora/components/NoraTextAreaInput/NoraTextAreaInput.js
+++ b/src/nora/components/NoraTextAreaInput/NoraTextAreaInput.js
@@ -72,7 +72,6 @@ export const NoraTextAreaInput = ({
   // which will in turn update the internal form state as to their validity
   useEffect(() => {
     if (!!formChangeHandler && (resolvedValue || initialValue)) {
-      console.log('TextAreaInput useEffect -- calling doValidation')
       doValidation(resolvedValue || initialValue, '')
     }
   }, [])
@@ -85,7 +84,7 @@ export const NoraTextAreaInput = ({
 
   // TODO: this indicates a field level error on the NoraTextAreaInput
   if (getError(currentError, touched)) {
-    console.log('NoraTextAreaInput field error: ', currentError)
+    // console.log('NoraTextAreaInput field error: ', currentError)
   }
 
   return (


### PR DESCRIPTION
**Description:**

- Noticed that the console in Nora was printing out some logs so figured I'd remove them from the Text related fields.

<img width="781" alt="Image 2020-04-22 at 10 26 29 AM" src="https://user-images.githubusercontent.com/12839832/80013612-06a13880-8484-11ea-9ab2-ec13e77b87e4.png">

**Is this a new component? Please review these reminders: **

_Please pick one and delete options that are not relevant:_

- [ ] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [ ] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [ ] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**

-

**Screenshots:**
