### PR TITLE
Refactor selects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.192",
+  "version": "1.1.193",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.190",
+  "version": "1.1.191",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.199",
+  "version": "1.1.200",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.191",
+  "version": "1.1.192",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 // See React-Select -- https://github.com/JedWatson/react-select for documentation
 // on usage, Async configuration, etc.
@@ -6,6 +6,8 @@ import ReactSelect from 'react-select'
 import ReactSelectAsync from 'react-select/async'
 import ReactSelectAsyncCreatable from 'react-select/async-creatable'
 import ReactSelectCreatable from 'react-select/creatable'
+import useErrorMessage from '../../hooks/useErrorMessage.js'
+import { InputLabel } from '../InputLabel'
 
 import styles from './Select.module.scss'
 
@@ -15,13 +17,65 @@ export const Select = ({
   isAsync,
   isCompact,
   isCreatable,
+  validator,
+  onChange,
+  formChangeHandler,
+  currentError,
+  formTouched,
+  labelCopy,
+  name,
   ...rest
 }) => {
+  console.log('Select props: ', {
+    className,
+    title,
+    isAsync,
+    isCompact,
+    validator,
+    onChange,
+    formChangeHandler,
+    currentError,
+    formTouched,
+    labelCopy,
+    name,
+  })
   const compactClass = isCompact ? styles.Compact : ''
+  // Since we're using arrow function we need to come before props assignment below
+  const onChangeHandler = (event) => {
+    updateSelectedValue(event.value)
+    if (onChange) {
+      onChange(event)
+    }
+  }
+
   const props = {
     className: `${className ? className : ''} ${compactClass} ${styles.root}`,
+    onChange: onChangeHandler,
+    onBlur,
     'aria-label': title, // https://react-select.com/props#select-props
     ...rest,
+  }
+  const resolvedValidator = validator ? validator : () => ''
+  const [getError, setError, , validate] = useErrorMessage(resolvedValidator)
+  const [selectedValue, updateSelectedValue] = useState(undefined)
+
+  const validationSelect = () => {
+    const errorMessage = validate(selectedValue)
+    setError(errorMessage)
+    if (formChangeHandler) {
+      formChangeHandler(selectedValue, errorMessage)
+    }
+  }
+
+  useEffect(() => {
+    const isSelectedValue = typeof selectedValue !== 'undefined'
+    if (isSelectedValue) {
+      validationSelect()
+    }
+  }, [selectedValue])
+
+  const onBlur = () => {
+    validationSelect()
   }
 
   const wrapperClass = title ? styles.wrapper : ''
@@ -42,8 +96,11 @@ export const Select = ({
 
   return (
     <div className={wrapperClass} data-tid={rest['data-tid']}>
+      {labelCopy && <InputLabel name={name} labelCopy={labelCopy} />}
+      {console.log('SelectTag ...props: ', { ...props })}
       <SelectTag {...props} />
       {title && <div className={styles.title}>{title}</div>}
+      {getError(currentError, formTouched)}
     </div>
   )
 }
@@ -59,6 +116,12 @@ Select.propTypes = {
   title: PropTypes.string,
   className: PropTypes.string,
   isCreatable: PropTypes.bool,
+  formChangeHandler: PropTypes.func,
+  currentError: PropTypes.string,
+  formTouched: PropTypes.bool,
+  labelCopy: PropTypes.string,
+  name: PropTypes.string,
+  validator: PropTypes.func,
 }
 
 Select.defaultProps = {

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -129,7 +129,7 @@ export const Select = ({
 
 Select.propTypes = {
   /** class name prefix */
-  classNamePrefix: PropTypes.string.isRequired,
+  classNamePrefix: PropTypes.string,
   /** loadOptions should take an inputValue and return a Promise that resolves */
   // to an array of options.
   loadOptions: PropTypes.func,

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -80,10 +80,8 @@ export const Select = ({
     // react-select multi select case
     if (Array.isArray(userSelection)) {
       resolvedValues = userSelection.map((selection) => selection.value)
-      // errorMessage = validate(arrayOfValues)
     } else {
       // react-select single select case
-      // errorMessage = validate(userSelection.value)
       resolvedValues = userSelection.value
     }
 

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -120,7 +120,6 @@ export const Select = ({
   return (
     <div className={wrapperClass} data-tid={rest['data-tid']}>
       {labelCopy && <InputLabel name={name} labelCopy={labelCopy} />}
-      {console.log('SelectTag ...props: ', { ...props })}
       <SelectTag {...props} />
       {title && <div className={styles.title}>{title}</div>}
       {getError(currentError, formTouched)}

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -76,17 +76,21 @@ export const Select = ({
 
   const validationSelect = () => {
     let errorMessage = ''
+    let resolvedValues = ''
     // react-select multi select case
     if (Array.isArray(userSelection)) {
-      const arrayOfValues = userSelection.map((selection) => selection.value)
-      errorMessage = validate(arrayOfValues)
+      resolvedValues = userSelection.map((selection) => selection.value)
+      // errorMessage = validate(arrayOfValues)
     } else {
       // react-select single select case
-      errorMessage = validate(userSelection.value)
+      // errorMessage = validate(userSelection.value)
+      resolvedValues = userSelection.value
     }
+
+    errorMessage = validate(resolvedValues)
     setError(errorMessage)
     if (formChangeHandler) {
-      formChangeHandler(userSelection, errorMessage)
+      formChangeHandler(resolvedValues, errorMessage)
     }
   }
 

--- a/src/components/Select/Select.md
+++ b/src/components/Select/Select.md
@@ -24,7 +24,9 @@ const options = [
 />
 ```
 
-Compact Select
+Compact Select with a default value. Note that a default value can either be
+an index into your options e.g. `defaultValue={[options[3]]}`, or, you may
+hard code it (but it will need to have the same shape!)
 
 ```jsx
 const onSelected = (selectedOption) => {
@@ -44,6 +46,10 @@ const options = [
   placeholder="Custom placeholder..."
   isCompact={true}
   onChange={onSelected}
+  // Notice it's the same shape as the options? It's probably preferable to
+  // just index into that original array like the commented out one below. //// But hopefully this provides clarity on the requirements of defaultValue.
+  defaultValue={{ value: 'la', label: 'Los Angeles' }}
+  // defaultValue={[options[3]]} /* probably even better approach */
   options={options}
 />
 ```
@@ -164,12 +170,31 @@ validator you hook up (if you choose to).
   previously selected items; so, once there are no selections left, the multi select's
   corresponding form validator will be called with an empty array.
 
-_Put differently, the [react-select docs](https://react-select.com/props#statemanager-props) specify this in Typescript notation as:
-`<Object, Array<Object>, null, undefined>`_
+_Put differently, the [react-select docs](https://react-select.com/props#statemanager-props) specify this in Typescript notation as: `<Object, Array<Object>, null, undefined>`_
 
 ```jsx
 import validateExists from '../../validators/validateExists'
+import { STATES } from './states-fixture.js'
 import { Form, Spacer, Button, InfoMessage, Select } from '../index'
+
+const loadOptions = (searchQuery) => {
+  const filteredStates = STATES.filter((item) => {
+    return item.value.toLowerCase().includes(searchQuery.toLowerCase())
+  })
+
+  const options = [
+    {
+      value: 'default and invalid choice',
+      label: 'Select me to see inline field error :)',
+    },
+    ...filteredStates,
+  ]
+  // Setting at 2 seconds so we can "feel" a noticable delay in the demo :)
+  return new Promise((resolve, reject) => {
+    setTimeout(() => resolve(options), 2000)
+  })
+}
+
 ;<Form
   config={{
     formName: 'Select in form example',
@@ -181,22 +206,15 @@ import { Form, Spacer, Button, InfoMessage, Select } from '../index'
           return (
             <Select
               title="What state?"
+              isAsync
               placeholder="State (single select)"
               options={options}
+              loadOptions={loadOptions}
               {...props}
             />
           )
         },
         name: 'states',
-        options: [
-          { value: 'CA', label: 'CA' },
-          { value: 'OR', label: 'OR' },
-          { value: 'NY', label: 'NY' },
-          {
-            value: 'default and invalid choice',
-            label: 'Select something other then me :)',
-          },
-        ],
         validators: [
           (val) =>
             val.length && val == 'default and invalid choice'

--- a/src/components/Select/Select.md
+++ b/src/components/Select/Select.md
@@ -145,7 +145,27 @@ const options = [
 ;<Select isMulti isCreatable name="colors" options={options} />
 ```
 
-Form engine example:
+---
+
+# Form Engine
+
+Example of `<Select />` component being used within the EDS form engine:
+
+- first select is "single select"
+- second is "multi select":
+
+Please note, the last user's selection will be one of used to call back the form engine
+validator you hook up (if you choose to).
+
+- For single select, that validator will be called back with the value of the selection as a string.
+
+- For multi select it will be called back with an array of the values matching all the selections thus far. Internally, react-select will map this to: `[{"value": "a", "label": "A"}, {"value": "b", "label": "B"}]`, but, the validator will then be called with:
+  `['a', 'b']`—most likely, it will validate against the existence of certain values, a minimum length, or similar. Also note, that react-select allows the user to remove all
+  previously selected items; so, once there are no selections left, the multi select's
+  corresponding form validator will be called with an empty array.
+
+_Put differently, the [react-select docs](https://react-select.com/props#statemanager-props) specify this in Typescript notation as:
+`<Object, Array<Object>, null, undefined>`_
 
 ```jsx
 import validateExists from '../../validators/validateExists'
@@ -161,7 +181,7 @@ import { Form, Spacer, Button, InfoMessage, Select } from '../index'
           return (
             <Select
               title="What state?"
-              placeholder="State"
+              placeholder="State (single select)"
               options={options}
               {...props}
             />
@@ -181,6 +201,33 @@ import { Form, Spacer, Button, InfoMessage, Select } from '../index'
           (val) =>
             val.length && val == 'default and invalid choice'
               ? 'You must select an actual state'
+              : '',
+        ],
+      },
+      states_multiselect: {
+        component: (props, options) => {
+          return (
+            <Select
+              isMulti
+              title="Pick a few states?"
+              placeholder="Pick a few states (multi select)"
+              options={options}
+              {...props}
+            />
+          )
+        },
+        name: 'states',
+        options: [
+          { value: 'CA', label: 'CA' },
+          { value: 'OR', label: 'OR' },
+          { value: 'NY', label: 'NY' },
+          { value: 'WA', label: 'WA' },
+          { value: 'TX', label: 'TX' },
+        ],
+        validators: [
+          (arrayOfSelections) =>
+            arrayOfSelections.length < 2
+              ? 'You must select at least two (2) states!'
               : '',
         ],
       },
@@ -217,6 +264,8 @@ import { Form, Spacer, Button, InfoMessage, Select } from '../index'
           </>
         )}
         {field('states')}
+        <Spacer.H16 />
+        {field('states_multiselect')}
         <Spacer.H16 />
         <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
           Submit

--- a/src/components/Select/Select.md
+++ b/src/components/Select/Select.md
@@ -158,12 +158,31 @@ import { Form, Spacer, Button, InfoMessage, Select } from '../index'
     fields: {
       states: {
         component: (props, options) => {
-          return <Select placeholder="State" options={options} {...props} />
+          return (
+            <Select
+              title="What state?"
+              placeholder="State"
+              options={options}
+              {...props}
+            />
+          )
         },
         name: 'states',
-        labelCopy: 'What state?',
-        options: [{ value: 'CA', label: 'CA' }],
-        validators: [validateExists],
+        options: [
+          { value: 'CA', label: 'CA' },
+          { value: 'OR', label: 'OR' },
+          { value: 'NY', label: 'NY' },
+          {
+            value: 'default and invalid choice',
+            label: 'Select something other then me :)',
+          },
+        ],
+        validators: [
+          (val) =>
+            val.length && val == 'default and invalid choice'
+              ? 'You must select an actual state'
+              : '',
+        ],
       },
     },
     onSubmit: async (formData) => {

--- a/src/components/Select/Select.md
+++ b/src/components/Select/Select.md
@@ -144,3 +144,66 @@ const options = [
 
 ;<Select isMulti isCreatable name="colors" options={options} />
 ```
+
+Form engine example:
+
+```jsx
+import validateExists from '../../validators/validateExists'
+import { Form, Spacer, Button, InfoMessage, Select } from '../index'
+;<Form
+  config={{
+    formName: 'Select in form example',
+    autocompleteOff: true,
+    formId: '1',
+    fields: {
+      states: {
+        component: (props, options) => {
+          return <Select placeholder="State" options={options} {...props} />
+        },
+        name: 'states',
+        labelCopy: 'What state?',
+        options: [{ value: 'CA', label: 'CA' }],
+        validators: [validateExists],
+      },
+    },
+    onSubmit: async (formData) => {
+      alert(
+        'form submission successful with values:' + JSON.stringify(formData)
+      )
+    },
+  }}
+>
+  {(api) => {
+    const {
+      field,
+      getFormErrorMessage,
+      getFormIsValid,
+      getFormInteractedWith,
+    } = api
+    return (
+      <div>
+        {!!getFormInteractedWith() && (
+          <>
+            <InfoMessage.Alert.Success>
+              {'Form interacted with.'}
+            </InfoMessage.Alert.Success>
+          </>
+        )}
+
+        {getFormErrorMessage() && (
+          <>
+            <InfoMessage.Alert.Error>
+              {getFormErrorMessage()}
+            </InfoMessage.Alert.Error>
+          </>
+        )}
+        {field('states')}
+        <Spacer.H16 />
+        <Button.Medium.Black disabled={!getFormIsValid()} type="submit">
+          Submit
+        </Button.Medium.Black>
+      </div>
+    )
+  }}
+</Form>
+```

--- a/src/components/Select/Select.test.js
+++ b/src/components/Select/Select.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Select } from './Select.js'
-import { render } from '@testing-library/react'
+import { render, fireEvent, waitForElement } from '@testing-library/react'
 
 describe('Select', () => {
   const mockProps = {
@@ -9,15 +9,13 @@ describe('Select', () => {
     'data-tid': 'my-select',
   }
 
-  test.only('matches snapshot', () => {
+  test('matches snapshot', () => {
     const tree = render(<Select {...mockProps} />)
     expect(tree).toMatchSnapshot()
   })
 
   test('adding a title prop adds a div and aria-label', () => {
-    const tree = renderer
-      .create(<Select {...mockProps} title="Hello World" />)
-      .toJSON()
+    const tree = render(<Select {...mockProps} title="Hello World" />)
     expect(tree).toMatchSnapshot()
   })
 })

--- a/src/components/Select/Select.test.js
+++ b/src/components/Select/Select.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import renderer from 'react-test-renderer'
 import { Select } from './Select.js'
+import { render } from '@testing-library/react'
 
 describe('Select', () => {
   const mockProps = {
@@ -9,8 +9,8 @@ describe('Select', () => {
     'data-tid': 'my-select',
   }
 
-  test('matches snapshot', () => {
-    const tree = renderer.create(<Select {...mockProps} />).toJSON()
+  test.only('matches snapshot', () => {
+    const tree = render(<Select {...mockProps} />)
     expect(tree).toMatchSnapshot()
   })
 

--- a/src/components/Select/Select.test.js
+++ b/src/components/Select/Select.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Select } from './Select.js'
-import { render, fireEvent, waitForElement } from '@testing-library/react'
+import { render } from '@testing-library/react'
 
 describe('Select', () => {
   const mockProps = {

--- a/src/components/Select/__snapshots__/Select.test.js.snap
+++ b/src/components/Select/__snapshots__/Select.test.js.snap
@@ -1,121 +1,220 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select adding a title prop adds a div and aria-label 1`] = `
-<div
-  className="wrapper"
-  data-tid="my-select"
->
-  <div
-    className="foo Compact root css-2b097c-container"
-    onKeyDown={[Function]}
-  >
-    <div
-      className="StyledReactSelect__control css-yk16xz-control"
-      onMouseDown={[Function]}
-      onTouchEnd={[Function]}
-    >
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
       <div
-        className="StyledReactSelect__value-container css-1hwfws3"
+        class="wrapper"
+        data-tid="my-select"
       >
         <div
-          className="StyledReactSelect__placeholder css-1wa3eu0-placeholder"
-        >
-          Type to search
-        </div>
-        <div
-          className="css-b8ldur-Input"
+          class="foo Compact root css-2b097c-container"
         >
           <div
-            className="StyledReactSelect__input"
-            style={
-              Object {
-                "display": "inline-block",
-              }
-            }
+            class="StyledReactSelect__control css-yk16xz-control"
           >
-            <input
-              aria-autocomplete="list"
-              aria-label="Hello World"
-              autoCapitalize="none"
-              autoComplete="off"
-              autoCorrect="off"
-              disabled={false}
-              id="react-select-3-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              spellCheck="false"
-              style={
-                Object {
-                  "background": 0,
-                  "border": 0,
-                  "boxSizing": "content-box",
-                  "color": "inherit",
-                  "fontSize": "inherit",
-                  "label": "input",
-                  "opacity": 1,
-                  "outline": 0,
-                  "padding": 0,
-                  "width": "1px",
-                }
-              }
-              tabIndex="0"
-              type="text"
-              value=""
+            <div
+              class="StyledReactSelect__value-container css-1hwfws3"
+            >
+              <div
+                class="StyledReactSelect__placeholder css-1wa3eu0-placeholder"
+              >
+                Type to search
+              </div>
+              <div
+                class="css-b8ldur-Input"
+              >
+                <div
+                  class="StyledReactSelect__input"
+                  style="display: inline-block;"
+                >
+                  <input
+                    aria-autocomplete="list"
+                    aria-label="Hello World"
+                    autocapitalize="none"
+                    autocomplete="off"
+                    autocorrect="off"
+                    id="react-select-3-input"
+                    spellcheck="false"
+                    style="box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;"
+                    tabindex="0"
+                    type="text"
+                    value=""
+                  />
+                  <div
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="StyledReactSelect__indicators css-1hb7zxy-IndicatorsContainer"
+            >
+              <span
+                class="StyledReactSelect__indicator-separator css-1okebmr-indicatorSeparator"
+              />
+              <div
+                aria-hidden="true"
+                class="StyledReactSelect__indicator StyledReactSelect__dropdown-indicator css-tlfecz-indicatorContainer"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="css-6q0nyr-Svg"
+                  focusable="false"
+                  height="20"
+                  viewBox="0 0 20 20"
+                  width="20"
+                >
+                  <path
+                    d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="title"
+        >
+          Hello World
+        </div>
+        
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="wrapper"
+      data-tid="my-select"
+    >
+      <div
+        class="foo Compact root css-2b097c-container"
+      >
+        <div
+          class="StyledReactSelect__control css-yk16xz-control"
+        >
+          <div
+            class="StyledReactSelect__value-container css-1hwfws3"
+          >
+            <div
+              class="StyledReactSelect__placeholder css-1wa3eu0-placeholder"
+            >
+              Type to search
+            </div>
+            <div
+              class="css-b8ldur-Input"
+            >
+              <div
+                class="StyledReactSelect__input"
+                style="display: inline-block;"
+              >
+                <input
+                  aria-autocomplete="list"
+                  aria-label="Hello World"
+                  autocapitalize="none"
+                  autocomplete="off"
+                  autocorrect="off"
+                  id="react-select-3-input"
+                  spellcheck="false"
+                  style="box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;"
+                  tabindex="0"
+                  type="text"
+                  value=""
+                />
+                <div
+                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="StyledReactSelect__indicators css-1hb7zxy-IndicatorsContainer"
+          >
+            <span
+              class="StyledReactSelect__indicator-separator css-1okebmr-indicatorSeparator"
             />
             <div
-              style={
-                Object {
-                  "height": 0,
-                  "left": 0,
-                  "overflow": "scroll",
-                  "position": "absolute",
-                  "top": 0,
-                  "visibility": "hidden",
-                  "whiteSpace": "pre",
-                }
-              }
+              aria-hidden="true"
+              class="StyledReactSelect__indicator StyledReactSelect__dropdown-indicator css-tlfecz-indicatorContainer"
             >
-              
+              <svg
+                aria-hidden="true"
+                class="css-6q0nyr-Svg"
+                focusable="false"
+                height="20"
+                viewBox="0 0 20 20"
+                width="20"
+              >
+                <path
+                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                />
+              </svg>
             </div>
           </div>
         </div>
       </div>
       <div
-        className="StyledReactSelect__indicators css-1hb7zxy-IndicatorsContainer"
+        class="title"
       >
-        <span
-          className="StyledReactSelect__indicator-separator css-1okebmr-indicatorSeparator"
-        />
-        <div
-          aria-hidden="true"
-          className="StyledReactSelect__indicator StyledReactSelect__dropdown-indicator css-tlfecz-indicatorContainer"
-          onMouseDown={[Function]}
-          onTouchEnd={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="css-6q0nyr-Svg"
-            focusable="false"
-            height={20}
-            viewBox="0 0 20 20"
-            width={20}
-          >
-            <path
-              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-            />
-          </svg>
-        </div>
+        Hello World
       </div>
+      
     </div>
-  </div>
-  <div
-    className="title"
-  >
-    Hello World
-  </div>
-  
-</div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`Select matches snapshot 1`] = `

--- a/src/components/Select/__snapshots__/Select.test.js.snap
+++ b/src/components/Select/__snapshots__/Select.test.js.snap
@@ -119,113 +119,206 @@ exports[`Select adding a title prop adds a div and aria-label 1`] = `
 `;
 
 exports[`Select matches snapshot 1`] = `
-<div
-  className=""
-  data-tid="my-select"
->
-  <div
-    className="foo Compact root css-2b097c-container"
-    onKeyDown={[Function]}
-  >
-    <div
-      className="StyledReactSelect__control css-yk16xz-control"
-      onMouseDown={[Function]}
-      onTouchEnd={[Function]}
-    >
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
       <div
-        className="StyledReactSelect__value-container css-1hwfws3"
+        class=""
+        data-tid="my-select"
       >
         <div
-          className="StyledReactSelect__placeholder css-1wa3eu0-placeholder"
-        >
-          Type to search
-        </div>
-        <div
-          className="css-b8ldur-Input"
+          class="foo Compact root css-2b097c-container"
         >
           <div
-            className="StyledReactSelect__input"
-            style={
-              Object {
-                "display": "inline-block",
-              }
-            }
+            class="StyledReactSelect__control css-yk16xz-control"
           >
-            <input
-              aria-autocomplete="list"
-              autoCapitalize="none"
-              autoComplete="off"
-              autoCorrect="off"
-              disabled={false}
-              id="react-select-2-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              spellCheck="false"
-              style={
-                Object {
-                  "background": 0,
-                  "border": 0,
-                  "boxSizing": "content-box",
-                  "color": "inherit",
-                  "fontSize": "inherit",
-                  "label": "input",
-                  "opacity": 1,
-                  "outline": 0,
-                  "padding": 0,
-                  "width": "1px",
-                }
-              }
-              tabIndex="0"
-              type="text"
-              value=""
+            <div
+              class="StyledReactSelect__value-container css-1hwfws3"
+            >
+              <div
+                class="StyledReactSelect__placeholder css-1wa3eu0-placeholder"
+              >
+                Type to search
+              </div>
+              <div
+                class="css-b8ldur-Input"
+              >
+                <div
+                  class="StyledReactSelect__input"
+                  style="display: inline-block;"
+                >
+                  <input
+                    aria-autocomplete="list"
+                    autocapitalize="none"
+                    autocomplete="off"
+                    autocorrect="off"
+                    id="react-select-2-input"
+                    spellcheck="false"
+                    style="box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;"
+                    tabindex="0"
+                    type="text"
+                    value=""
+                  />
+                  <div
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="StyledReactSelect__indicators css-1hb7zxy-IndicatorsContainer"
+            >
+              <span
+                class="StyledReactSelect__indicator-separator css-1okebmr-indicatorSeparator"
+              />
+              <div
+                aria-hidden="true"
+                class="StyledReactSelect__indicator StyledReactSelect__dropdown-indicator css-tlfecz-indicatorContainer"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="css-6q0nyr-Svg"
+                  focusable="false"
+                  height="20"
+                  viewBox="0 0 20 20"
+                  width="20"
+                >
+                  <path
+                    d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+        
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class=""
+      data-tid="my-select"
+    >
+      <div
+        class="foo Compact root css-2b097c-container"
+      >
+        <div
+          class="StyledReactSelect__control css-yk16xz-control"
+        >
+          <div
+            class="StyledReactSelect__value-container css-1hwfws3"
+          >
+            <div
+              class="StyledReactSelect__placeholder css-1wa3eu0-placeholder"
+            >
+              Type to search
+            </div>
+            <div
+              class="css-b8ldur-Input"
+            >
+              <div
+                class="StyledReactSelect__input"
+                style="display: inline-block;"
+              >
+                <input
+                  aria-autocomplete="list"
+                  autocapitalize="none"
+                  autocomplete="off"
+                  autocorrect="off"
+                  id="react-select-2-input"
+                  spellcheck="false"
+                  style="box-sizing: content-box; width: 2px; border: 0px; font-size: inherit; opacity: 1; outline: 0; padding: 0px;"
+                  tabindex="0"
+                  type="text"
+                  value=""
+                />
+                <div
+                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: inherit; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="StyledReactSelect__indicators css-1hb7zxy-IndicatorsContainer"
+          >
+            <span
+              class="StyledReactSelect__indicator-separator css-1okebmr-indicatorSeparator"
             />
             <div
-              style={
-                Object {
-                  "height": 0,
-                  "left": 0,
-                  "overflow": "scroll",
-                  "position": "absolute",
-                  "top": 0,
-                  "visibility": "hidden",
-                  "whiteSpace": "pre",
-                }
-              }
+              aria-hidden="true"
+              class="StyledReactSelect__indicator StyledReactSelect__dropdown-indicator css-tlfecz-indicatorContainer"
             >
-              
+              <svg
+                aria-hidden="true"
+                class="css-6q0nyr-Svg"
+                focusable="false"
+                height="20"
+                viewBox="0 0 20 20"
+                width="20"
+              >
+                <path
+                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                />
+              </svg>
             </div>
           </div>
         </div>
       </div>
-      <div
-        className="StyledReactSelect__indicators css-1hb7zxy-IndicatorsContainer"
-      >
-        <span
-          className="StyledReactSelect__indicator-separator css-1okebmr-indicatorSeparator"
-        />
-        <div
-          aria-hidden="true"
-          className="StyledReactSelect__indicator StyledReactSelect__dropdown-indicator css-tlfecz-indicatorContainer"
-          onMouseDown={[Function]}
-          onTouchEnd={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="css-6q0nyr-Svg"
-            focusable="false"
-            height={20}
-            viewBox="0 0 20 20"
-            width={20}
-          >
-            <path
-              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-            />
-          </svg>
-        </div>
-      </div>
+      
     </div>
-  </div>
-  
-</div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;

--- a/src/components/Select/__snapshots__/Select.test.js.snap
+++ b/src/components/Select/__snapshots__/Select.test.js.snap
@@ -114,6 +114,7 @@ exports[`Select adding a title prop adds a div and aria-label 1`] = `
   >
     Hello World
   </div>
+  
 </div>
 `;
 
@@ -225,5 +226,6 @@ exports[`Select matches snapshot 1`] = `
       </div>
     </div>
   </div>
+  
 </div>
 `;

--- a/src/components/Select/states-fixture.js
+++ b/src/components/Select/states-fixture.js
@@ -1,0 +1,238 @@
+export const STATES = [
+  {
+    label: 'AL',
+    value: 'AL',
+  },
+  {
+    label: 'AK',
+    value: 'AK',
+  },
+  {
+    label: 'AS',
+    value: 'AS',
+  },
+  {
+    label: 'AZ',
+    value: 'AZ',
+  },
+  {
+    label: 'AR',
+    value: 'AR',
+  },
+  {
+    label: 'CA',
+    value: 'CA',
+  },
+  {
+    label: 'CO',
+    value: 'CO',
+  },
+  {
+    label: 'CT',
+    value: 'CT',
+  },
+  {
+    label: 'DE',
+    value: 'DE',
+  },
+  {
+    label: 'DC',
+    value: 'DC',
+  },
+  {
+    label: 'FM',
+    value: 'FM',
+  },
+  {
+    label: 'FL',
+    value: 'FL',
+  },
+  {
+    label: 'GA',
+    value: 'GA',
+  },
+  {
+    label: 'GU',
+    value: 'GU',
+  },
+  {
+    label: 'HI',
+    value: 'HI',
+  },
+  {
+    label: 'ID',
+    value: 'ID',
+  },
+  {
+    label: 'IL',
+    value: 'IL',
+  },
+  {
+    label: 'IN',
+    value: 'IN',
+  },
+  {
+    label: 'IA',
+    value: 'IA',
+  },
+  {
+    label: 'KS',
+    value: 'KS',
+  },
+  {
+    label: 'KY',
+    value: 'KY',
+  },
+  {
+    label: 'LA',
+    value: 'LA',
+  },
+  {
+    label: 'ME',
+    value: 'ME',
+  },
+  {
+    label: 'MH',
+    value: 'MH',
+  },
+  {
+    label: 'MD',
+    value: 'MD',
+  },
+  {
+    label: 'MA',
+    value: 'MA',
+  },
+  {
+    label: 'MI',
+    value: 'MI',
+  },
+  {
+    label: 'MN',
+    value: 'MN',
+  },
+  {
+    label: 'MS',
+    value: 'MS',
+  },
+  {
+    label: 'MO',
+    value: 'MO',
+  },
+  {
+    label: 'MT',
+    value: 'MT',
+  },
+  {
+    label: 'NE',
+    value: 'NE',
+  },
+  {
+    label: 'NV',
+    value: 'NV',
+  },
+  {
+    label: 'NH',
+    value: 'NH',
+  },
+  {
+    label: 'NJ',
+    value: 'NJ',
+  },
+  {
+    label: 'NM',
+    value: 'NM',
+  },
+  {
+    label: 'NY',
+    value: 'NY',
+  },
+  {
+    label: 'NC',
+    value: 'NC',
+  },
+  {
+    label: 'ND',
+    value: 'ND',
+  },
+  {
+    label: 'MP',
+    value: 'MP',
+  },
+  {
+    label: 'OH',
+    value: 'OH',
+  },
+  {
+    label: 'OK',
+    value: 'OK',
+  },
+  {
+    label: 'OR',
+    value: 'OR',
+  },
+  {
+    label: 'PW',
+    value: 'PW',
+  },
+  {
+    label: 'PA',
+    value: 'PA',
+  },
+  {
+    label: 'PR',
+    value: 'PR',
+  },
+  {
+    label: 'RI',
+    value: 'RI',
+  },
+  {
+    label: 'SC',
+    value: 'SC',
+  },
+  {
+    label: 'SD',
+    value: 'SD',
+  },
+  {
+    label: 'TN',
+    value: 'TN',
+  },
+  {
+    label: 'TX',
+    value: 'TX',
+  },
+  {
+    label: 'UT',
+    value: 'UT',
+  },
+  {
+    label: 'VT',
+    value: 'VT',
+  },
+  {
+    label: 'VI',
+    value: 'VI',
+  },
+  {
+    label: 'VA',
+    value: 'VA',
+  },
+  {
+    label: 'WA',
+    value: 'WA',
+  },
+  {
+    label: 'WV',
+    value: 'WV',
+  },
+  {
+    label: 'WI',
+    value: 'WI',
+  },
+  {
+    label: 'WY',
+    value: 'WY',
+  },
+]

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -322,23 +322,46 @@ export declare const SearchInput: {
 
 export declare const Select: {
   ({
+    classNamePrefix,
     className,
     title,
     isAsync,
+    isCompact,
     isCreatable,
+    validator,
+    onChange,
+    formChangeHandler,
+    currentError,
+    formTouched,
+    labelCopy,
+    name,
     ...rest
   }: {
     [x: string]: any
+    classNamePrefix?: string
     className?: string
     title?: string
     isAsync?: boolean
     isCreatable?: boolean
+    isCompact?: boolean
+    validator?: (selectStringOrArrayOfSelections: any) => string
+    loadOptions?: (selectStringOrArrayOfSelections: any) => any
+    onChange?: (selectStringOrArrayOfSelections: any) => any
+    formChangeHandler?: (
+      selectStringOrArrayOfSelections: any,
+      errorValue: string
+    ) => void
+    currentError?: string
+    formTouched?: boolean
+    labelCopy?: string
+    name?: string
   }): JSX.Element
   propTypes: {
     classNamePrefix?: string
     loadOptions?: any
     onChange?: any
     isAsync?: boolean
+    isCompact?: boolean
     title?: string
     className?: string
     isCreatable?: boolean

--- a/src/components/index.tests.tsx
+++ b/src/components/index.tests.tsx
@@ -404,6 +404,7 @@ class SelectTest extends React.Component<any, any> {
           onChange={onSelected}
           options={options}
           isAsync={true}
+          isMulti={true}
           data-tid="foo"
         />
         <Select onChange={onSelected} options={options} isCreatable={true} />


### PR DESCRIPTION
**Description:**

- [Asana Task](https://app.asana.com/0/1136962714401929/1155914817079659/f)
- EDS Select Initial Values and Validation
- Monorepo PR: https://github.com/getethos/ethos/pull/3312

- [x] is there a form engine example within the Select field example?
- [x] Is single select working?
- [x] Is multi select also working?

- [x] Figure out which of the shared fields is wrapping this and verify in funnel

- frontend/src/main/InsuranceApp/term/Apply/Greenhouse/AuraDe/AuraDeQuestionUi.js for AuraDeSearchQuestion case (Eric and Jas):

```

          <AuraDeSearchField
            {...fieldProps}
            cacheOptions
            isAsync
            isMulti
            loadOptions={loadOptions}
          />
```
For above, it looks like the "**What is your occupation?**" aura question uses this and is an interesting usage in terms of it's async. The Doctor question also appears to use Select indirectly but via _AuraDeSearchComponent_




- underwriting/nora/frontend/src/features/dashboard/Toolbar.tsx for the dashboard filters in toolbar (Steph)


- frontend/src/main/InsuranceApp/term/Apply/Greenhouse/Checkout/components/PolicyDetailsCard.js appears to use following which wrap <Select /) (Drew):

    - frontend/shared/components/Dropdown/CoverageDropdown.js 
    - frontend/shared/components/Dropdown/TermDropdown.js

- frontend/src/main/InsuranceApp/PreInterview/Questions/components.js uses in pre interview aka Starboy getSelectComponent (James) for states dropdown, birthCountry dropdown etc. -- all appear to be single selects

- [x] Dev QA (see screengrabs at bottom of this PR)

- [x] Does `defaultValue` still work properly?


- [x] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?


**Screenshots:**

Single select tests:

initial state form is invalid so submit button is reflecting this will disabled button:
![image](https://user-images.githubusercontent.com/142403/81620942-f7861a00-93a1-11ea-9a2d-adbcf410033a.png)


selecting an invalid option:

![image](https://user-images.githubusercontent.com/142403/81620912-dfae9600-93a1-11ea-9a4e-40593b973d09.png)

selecting an valid option:

![image](https://user-images.githubusercontent.com/142403/81620969-08369000-93a2-11ea-9699-5d6ef458b2b8.png)


___ 

Here's multi which I've added as a second field to the form engine example:

Valid selection (in this case I have a validator setup to ensure 2+ items selected):

![image](https://user-images.githubusercontent.com/142403/81630532-bea66f00-93ba-11ea-97ea-18c033268f03.png)

Invalid (only 1 selected):
![image](https://user-images.githubusercontent.com/142403/81630560-d4b42f80-93ba-11ea-8017-5c35fc9e89aa.png)


Edge case -- user selects some multi items, then clears them out -- still results in validation working properly:

![image](https://user-images.githubusercontent.com/142403/81631228-3c1eaf00-93bc-11ea-813e-074a8fa23867.png)

Improves the docs for the single vs. multi validation complexity:

![image](https://user-images.githubusercontent.com/142403/81632260-adf7f800-93be-11ea-90d3-1db01efd4c3f.png)


Also adds a form engine example with even more explanation!

![image](https://user-images.githubusercontent.com/142403/81632280-b94b2380-93be-11ea-8ff2-fc281d80cb07.png)

