### PR TITLE
Stepper p2 and type2 document public props usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.187",
+  "version": "1.1.188",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.188",
+  "version": "1.1.189",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Caption2.md
+++ b/src/components/Caption2.md
@@ -1,13 +1,31 @@
 ```jsx
-<Caption2.Regular400>We offer modern, ethical life insurance to protect the life you're building and the people you love</Caption2.Regular400>
+<Caption2.Regular400>
+  We offer modern, ethical life insurance to protect the life you're building
+  and the people you love
+</Caption2.Regular400>
 ```
 
 ```jsx
-<Caption2.Medium500>We offer modern, ethical life insurance to protect the life you're building and the people you love</Caption2.Medium500>
+<Caption2.Medium500>
+  We offer modern, ethical life insurance to protect the life you're building
+  and the people you love
+</Caption2.Medium500>
 ```
 
 This example configures the caption to be a label with "all-caps":
 
 ```jsx
-<Caption2.Medium500 allCaps={true} element='label'>All-Caps Label</Caption2.Medium500>
+<Caption2.Medium500 allCaps={true} element="label">
+  All-Caps Label
+</Caption2.Medium500>
+```
+
+Note that any `TypeBase.PUBLIC_PROPS` are available for you to _pass through_
+if you should need it. For exapmple, to have a
+
+```jsx
+import { COLORS } from './index'
+;<Caption2.Regular400 color={COLORS.GRAY_STROKE_AND_DISABLED}>
+  I am ghosted :)
+</Caption2.Regular400>
 ```

--- a/src/components/Stepper/Stepper.js
+++ b/src/components/Stepper/Stepper.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Icon } from '../index'
+import { COLORS, Caption2, Icon } from '../index'
 import PropTypes from 'prop-types'
 import uuidv4 from 'uuid/v4'
 import styles from './Stepper.module.scss'
@@ -18,13 +18,19 @@ export const Stepper = ({ steps }) => {
     return <span className={styles.Step}></span>
   }
 
-  const getTitleClassForStatus = (status) => {
-    if (status == 'complete') {
-      return styles.TitleComplete
-    } else if (status == 'active') {
-      return styles.TitleActive
+  const getTitle = (step) => {
+    if (step.status == 'complete' || step.status == 'active') {
+      return (
+        <Caption2.Regular400 color={COLORS.GRAY_PRIMARY}>
+          {step.title}
+        </Caption2.Regular400>
+      )
     }
-    return styles.Title
+    return (
+      <Caption2.Regular400 color={COLORS.GRAY_STROKE_AND_DISABLED}>
+        {step.title}
+      </Caption2.Regular400>
+    )
   }
 
   return (
@@ -34,9 +40,7 @@ export const Stepper = ({ steps }) => {
           <React.Fragment key={uuidv4()}>
             <li className={styles.Node}>
               {getIconForStatus(step.status)}
-              <span className={getTitleClassForStatus(step.status)}>
-                {step.title}
-              </span>
+              {getTitle(step)}
             </li>
             {/* Do not put a vertical line after last one :) */}
             {i !== steps.length - 1 && (

--- a/src/components/Stepper/Stepper.module.scss
+++ b/src/components/Stepper/Stepper.module.scss
@@ -15,18 +15,6 @@
   position: relative;
 }
 
-.Title {
-  color: var(--GrayStrokeAndDisabled--opaque);
-}
-
-.TitleComplete,
-.TitleActive {
-  color: var(--GrayPrimary--opaque);
-}
-.TitleActive {
-  font-weight: 500;
-}
-
 /* Steps are circles until they become completed and turn to checks */
 .Step {
   width: var(--Space-10);

--- a/src/components/Type2/TitleLarge2.md
+++ b/src/components/Type2/TitleLarge2.md
@@ -1,20 +1,42 @@
 ```jsx
-<TitleLarge2.Serif.Medium500>We offer modern, ethical life insurance</TitleLarge2.Serif.Medium500>
+<TitleLarge2.Serif.Medium500>
+  We offer modern, ethical life insurance
+</TitleLarge2.Serif.Medium500>
 ```
 
 ```jsx
-<TitleLarge2.Serif.Book500>We offer modern, ethical life insurance</TitleLarge2.Serif.Book500>
+<TitleLarge2.Serif.Book500>
+  We offer modern, ethical life insurance
+</TitleLarge2.Serif.Book500>
 ```
 
 ```jsx
-<TitleLarge2.Sans.Medium500>We offer modern, ethical life insurance</TitleLarge2.Sans.Medium500>
+<TitleLarge2.Sans.Medium500>
+  We offer modern, ethical life insurance
+</TitleLarge2.Sans.Medium500>
 ```
 
 ```jsx
-<TitleLarge2.Sans.Regular400>We offer modern, ethical life insurance</TitleLarge2.Sans.Regular400>
+<TitleLarge2.Sans.Regular400>
+  We offer modern, ethical life insurance
+</TitleLarge2.Sans.Regular400>
 ```
 
 ```jsx
-<TitleLarge2.Sans.Regular400 element='label'>I should be a label element. Inspect me to see :)</TitleLarge2.Sans.Regular400>
+<TitleLarge2.Sans.Regular400 element="label">
+  I should be a label element. Inspect me to see :)
+</TitleLarge2.Sans.Regular400>
 ```
 
+Note that any `TypeBase.PUBLIC_PROPS` are available for you to _pass through_
+if you should need it. For exapmple, to have a
+
+```jsx
+import { COLORS } from '../index'
+;<TitleLarge2.Sans.Regular400
+  element="label"
+  color={COLORS.GRAY_STROKE_AND_DISABLED}
+>
+  I should be ghosted :)
+</TitleLarge2.Sans.Regular400>
+```

--- a/src/components/Type2/TitleMedium2.md
+++ b/src/components/Type2/TitleMedium2.md
@@ -1,20 +1,42 @@
 ```jsx
-<TitleMedium2.Serif.Medium500>We offer modern, ethical life insurance</TitleMedium2.Serif.Medium500>
+<TitleMedium2.Serif.Medium500>
+  We offer modern, ethical life insurance
+</TitleMedium2.Serif.Medium500>
 ```
 
 ```jsx
-<TitleMedium2.Serif.Book500>We offer modern, ethical life insurance</TitleMedium2.Serif.Book500>
+<TitleMedium2.Serif.Book500>
+  We offer modern, ethical life insurance
+</TitleMedium2.Serif.Book500>
 ```
 
 ```jsx
-<TitleMedium2.Sans.Medium500>We offer modern, ethical life insurance</TitleMedium2.Sans.Medium500>
+<TitleMedium2.Sans.Medium500>
+  We offer modern, ethical life insurance
+</TitleMedium2.Sans.Medium500>
 ```
 
 ```jsx
-<TitleMedium2.Sans.Regular400>We offer modern, ethical life insurance</TitleMedium2.Sans.Regular400>
+<TitleMedium2.Sans.Regular400>
+  We offer modern, ethical life insurance
+</TitleMedium2.Sans.Regular400>
 ```
 
 ```jsx
-<TitleMedium2.Sans.Regular400 element='label'>I should be a label element. Inspect me to see :)</TitleMedium2.Sans.Regular400>
+<TitleMedium2.Sans.Regular400 element="label">
+  I should be a label element. Inspect me to see :)
+</TitleMedium2.Sans.Regular400>
 ```
 
+Note that any `TypeBase.PUBLIC_PROPS` are available for you to _pass through_
+if you should need it. For exapmple, to have a
+
+```jsx
+import { COLORS } from '../index'
+;<TitleMedium2.Sans.Regular400
+  element="label"
+  color={COLORS.GRAY_STROKE_AND_DISABLED}
+>
+  I should be ghosted :)
+</TitleMedium2.Sans.Regular400>
+```

--- a/src/components/Type2/TitleSmall2.md
+++ b/src/components/Type2/TitleSmall2.md
@@ -1,20 +1,42 @@
 ```jsx
-<TitleSmall2.Serif.Medium500>We offer modern, ethical life insurance</TitleSmall2.Serif.Medium500>
+<TitleSmall2.Serif.Medium500>
+  We offer modern, ethical life insurance
+</TitleSmall2.Serif.Medium500>
 ```
 
 ```jsx
-<TitleSmall2.Serif.Book500>We offer modern, ethical life insurance</TitleSmall2.Serif.Book500>
+<TitleSmall2.Serif.Book500>
+  We offer modern, ethical life insurance
+</TitleSmall2.Serif.Book500>
 ```
 
 ```jsx
-<TitleSmall2.Sans.Medium500>We offer modern, ethical life insurance</TitleSmall2.Sans.Medium500>
+<TitleSmall2.Sans.Medium500>
+  We offer modern, ethical life insurance
+</TitleSmall2.Sans.Medium500>
 ```
 
 ```jsx
-<TitleSmall2.Sans.Regular400>We offer modern, ethical life insurance</TitleSmall2.Sans.Regular400>
+<TitleSmall2.Sans.Regular400>
+  We offer modern, ethical life insurance
+</TitleSmall2.Sans.Regular400>
 ```
 
 ```jsx
-<TitleSmall2.Sans.Regular400 element='label'>I should be a label element. Inspect me to see :)</TitleSmall2.Sans.Regular400>
+<TitleSmall2.Sans.Regular400 element="label">
+  I should be a label element. Inspect me to see :)
+</TitleSmall2.Sans.Regular400>
 ```
 
+Note that any `TypeBase.PUBLIC_PROPS` are available for you to _pass through_
+if you should need it. For exapmple, to have a
+
+```jsx
+import { COLORS } from '../index'
+;<TitleSmall2.Sans.Regular400
+  element="label"
+  color={COLORS.GRAY_STROKE_AND_DISABLED}
+>
+  I should be ghosted :)
+</TitleSmall2.Sans.Regular400>
+```

--- a/src/components/Type2/TitleXLarge2.md
+++ b/src/components/Type2/TitleXLarge2.md
@@ -1,12 +1,30 @@
 ```jsx
-<TitleXLarge2.Serif.Medium500>We offer modern, ethical life insurance</TitleXLarge2.Serif.Medium500>
+<TitleXLarge2.Serif.Medium500>
+  We offer modern, ethical life insurance
+</TitleXLarge2.Serif.Medium500>
 ```
 
 ```jsx
-<TitleXLarge2.Serif.Book500>We offer modern, ethical life insurance</TitleXLarge2.Serif.Book500>
+<TitleXLarge2.Serif.Book500>
+  We offer modern, ethical life insurance
+</TitleXLarge2.Serif.Book500>
 ```
 
 ```jsx
-<TitleXLarge2.Serif.Medium500 element='label'>I should be a label element. Inspect me to see :)</TitleXLarge2.Serif.Medium500>
+<TitleXLarge2.Serif.Medium500 element="label">
+  I should be a label element. Inspect me to see :)
+</TitleXLarge2.Serif.Medium500>
 ```
 
+Note that any `TypeBase.PUBLIC_PROPS` are available for you to _pass through_
+if you should need it. For exapmple, to have a
+
+```jsx
+import { COLORS } from '../index'
+;<TitleXLarge2.Serif.Medium500
+  element="label"
+  color={COLORS.GRAY_STROKE_AND_DISABLED}
+>
+  I should be ghosted :)
+</TitleXLarge2.Serif.Medium500>
+```

--- a/src/components/TypeBase/TypeBase.js
+++ b/src/components/TypeBase/TypeBase.js
@@ -168,7 +168,6 @@ export const TypeFoundry = (privateProps) => {
 
   // TODO: figure out if downstream or upstream is the correct nomenclature here
   const PublicTypeComponent = (downstreamProps) => {
-    console.log('downstreamProps props in type foundry: ', downstreamProps)
     Object.keys(downstreamProps).forEach(throwIllegalProp)
     return <TypeBase {...downstreamProps} {...privateProps} />
   }

--- a/src/components/TypeBase/TypeBase.js
+++ b/src/components/TypeBase/TypeBase.js
@@ -168,6 +168,7 @@ export const TypeFoundry = (privateProps) => {
 
   // TODO: figure out if downstream or upstream is the correct nomenclature here
   const PublicTypeComponent = (downstreamProps) => {
+    console.log('downstreamProps props in type foundry: ', downstreamProps)
     Object.keys(downstreamProps).forEach(throwIllegalProp)
     return <TypeBase {...downstreamProps} {...privateProps} />
   }


### PR DESCRIPTION
**Description:**

- [Asana Task](https://app.asana.com/0/1147552137426708/1171609519486689/f)
- Updates the Stepper to use the Type 2 system
- Adds some documentation to EDS on Type 2 system examples making it super clear that you can use any of the type base "public props"


- [x] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**

- https://github.com/getethos/ethos/pull/3237

**Screenshots:**
![image](https://user-images.githubusercontent.com/142403/81235035-e064b800-8fae-11ea-828a-1c65952f55b6.png)

![image](https://user-images.githubusercontent.com/142403/81235151-1c981880-8faf-11ea-881f-c28383312cf9.png)

Did same as above for all the type 2 Title* component examples too