### PR TITLE
CMS Estimate experiment in UniversalNavbarExpanded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.174",
+  "version": "1.1.175",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/UniversalNavbarExpanded/MobileNav/SecondaryLinks.js
+++ b/src/components/UniversalNavbarExpanded/MobileNav/SecondaryLinks.js
@@ -38,6 +38,7 @@ const SecondaryLinks = ({
         <div
           className={styles.secondaryLinksItem}
           key={`secondaryLinks${index}`}
+          data-optimizely={`estimateNavBarCopyMobileOptimizely${index}`}
         >
           <NavLink
             href={link.href}

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.d.ts
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.d.ts
@@ -49,6 +49,8 @@ type UniversalNavbarExpandedProps = {
       title: string
     }
     NAVLINKS: NavLink[]
+    /** Estimate copy experiment on optimizely */
+    estimateExperiment?: boolean
   }
 }
 

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -6,7 +6,7 @@ import LogoNotAnimated from '../UniversalNavbar/assets/ethos-logo-black.js'
 import { AccountIcon, SearchIcon } from '../UniversalNavbar/assets/icons.js'
 
 // EDS core components
-import { Layout } from '../index'
+import { Layout, Caption2 } from '../index'
 
 // UniversalNavbarExpanded simple siblings
 import CtaButton from './CtaButton'
@@ -34,6 +34,7 @@ import styles from './UniversalNavbarExpanded.module.scss'
  * @param {object} LinkComponent - Agnotistic Reach and React Router Link (ex. Gatsby's <Link>)
  * @param {string} logoHref - Href for the logo
  * @param {object} links - URLs and text
+ * @param {boolean} estimateExperiment - enable the estimate experiment button/copy
  *
  * @return {JSX.Element}
  */
@@ -44,6 +45,7 @@ const UniversalNavbarExpanded = ({
   logoHref,
   trackCtaClick,
   links,
+  estimateExperiment,
 }) => {
   const BELOW_ACCORDION_LINKS = [links.CTA, links.ACCOUNT, links.SEARCH]
 
@@ -57,6 +59,17 @@ const UniversalNavbarExpanded = ({
     <NavLink className={styles.accountIcon} href={links.ACCOUNT.href}>
       <AccountIcon />
     </NavLink>
+  )
+
+  const ExperimentCopy = () => (
+    <div
+      className={styles.estimateCopyOptimizely}
+      data-optimizely="estimateNavBarCopyOptimizely"
+    >
+      <div className={styles.estimateCopy}>
+        <Caption2.Regular400>Want to know your real rate?</Caption2.Regular400>
+      </div>
+    </div>
   )
 
   const layoutClasses = [styles.flex, styles.itemsCenter]
@@ -83,6 +96,7 @@ const UniversalNavbarExpanded = ({
                 <DropdownNav links={links} LinkComponent={LinkComponent} />
               </div>
               <div className={layoutClasses.join(' ')}>
+                {estimateExperiment && <ExperimentCopy />}
                 <SearchIconLink />
                 <AccountIconLink />
                 <div className={styles.cta}>

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -180,6 +180,8 @@ UniversalNavbarExpanded.propTypes = {
       })
     ),
   }).isRequired,
+  /** Estimate copy experiment on optimizely */
+  estimateExperiment: PropTypes.bool,
 }
 
 UniversalNavbarExpanded.defaultProps = {
@@ -188,6 +190,7 @@ UniversalNavbarExpanded.defaultProps = {
   logoHref: '/',
   trackCtaClick: () => {},
   links: {},
+  estimateExperiment: false,
 }
 
 export { UniversalNavbarExpanded }

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.md
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.md
@@ -2,5 +2,7 @@ This element has a fixed position at the top of the screen which you can see her
 
 ```jsx
 import { CMS_LINKS } from './SampleContent';
-<UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS}/>
+<UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS} estimateExperiment={true}/>
+
+// <UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS}/>
 ```

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
@@ -95,3 +95,14 @@ $laptop-range-small-end: 929px;
     display: none;
   }
 }
+
+.estimateCopyOptimizely {
+  display: none;
+}
+
+.estimateCopy {
+  width: 100px;
+  @include for-phone-only {
+    display: none;
+  }
+}

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.test.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.test.js
@@ -16,7 +16,11 @@ describe('<UniversalNavbarExpanded>', () => {
     it('builds with sample links provided and estimateExperiment enabled', () => {
       expect(
         shallowSnapshot(
-          <UniversalNavbarExpanded logoHref="/" links={CMS_LINKS} estimateExperiment={true}/>
+          <UniversalNavbarExpanded
+            logoHref="/"
+            links={CMS_LINKS}
+            estimateExperiment={true}
+          />
         )
       ).toMatchSnapshot()
     })

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.test.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.test.js
@@ -13,6 +13,13 @@ describe('<UniversalNavbarExpanded>', () => {
         )
       ).toMatchSnapshot()
     })
+    it('builds with sample links provided and estimateExperiment enabled', () => {
+      expect(
+        shallowSnapshot(
+          <UniversalNavbarExpanded logoHref="/" links={CMS_LINKS} estimateExperiment={true}/>
+        )
+      ).toMatchSnapshot()
+    })
   })
 })
 

--- a/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
+++ b/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
@@ -438,3 +438,443 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
   </div>
 </div>
 `;
+
+exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links provided and estimateExperiment enabled 1`] = `
+<div
+  className="navbarWrapper"
+>
+  <div
+    className="navbar"
+  >
+    <ScrollDetector
+      element="div"
+      offsetHeight={0}
+    >
+      <MobileNav
+        ctaButtonTrackingFunction={[Function]}
+        extraClass="isFixedCta"
+        hideMobileCta={false}
+        links={
+          Object {
+            "ACCOUNT": Object {
+              "href": "/login/",
+              "title": "Account",
+            },
+            "CTA": Object {
+              "href": "/term",
+              "title": "Check my price",
+            },
+            "INDEX": Object {
+              "href": "/",
+            },
+            "NAVLINKS": Array [
+              Object {
+                "id": "NAVLINKS_MOCK_ID_1",
+                "subnav": Object {
+                  "cta": Object {
+                    "href": "/#/Components/UniversalNavbarExpanded",
+                    "id": "NAVLINKS_MOCK_ID_2",
+                    "subcopy": "Learn more about term life insurance and the plans and options you have available.",
+                    "title": "Our plans",
+                  },
+                  "items": Array [
+                    Object {
+                      "href": "/#/Components/UniversalNavbarExpanded",
+                      "id": "NAVLINKS_MOCK_ID_3",
+                      "title": "What is term life insurance and how much does it cost?",
+                    },
+                    Object {
+                      "href": "/how-it-works/",
+                      "id": "NAVLINKS_MOCK_ID_4",
+                      "title": "How our application process works",
+                    },
+                    Object {
+                      "href": "/life/who-needs-life-insurance/",
+                      "id": "NAVLINKS_MOCK_ID_5",
+                      "title": "Do I need life insurance?",
+                    },
+                    Object {
+                      "href": "/life/how-choose-right-type-life-insurance/",
+                      "id": "NAVLINKS_MOCK_ID_6",
+                      "title": "Choosing your coverage amount and term length",
+                    },
+                    Object {
+                      "href": "/app/needs/",
+                      "id": "NAVLINKS_MOCK_ID_7",
+                      "title": "Coverage calculator",
+                    },
+                  ],
+                },
+                "title": "What we offer",
+              },
+              Object {
+                "id": "NAVLINKS_MOCK_ID_8",
+                "subnav": Object {
+                  "cta": Object {
+                    "href": "/life/life-insurance-basics/",
+                    "id": "NAVLINKS_MOCK_ID_9",
+                    "subcopy": "Wondering where to start? We’ve broken down the essentials for you.",
+                    "title": "Life insurance 101",
+                  },
+                  "items": Array [
+                    Object {
+                      "href": "/life/term-group-whole/",
+                      "id": "NAVLINKS_MOCK_ID_10",
+                      "title": "What are the main types of life insurance and how do they work?",
+                    },
+                    Object {
+                      "href": "/life/underwriting-explained/",
+                      "id": "NAVLINKS_MOCK_ID_11",
+                      "title": "What is underwriting and how long does it take?",
+                    },
+                    Object {
+                      "href": "/life/pick-beneficiary/",
+                      "id": "NAVLINKS_MOCK_ID_12",
+                      "title": "Choosing your beneficiary",
+                    },
+                    Object {
+                      "href": "/life/who-needs-sp/",
+                      "id": "NAVLINKS_MOCK_ID_13",
+                      "title": "What if I don't work?",
+                    },
+                    Object {
+                      "href": "/life/employer-sponsored-life-insurance/",
+                      "id": "NAVLINKS_MOCK_ID_14",
+                      "title": "Is my life insurance through work enough?",
+                    },
+                  ],
+                },
+                "title": "Life insurance basics",
+              },
+              Object {
+                "id": "NAVLINKS_MOCK_ID_15",
+                "subnav": Object {
+                  "cta": Object {
+                    "href": "/why-ethos/",
+                    "id": "NAVLINKS_MOCK_ID_16",
+                    "subcopy": "We put people before profit. Find out how we bring our policyholders the best experience possible.",
+                    "title": "The Ethos Difference",
+                  },
+                  "items": Array [
+                    Object {
+                      "href": "/about/",
+                      "id": "NAVLINKS_MOCK_ID_17",
+                      "title": "Our mission",
+                    },
+                    Object {
+                      "href": "/reviews/",
+                      "id": "NAVLINKS_MOCK_ID_18",
+                      "title": "Reviews",
+                    },
+                    Object {
+                      "href": "/life/customer-stories/",
+                      "id": "NAVLINKS_MOCK_ID_19",
+                      "title": "Customer stories",
+                    },
+                    Object {
+                      "href": "/life/ethosforgood/",
+                      "id": "NAVLINKS_MOCK_ID_20",
+                      "title": "Ethos for Good",
+                    },
+                    Object {
+                      "href": "/friends/",
+                      "id": "NAVLINKS_MOCK_ID_21",
+                      "title": "Refer a friend",
+                    },
+                  ],
+                },
+                "title": "Why Ethos",
+              },
+              Object {
+                "id": "NAVLINKS_MOCK_ID_22",
+                "subnav": Object {
+                  "cta": Object {
+                    "href": "/faq/",
+                    "id": "NAVLINKS_MOCK_ID_23",
+                    "subcopy": "Life insurance can be complicated, but don’t worry. We’re here to help answer your questions.",
+                    "title": "FAQ",
+                  },
+                  "items": Array [
+                    Object {
+                      "href": "/faq/life-insurance-basics/",
+                      "id": "NAVLINKS_MOCK_ID_24",
+                      "title": "Questions about life insurance",
+                    },
+                    Object {
+                      "href": "/faq/ethos/",
+                      "id": "NAVLINKS_MOCK_ID_25",
+                      "title": "Questions about Ethos",
+                    },
+                    Object {
+                      "href": "/faq/application/",
+                      "id": "NAVLINKS_MOCK_ID_26",
+                      "title": "Questions about your application",
+                    },
+                    Object {
+                      "href": "/faq/policy/",
+                      "id": "NAVLINKS_MOCK_ID_27",
+                      "title": "Questions about your policy",
+                    },
+                    Object {
+                      "href": "/contact-us/",
+                      "id": "NAVLINKS_MOCK_ID_28",
+                      "title": "Contact us",
+                    },
+                  ],
+                },
+                "title": "Help Center",
+              },
+            ],
+            "SEARCH": Object {
+              "href": "/search/",
+              "title": "Search",
+            },
+          }
+        }
+        logoHref="/"
+        secondaryLinksLinks={
+          Array [
+            Object {
+              "href": "/term",
+              "title": "Check my price",
+            },
+            Object {
+              "href": "/login/",
+              "title": "Account",
+            },
+            Object {
+              "href": "/search/",
+              "title": "Search",
+            },
+          ]
+        }
+      />
+      <div
+        className="laptopAndUp"
+      >
+        <div
+          className="laptopAndUpContainer"
+        >
+          <div
+            className="flex itemsCenter"
+          >
+            <NavLink
+              href="/"
+            >
+              <svg
+                className="logo"
+                viewBox="0 0 971.997 180.498"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title>
+                  Ethos Logo
+                </title>
+                <path
+                  d="M184.573 2.845v29.202h58.416v146.028h29.202V32.047h58.41V2.845H184.573zM0 2.845v175.23h129.318v-29.208H29.202v-43.806h86.988V75.859H29.202V32.047h100.116V2.845H0zm505.833 0v73.014h-87.612V2.845h-29.208v175.23h29.208v-73.014h87.612v73.014h29.202V2.845h-29.202zm252.688 16.523a63.8 63.8 0 0 0-90.228 0c-3.6 3.606-11.1 12.036-13.662 16.188a63.725 63.725 0 0 1 87.894 87.378l.984-.984c4.272-2.592 11.322-8.664 15.012-12.354a63.8 63.8 0 0 0 0-90.228"
+                />
+                <path
+                  d="M650.356 127.535c-25.068-25.068-40.422-71.178-12.132-119.922L625 20.837a93.374 93.374 0 0 0 132.054 132.048l13.224-13.224c-46.422 26.988-92.616 15.18-119.922-12.126m251.813 53.175c42.42 0 69.828-21.018 69.828-53.55 0-30.5-21.438-41.532-56.034-49.428l-21.192-4.65c-19.08-4.218-29.424-9.12-29.424-22.944 0-14.094 13.134-23.2 33.462-23.2 18.966 0 35.658 7.044 45.942 19.362l22.008-17.69C954.645 15.51 933.273.21 899.583.21c-38.064 0-65.694 21.648-65.694 51.48 0 34.044 27.87 44.436 52.152 49.686l23.52 5.172c18.594 4.038 30.978 9.576 30.978 23.454 0 14.916-13.422 23.46-36.816 23.46-25.518 0-44.808-12.534-52.89-25.17l-24.15 17.388c12.438 17.046 38.64 35.028 75.486 35.028"
+                />
+              </svg>
+            </NavLink>
+            <DropdownNav
+              links={
+                Object {
+                  "ACCOUNT": Object {
+                    "href": "/login/",
+                    "title": "Account",
+                  },
+                  "CTA": Object {
+                    "href": "/term",
+                    "title": "Check my price",
+                  },
+                  "INDEX": Object {
+                    "href": "/",
+                  },
+                  "NAVLINKS": Array [
+                    Object {
+                      "id": "NAVLINKS_MOCK_ID_1",
+                      "subnav": Object {
+                        "cta": Object {
+                          "href": "/#/Components/UniversalNavbarExpanded",
+                          "id": "NAVLINKS_MOCK_ID_2",
+                          "subcopy": "Learn more about term life insurance and the plans and options you have available.",
+                          "title": "Our plans",
+                        },
+                        "items": Array [
+                          Object {
+                            "href": "/#/Components/UniversalNavbarExpanded",
+                            "id": "NAVLINKS_MOCK_ID_3",
+                            "title": "What is term life insurance and how much does it cost?",
+                          },
+                          Object {
+                            "href": "/how-it-works/",
+                            "id": "NAVLINKS_MOCK_ID_4",
+                            "title": "How our application process works",
+                          },
+                          Object {
+                            "href": "/life/who-needs-life-insurance/",
+                            "id": "NAVLINKS_MOCK_ID_5",
+                            "title": "Do I need life insurance?",
+                          },
+                          Object {
+                            "href": "/life/how-choose-right-type-life-insurance/",
+                            "id": "NAVLINKS_MOCK_ID_6",
+                            "title": "Choosing your coverage amount and term length",
+                          },
+                          Object {
+                            "href": "/app/needs/",
+                            "id": "NAVLINKS_MOCK_ID_7",
+                            "title": "Coverage calculator",
+                          },
+                        ],
+                      },
+                      "title": "What we offer",
+                    },
+                    Object {
+                      "id": "NAVLINKS_MOCK_ID_8",
+                      "subnav": Object {
+                        "cta": Object {
+                          "href": "/life/life-insurance-basics/",
+                          "id": "NAVLINKS_MOCK_ID_9",
+                          "subcopy": "Wondering where to start? We’ve broken down the essentials for you.",
+                          "title": "Life insurance 101",
+                        },
+                        "items": Array [
+                          Object {
+                            "href": "/life/term-group-whole/",
+                            "id": "NAVLINKS_MOCK_ID_10",
+                            "title": "What are the main types of life insurance and how do they work?",
+                          },
+                          Object {
+                            "href": "/life/underwriting-explained/",
+                            "id": "NAVLINKS_MOCK_ID_11",
+                            "title": "What is underwriting and how long does it take?",
+                          },
+                          Object {
+                            "href": "/life/pick-beneficiary/",
+                            "id": "NAVLINKS_MOCK_ID_12",
+                            "title": "Choosing your beneficiary",
+                          },
+                          Object {
+                            "href": "/life/who-needs-sp/",
+                            "id": "NAVLINKS_MOCK_ID_13",
+                            "title": "What if I don't work?",
+                          },
+                          Object {
+                            "href": "/life/employer-sponsored-life-insurance/",
+                            "id": "NAVLINKS_MOCK_ID_14",
+                            "title": "Is my life insurance through work enough?",
+                          },
+                        ],
+                      },
+                      "title": "Life insurance basics",
+                    },
+                    Object {
+                      "id": "NAVLINKS_MOCK_ID_15",
+                      "subnav": Object {
+                        "cta": Object {
+                          "href": "/why-ethos/",
+                          "id": "NAVLINKS_MOCK_ID_16",
+                          "subcopy": "We put people before profit. Find out how we bring our policyholders the best experience possible.",
+                          "title": "The Ethos Difference",
+                        },
+                        "items": Array [
+                          Object {
+                            "href": "/about/",
+                            "id": "NAVLINKS_MOCK_ID_17",
+                            "title": "Our mission",
+                          },
+                          Object {
+                            "href": "/reviews/",
+                            "id": "NAVLINKS_MOCK_ID_18",
+                            "title": "Reviews",
+                          },
+                          Object {
+                            "href": "/life/customer-stories/",
+                            "id": "NAVLINKS_MOCK_ID_19",
+                            "title": "Customer stories",
+                          },
+                          Object {
+                            "href": "/life/ethosforgood/",
+                            "id": "NAVLINKS_MOCK_ID_20",
+                            "title": "Ethos for Good",
+                          },
+                          Object {
+                            "href": "/friends/",
+                            "id": "NAVLINKS_MOCK_ID_21",
+                            "title": "Refer a friend",
+                          },
+                        ],
+                      },
+                      "title": "Why Ethos",
+                    },
+                    Object {
+                      "id": "NAVLINKS_MOCK_ID_22",
+                      "subnav": Object {
+                        "cta": Object {
+                          "href": "/faq/",
+                          "id": "NAVLINKS_MOCK_ID_23",
+                          "subcopy": "Life insurance can be complicated, but don’t worry. We’re here to help answer your questions.",
+                          "title": "FAQ",
+                        },
+                        "items": Array [
+                          Object {
+                            "href": "/faq/life-insurance-basics/",
+                            "id": "NAVLINKS_MOCK_ID_24",
+                            "title": "Questions about life insurance",
+                          },
+                          Object {
+                            "href": "/faq/ethos/",
+                            "id": "NAVLINKS_MOCK_ID_25",
+                            "title": "Questions about Ethos",
+                          },
+                          Object {
+                            "href": "/faq/application/",
+                            "id": "NAVLINKS_MOCK_ID_26",
+                            "title": "Questions about your application",
+                          },
+                          Object {
+                            "href": "/faq/policy/",
+                            "id": "NAVLINKS_MOCK_ID_27",
+                            "title": "Questions about your policy",
+                          },
+                          Object {
+                            "href": "/contact-us/",
+                            "id": "NAVLINKS_MOCK_ID_28",
+                            "title": "Contact us",
+                          },
+                        ],
+                      },
+                      "title": "Help Center",
+                    },
+                  ],
+                  "SEARCH": Object {
+                    "href": "/search/",
+                    "title": "Search",
+                  },
+                }
+              }
+            />
+          </div>
+          <div
+            className="flex itemsCenter"
+          >
+            <ExperimentCopy />
+            <SearchIconLink />
+            <AccountIconLink />
+            <div
+              className="cta"
+            >
+              <CtaButton
+                href="/term"
+                trackingFunction={[Function]}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </ScrollDetector>
+  </div>
+</div>
+`;


### PR DESCRIPTION
**Description:**
- Would like to merge by EOD April 23rd if possible.
- Diff is largely made up of snapshot update! Changes are smaller than they look.
- [Asana Task](https://app.asana.com/0/1116481661798430/1166819983224779/f)
- Need some Optimizely Web selectors and additional copy in the navbar, for running some CMS side experiment targeting on all pages.

**Is this a new component? Please review these reminders:**
Not a new component.
- [x] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [x] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [x] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**
- https://github.com/getethos/cms/pull/2930 (original estimate widget PR - being broken into multiple smaller PRs)

**Screenshots:**
<img width="1574" alt="Screen Shot 2020-04-23 at 1 51 58 AM" src="https://user-images.githubusercontent.com/4285270/80079378-0e54f180-8505-11ea-9381-1d551cb4e062.png">
