### PR TITLE
Add aria-label and data-tid props

### DIFF
--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -20,6 +20,7 @@ export const Select = ({
   const compactClass = isCompact ? styles.Compact : ''
   const props = {
     className: `${className ? className : ''} ${compactClass} ${styles.root}`,
+    'aria-label': title, // https://react-select.com/props#select-props
     ...rest,
   }
 
@@ -40,7 +41,7 @@ export const Select = ({
   const SelectTag = getTag()
 
   return (
-    <div className={wrapperClass}>
+    <div className={wrapperClass} data-tid={rest['data-tid']}>
       <SelectTag {...props} />
       {title && <div className={styles.title}>{title}</div>}
     </div>

--- a/src/components/Select/Select.md
+++ b/src/components/Select/Select.md
@@ -20,6 +20,7 @@ const options = [
   placeholder="Custom placeholder..."
   onChange={onSelected}
   options={options}
+  data-tid="my-select"
 />
 ```
 

--- a/src/components/Select/Select.test.js
+++ b/src/components/Select/Select.test.js
@@ -14,7 +14,7 @@ describe('Select', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('title adds a div and aria-label', () => {
+  test('adding a title prop adds a div and aria-label', () => {
     const tree = renderer
       .create(<Select {...mockProps} title="Hello World" />)
       .toJSON()

--- a/src/components/Select/Select.test.js
+++ b/src/components/Select/Select.test.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Select } from './Select.js'
+
+describe('Select', () => {
+  const mockProps = {
+    className: 'foo',
+    isCompact: true,
+    'data-tid': 'my-select',
+  }
+
+  test('matches snapshot', () => {
+    const tree = renderer.create(<Select {...mockProps} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('title adds a div and aria-label', () => {
+    const tree = renderer
+      .create(<Select {...mockProps} title="Hello World" />)
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/Select/__snapshots__/Select.test.js.snap
+++ b/src/components/Select/__snapshots__/Select.test.js.snap
@@ -1,117 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Select matches snapshot 1`] = `
-<div
-  className=""
-  data-tid="my-select"
->
-  <div
-    className="foo Compact root css-2b097c-container"
-    onKeyDown={[Function]}
-  >
-    <div
-      className="StyledReactSelect__control css-yk16xz-control"
-      onMouseDown={[Function]}
-      onTouchEnd={[Function]}
-    >
-      <div
-        className="StyledReactSelect__value-container css-1hwfws3"
-      >
-        <div
-          className="StyledReactSelect__placeholder css-1wa3eu0-placeholder"
-        >
-          Type to search
-        </div>
-        <div
-          className="css-b8ldur-Input"
-        >
-          <div
-            className="StyledReactSelect__input"
-            style={
-              Object {
-                "display": "inline-block",
-              }
-            }
-          >
-            <input
-              aria-autocomplete="list"
-              autoCapitalize="none"
-              autoComplete="off"
-              autoCorrect="off"
-              disabled={false}
-              id="react-select-2-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              spellCheck="false"
-              style={
-                Object {
-                  "background": 0,
-                  "border": 0,
-                  "boxSizing": "content-box",
-                  "color": "inherit",
-                  "fontSize": "inherit",
-                  "label": "input",
-                  "opacity": 1,
-                  "outline": 0,
-                  "padding": 0,
-                  "width": "1px",
-                }
-              }
-              tabIndex="0"
-              type="text"
-              value=""
-            />
-            <div
-              style={
-                Object {
-                  "height": 0,
-                  "left": 0,
-                  "overflow": "scroll",
-                  "position": "absolute",
-                  "top": 0,
-                  "visibility": "hidden",
-                  "whiteSpace": "pre",
-                }
-              }
-            >
-              
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="StyledReactSelect__indicators css-1hb7zxy-IndicatorsContainer"
-      >
-        <span
-          className="StyledReactSelect__indicator-separator css-1okebmr-indicatorSeparator"
-        />
-        <div
-          aria-hidden="true"
-          className="StyledReactSelect__indicator StyledReactSelect__dropdown-indicator css-tlfecz-indicatorContainer"
-          onMouseDown={[Function]}
-          onTouchEnd={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="css-6q0nyr-Svg"
-            focusable="false"
-            height={20}
-            viewBox="0 0 20 20"
-            width={20}
-          >
-            <path
-              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-            />
-          </svg>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Select title adds a div and aria-label 1`] = `
+exports[`Select adding a title prop adds a div and aria-label 1`] = `
 <div
   className="wrapper"
   data-tid="my-select"
@@ -224,6 +113,117 @@ exports[`Select title adds a div and aria-label 1`] = `
     className="title"
   >
     Hello World
+  </div>
+</div>
+`;
+
+exports[`Select matches snapshot 1`] = `
+<div
+  className=""
+  data-tid="my-select"
+>
+  <div
+    className="foo Compact root css-2b097c-container"
+    onKeyDown={[Function]}
+  >
+    <div
+      className="StyledReactSelect__control css-yk16xz-control"
+      onMouseDown={[Function]}
+      onTouchEnd={[Function]}
+    >
+      <div
+        className="StyledReactSelect__value-container css-1hwfws3"
+      >
+        <div
+          className="StyledReactSelect__placeholder css-1wa3eu0-placeholder"
+        >
+          Type to search
+        </div>
+        <div
+          className="css-b8ldur-Input"
+        >
+          <div
+            className="StyledReactSelect__input"
+            style={
+              Object {
+                "display": "inline-block",
+              }
+            }
+          >
+            <input
+              aria-autocomplete="list"
+              autoCapitalize="none"
+              autoComplete="off"
+              autoCorrect="off"
+              disabled={false}
+              id="react-select-2-input"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              spellCheck="false"
+              style={
+                Object {
+                  "background": 0,
+                  "border": 0,
+                  "boxSizing": "content-box",
+                  "color": "inherit",
+                  "fontSize": "inherit",
+                  "label": "input",
+                  "opacity": 1,
+                  "outline": 0,
+                  "padding": 0,
+                  "width": "1px",
+                }
+              }
+              tabIndex="0"
+              type="text"
+              value=""
+            />
+            <div
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "overflow": "scroll",
+                  "position": "absolute",
+                  "top": 0,
+                  "visibility": "hidden",
+                  "whiteSpace": "pre",
+                }
+              }
+            >
+              
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="StyledReactSelect__indicators css-1hb7zxy-IndicatorsContainer"
+      >
+        <span
+          className="StyledReactSelect__indicator-separator css-1okebmr-indicatorSeparator"
+        />
+        <div
+          aria-hidden="true"
+          className="StyledReactSelect__indicator StyledReactSelect__dropdown-indicator css-tlfecz-indicatorContainer"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <svg
+            aria-hidden="true"
+            className="css-6q0nyr-Svg"
+            focusable="false"
+            height={20}
+            viewBox="0 0 20 20"
+            width={20}
+          >
+            <path
+              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/Select/__snapshots__/Select.test.js.snap
+++ b/src/components/Select/__snapshots__/Select.test.js.snap
@@ -1,0 +1,229 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Select matches snapshot 1`] = `
+<div
+  className=""
+  data-tid="my-select"
+>
+  <div
+    className="foo Compact root css-2b097c-container"
+    onKeyDown={[Function]}
+  >
+    <div
+      className="StyledReactSelect__control css-yk16xz-control"
+      onMouseDown={[Function]}
+      onTouchEnd={[Function]}
+    >
+      <div
+        className="StyledReactSelect__value-container css-1hwfws3"
+      >
+        <div
+          className="StyledReactSelect__placeholder css-1wa3eu0-placeholder"
+        >
+          Type to search
+        </div>
+        <div
+          className="css-b8ldur-Input"
+        >
+          <div
+            className="StyledReactSelect__input"
+            style={
+              Object {
+                "display": "inline-block",
+              }
+            }
+          >
+            <input
+              aria-autocomplete="list"
+              autoCapitalize="none"
+              autoComplete="off"
+              autoCorrect="off"
+              disabled={false}
+              id="react-select-2-input"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              spellCheck="false"
+              style={
+                Object {
+                  "background": 0,
+                  "border": 0,
+                  "boxSizing": "content-box",
+                  "color": "inherit",
+                  "fontSize": "inherit",
+                  "label": "input",
+                  "opacity": 1,
+                  "outline": 0,
+                  "padding": 0,
+                  "width": "1px",
+                }
+              }
+              tabIndex="0"
+              type="text"
+              value=""
+            />
+            <div
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "overflow": "scroll",
+                  "position": "absolute",
+                  "top": 0,
+                  "visibility": "hidden",
+                  "whiteSpace": "pre",
+                }
+              }
+            >
+              
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="StyledReactSelect__indicators css-1hb7zxy-IndicatorsContainer"
+      >
+        <span
+          className="StyledReactSelect__indicator-separator css-1okebmr-indicatorSeparator"
+        />
+        <div
+          aria-hidden="true"
+          className="StyledReactSelect__indicator StyledReactSelect__dropdown-indicator css-tlfecz-indicatorContainer"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <svg
+            aria-hidden="true"
+            className="css-6q0nyr-Svg"
+            focusable="false"
+            height={20}
+            viewBox="0 0 20 20"
+            width={20}
+          >
+            <path
+              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Select title adds a div and aria-label 1`] = `
+<div
+  className="wrapper"
+  data-tid="my-select"
+>
+  <div
+    className="foo Compact root css-2b097c-container"
+    onKeyDown={[Function]}
+  >
+    <div
+      className="StyledReactSelect__control css-yk16xz-control"
+      onMouseDown={[Function]}
+      onTouchEnd={[Function]}
+    >
+      <div
+        className="StyledReactSelect__value-container css-1hwfws3"
+      >
+        <div
+          className="StyledReactSelect__placeholder css-1wa3eu0-placeholder"
+        >
+          Type to search
+        </div>
+        <div
+          className="css-b8ldur-Input"
+        >
+          <div
+            className="StyledReactSelect__input"
+            style={
+              Object {
+                "display": "inline-block",
+              }
+            }
+          >
+            <input
+              aria-autocomplete="list"
+              aria-label="Hello World"
+              autoCapitalize="none"
+              autoComplete="off"
+              autoCorrect="off"
+              disabled={false}
+              id="react-select-3-input"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              spellCheck="false"
+              style={
+                Object {
+                  "background": 0,
+                  "border": 0,
+                  "boxSizing": "content-box",
+                  "color": "inherit",
+                  "fontSize": "inherit",
+                  "label": "input",
+                  "opacity": 1,
+                  "outline": 0,
+                  "padding": 0,
+                  "width": "1px",
+                }
+              }
+              tabIndex="0"
+              type="text"
+              value=""
+            />
+            <div
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "overflow": "scroll",
+                  "position": "absolute",
+                  "top": 0,
+                  "visibility": "hidden",
+                  "whiteSpace": "pre",
+                }
+              }
+            >
+              
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="StyledReactSelect__indicators css-1hb7zxy-IndicatorsContainer"
+      >
+        <span
+          className="StyledReactSelect__indicator-separator css-1okebmr-indicatorSeparator"
+        />
+        <div
+          aria-hidden="true"
+          className="StyledReactSelect__indicator StyledReactSelect__dropdown-indicator css-tlfecz-indicatorContainer"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <svg
+            aria-hidden="true"
+            className="css-6q0nyr-Svg"
+            focusable="false"
+            height={20}
+            viewBox="0 0 20 20"
+            width={20}
+          >
+            <path
+              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="title"
+  >
+    Hello World
+  </div>
+</div>
+`;

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -342,6 +342,7 @@ export declare const Select: {
     title?: string
     className?: string
     isCreatable?: boolean
+    'data-tid'?: string
   }
   defaultProps: {
     classNamePrefix?: string

--- a/src/components/index.tests.tsx
+++ b/src/components/index.tests.tsx
@@ -383,8 +383,14 @@ class SelectTest extends React.Component<any, any> {
           options={options}
           isAsync={true}
           isCreatable={true}
+          data-tid="foo"
         />
-        <Select onChange={onSelected} options={options} isAsync={true} />
+        <Select
+          onChange={onSelected}
+          options={options}
+          isAsync={true}
+          data-tid="foo"
+        />
         <Select onChange={onSelected} options={options} isCreatable={true} />
         <Select onChange={onSelected} options={options} />
       </>


### PR DESCRIPTION
**Description:**

- Based on a PR comment (https://github.com/getethos/ethos/pull/3194#pullrequestreview-405364329), adds an `aria-label` to the `Select` component for a11y
- Adds a `data-tid` prop to `Select`
- Adds snapshot tests

**Referencing PR or Branch (e.g. in CMS or monorepo):**

Reference but does not depend on these changes
- https://github.com/getethos/ethos/pull/3194

**Screenshots:**
![image](https://user-images.githubusercontent.com/11672466/81025506-b636bd00-8e2b-11ea-8f8c-c00c8927907c.png)
![image](https://user-images.githubusercontent.com/11672466/81025532-d0709b00-8e2b-11ea-8ad2-764fff1fa360.png)

