### PR TITLE
Pagination with ellipsis - limit number of pages displayed at one time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.190",
+  "version": "1.1.199",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Grid/Pagination.js
+++ b/src/components/Grid/Pagination.js
@@ -3,6 +3,8 @@ import { memo } from 'react'
 
 import { usePagination } from './usePagination'
 
+const DEFAULT_DISPLAY_PAGES_COUNT = 6
+
 /**
  * Pagination component for use with the data grid
  *
@@ -11,12 +13,13 @@ import { usePagination } from './usePagination'
  * @param {object} props - Component Props
  * @prop {number} [props.currentPage] - The current page
  * @prop {number} [props.pageCount] - The total number of pages available for the collection of things
- * @prop {function} [props.fetchPageCallback] - Callback thats fires when the next page should be fetched
+ * @prop {number} [props.displayedPagesCount] - Number of pages displayed at a time
+ * @prop {function} [props.fetchPageCallback] - Callback that fires when the next page should be fetched
  *
  * @return {JSX.Element}
  */
 export const Pagination = memo(
-  ({ currentPage, pageCount, fetchPageCallback }) => {
+  ({ currentPage, pageCount, displayedPagesCount, fetchPageCallback }) => {
     if (
       typeof currentPage !== 'number' ||
       typeof pageCount !== 'number' ||
@@ -30,7 +33,11 @@ export const Pagination = memo(
       fetchPageCallback,
     })
 
-    return conditionallyRenderPagingButtons(pageCount, currentPage)
+    return conditionallyRenderPagingButtons(
+      pageCount,
+      currentPage,
+      displayedPagesCount
+    )
   }
 )
 
@@ -38,5 +45,11 @@ Pagination.propTypes = {
   fetchPageCallback: PropTypes.func.isRequired,
   currentPage: PropTypes.number.isRequired,
   pageCount: PropTypes.number.isRequired,
+  displayedPagesCount: PropTypes.number,
 }
+
+Pagination.defaultProps = {
+  displayedPagesCount: DEFAULT_DISPLAY_PAGES_COUNT,
+}
+
 Pagination.displayName = 'Pagination'

--- a/src/components/Grid/Pagination.md
+++ b/src/components/Grid/Pagination.md
@@ -218,6 +218,7 @@ const GridAndPagination = memo(() => {
       <Pagination
         currentPage={pagingState.currentPage}
         pageCount={pagingState.pageCount}
+        displayedPagesCount={6}
         fetchPageCallback={fetchPage}
       />
     </>
@@ -225,4 +226,45 @@ const GridAndPagination = memo(() => {
 })
 
 ;<GridAndPagination />
+```
+** Example Pagination views **
+
+Pagination view with all page numbers displayed
+```jsx
+<Pagination
+ currentPage={2}
+ pageCount={5}
+ displayedPagesCount={6}
+ fetchPageCallback={() => {}}
+/>
+```
+
+Pagination view with total count more than display pages
+```jsx
+<Pagination
+ currentPage={2}
+ pageCount={10}
+ displayedPagesCount={6}
+ fetchPageCallback={() => {}}
+/>
+```
+
+Pagination view with left ellipsis
+```jsx
+<Pagination
+ currentPage={15}
+ pageCount={20}
+ displayedPagesCount={10}
+ fetchPageCallback={() => {}}
+/>
+```
+
+Pagination view with left and right ellipsis
+```jsx
+<Pagination
+ currentPage={6}
+ pageCount={20}
+ displayedPagesCount={10}
+ fetchPageCallback={() => {}}
+/>
 ```

--- a/src/components/Grid/Pagination.test.js
+++ b/src/components/Grid/Pagination.test.js
@@ -28,7 +28,57 @@ describe('Pagination Component', () => {
   it('default rendering', async () => {
     await act(async () => {
       tree = TestRenderer.create(
-        <Pagination currentPage={2} pageCount={3} fetchPageCallback={fetchFn} />
+        <Pagination
+          currentPage={2}
+          pageCount={3}
+          displayedPagesCount={3}
+          fetchPageCallback={fetchFn}
+        />
+      )
+    })
+    let snapShot = tree.toJSON()
+    expect(snapShot).toMatchSnapshot()
+  })
+
+  it('rendering with end ellipsis', async () => {
+    await act(async () => {
+      tree = TestRenderer.create(
+        <Pagination
+          currentPage={5}
+          pageCount={20}
+          displayedPagesCount={10}
+          fetchPageCallback={fetchFn}
+        />
+      )
+    })
+    let snapShot = tree.toJSON()
+    expect(snapShot).toMatchSnapshot()
+  })
+
+  it('rendering with start ellipsis', async () => {
+    await act(async () => {
+      tree = TestRenderer.create(
+        <Pagination
+          currentPage={15}
+          pageCount={20}
+          displayedPagesCount={10}
+          fetchPageCallback={fetchFn}
+        />
+      )
+    })
+    let snapShot = tree.toJSON()
+    expect(snapShot).toMatchSnapshot()
+  })
+
+  it('rendering with start and end ellipsis', async () => {
+    await act(async () => {
+      tree = TestRenderer.create(
+        <Pagination
+          currentPage={6}
+          pageCount={20}
+          displayedPagesCount={10}
+          fetchPageCallback={fetchFn}
+        />
       )
     })
     let snapShot = tree.toJSON()
@@ -38,7 +88,12 @@ describe('Pagination Component', () => {
   it('fetches', async () => {
     await act(async () => {
       tree = TestRenderer.create(
-        <Pagination currentPage={1} pageCount={3} fetchPageCallback={fetchFn} />
+        <Pagination
+          currentPage={1}
+          pageCount={3}
+          displayedPagesCount={3}
+          fetchPageCallback={fetchFn}
+        />
       )
     })
     const root = tree.root
@@ -55,7 +110,12 @@ describe('Pagination Component', () => {
   it('has aria labels', async () => {
     await act(async () => {
       tree = TestRenderer.create(
-        <Pagination currentPage={2} pageCount={3} fetchPageCallback={fetchFn} />
+        <Pagination
+          currentPage={2}
+          pageCount={3}
+          displayedPagesCount={3}
+          fetchPageCallback={fetchFn}
+        />
       )
     })
     const root = tree.root
@@ -92,7 +152,12 @@ describe('Hide Pagination', () => {
   it('hides the pagination if only a single page worth of items', async () => {
     await act(async () => {
       tree = TestRenderer.create(
-        <Pagination currentPage={1} pageCount={1} fetchPageCallback={fetchFn} />
+        <Pagination
+          currentPage={1}
+          pageCount={1}
+          displayedPagesCount={1}
+          fetchPageCallback={fetchFn}
+        />
       )
     })
     const root = tree.root

--- a/src/components/Grid/PaginationHelper.js
+++ b/src/components/Grid/PaginationHelper.js
@@ -1,0 +1,48 @@
+export const ELLIPSIS = '...'
+
+export const generatePagination = ({
+  currentPage,
+  pageCount,
+  displayedPagesCount,
+}) => {
+  let pages = [],
+    omit = pageCount - displayedPagesCount,
+    omitLeft,
+    omitRight
+  let showPageMedian = Math.floor(displayedPagesCount / 2)
+
+  if (pageCount > displayedPagesCount) {
+    if (currentPage > showPageMedian) {
+      omitLeft = Math.min(currentPage - showPageMedian, omit)
+      omitRight = omit - omitLeft
+    } else {
+      omitLeft = 0
+      omitRight = omit
+    }
+    for (let i = 1; i <= pageCount; i++) {
+      if (omitLeft > 0) {
+        if (i > 1 && i < omitLeft + 3) {
+          continue
+        }
+      }
+      if (omitRight > 0) {
+        if (i < pageCount && i > pageCount - omitRight - 2) {
+          continue
+        }
+      }
+      pages.push(i)
+    }
+    if (omitLeft > 0) {
+      pages.splice(1, 0, ELLIPSIS)
+    }
+    if (omitRight > 0) {
+      pages.splice(pages.length - 1, 0, ELLIPSIS)
+    }
+    return pages
+  } else {
+    for (let i = 1; i <= pageCount; i++) {
+      pages.push(i)
+    }
+  }
+  return pages
+}

--- a/src/components/Grid/PaginationHelper.test.js
+++ b/src/components/Grid/PaginationHelper.test.js
@@ -1,0 +1,60 @@
+import { generatePagination, ELLIPSIS } from './PaginationHelper'
+
+describe('generatePagination', function() {
+  it(`Page number is less than the number of pages displayed, 
+  display all page numbers`, () => {
+    let pagination = generatePagination({
+      currentPage: 5,
+      pageCount: 9,
+      displayedPagesCount: 10,
+    })
+    expect(pagination).toStrictEqual([1, 2, 3, 4, 5, 6, 7, 8, 9])
+  })
+
+  it(`Page number equals the number of pages displayed, 
+  display all page numbers`, () => {
+    let pagination = generatePagination({
+      currentPage: 9,
+      pageCount: 10,
+      displayedPagesCount: 10,
+    })
+    expect(pagination).toStrictEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  })
+
+  it(`Total pages are greater than the number of pages displayed, 
+  the current page <= number of pages/2, 
+  display only the end ellipsis`, function() {
+    let pagination = generatePagination({
+      currentPage: 5,
+      pageCount: 20,
+      displayedPagesCount: 10,
+    })
+    expect(pagination[pagination.length - 2]).toStrictEqual(ELLIPSIS)
+    expect(pagination[1]).not.toStrictEqual(ELLIPSIS)
+  })
+
+  it(`Total pages are greater than the number of pages displayed, 
+  the current page >= the number of pages - the number of pages is displayed/2, 
+  display only the start ellipsis`, function() {
+    let pagination = generatePagination({
+      currentPage: 15,
+      pageCount: 20,
+      displayedPagesCount: 10,
+    })
+    expect(pagination[1]).toStrictEqual(ELLIPSIS)
+    expect(pagination[pagination.length - 2]).not.toStrictEqual(ELLIPSIS)
+  })
+
+  it(`Total pages are greater than the number of displaypages, 
+  the current page > the number of pages displayed/2, 
+  current page < the total number of pages - the number of pages displayed/2, 
+  display start and end the ellipsis`, function() {
+    let pagination = generatePagination({
+      currentPage: 6,
+      pageCount: 20,
+      displayedPagesCount: 10,
+    })
+    expect(pagination[1]).toStrictEqual(ELLIPSIS)
+    expect(pagination[pagination.length - 2]).toStrictEqual(ELLIPSIS)
+  })
+})

--- a/src/components/Grid/__snapshots__/Pagination.test.js.snap
+++ b/src/components/Grid/__snapshots__/Pagination.test.js.snap
@@ -45,3 +45,292 @@ exports[`Pagination Component default rendering 1`] = `
   </button>
 </nav>
 `;
+
+exports[`Pagination Component rendering with end ellipsis 1`] = `
+<nav
+  aria-label="pagination"
+  className="pagination"
+>
+  <button
+    aria-label="Goto Page 4"
+    className="paginationButtons"
+    disabled={false}
+    onClick={[Function]}
+  >
+    «
+  </button>
+  <button
+    aria-label="Goto Page 1"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    1
+  </button>
+  <button
+    aria-label="Goto Page 2"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    2
+  </button>
+  <button
+    aria-label="Goto Page 3"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    3
+  </button>
+  <button
+    aria-label="Goto Page 4"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    4
+  </button>
+  <button
+    aria-current="page"
+    aria-label="Goto Page 5"
+    className="paginationButtons active"
+    onClick={[Function]}
+  >
+    5
+  </button>
+  <button
+    aria-label="Goto Page 6"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    6
+  </button>
+  <button
+    aria-label="Goto Page 7"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    7
+  </button>
+  <button
+    aria-label="Goto Page 8"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    8
+  </button>
+  <button
+    aria-disabled={true}
+    aria-label="More Pages"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    ...
+  </button>
+  <button
+    aria-label="Goto Page 20"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    20
+  </button>
+  <button
+    aria-label="Goto Page 6"
+    className="paginationButtons"
+    disabled={false}
+    onClick={[Function]}
+  >
+    »
+  </button>
+</nav>
+`;
+
+exports[`Pagination Component rendering with start and end ellipsis 1`] = `
+<nav
+  aria-label="pagination"
+  className="pagination"
+>
+  <button
+    aria-label="Goto Page 5"
+    className="paginationButtons"
+    disabled={false}
+    onClick={[Function]}
+  >
+    «
+  </button>
+  <button
+    aria-label="Goto Page 1"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    1
+  </button>
+  <button
+    aria-disabled={true}
+    aria-label="More Pages"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    ...
+  </button>
+  <button
+    aria-label="Goto Page 4"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    4
+  </button>
+  <button
+    aria-label="Goto Page 5"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    5
+  </button>
+  <button
+    aria-current="page"
+    aria-label="Goto Page 6"
+    className="paginationButtons active"
+    onClick={[Function]}
+  >
+    6
+  </button>
+  <button
+    aria-label="Goto Page 7"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    7
+  </button>
+  <button
+    aria-label="Goto Page 8"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    8
+  </button>
+  <button
+    aria-label="Goto Page 9"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    9
+  </button>
+  <button
+    aria-disabled={true}
+    aria-label="More Pages"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    ...
+  </button>
+  <button
+    aria-label="Goto Page 20"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    20
+  </button>
+  <button
+    aria-label="Goto Page 7"
+    className="paginationButtons"
+    disabled={false}
+    onClick={[Function]}
+  >
+    »
+  </button>
+</nav>
+`;
+
+exports[`Pagination Component rendering with start ellipsis 1`] = `
+<nav
+  aria-label="pagination"
+  className="pagination"
+>
+  <button
+    aria-label="Goto Page 14"
+    className="paginationButtons"
+    disabled={false}
+    onClick={[Function]}
+  >
+    «
+  </button>
+  <button
+    aria-label="Goto Page 1"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    1
+  </button>
+  <button
+    aria-disabled={true}
+    aria-label="More Pages"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    ...
+  </button>
+  <button
+    aria-label="Goto Page 13"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    13
+  </button>
+  <button
+    aria-label="Goto Page 14"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    14
+  </button>
+  <button
+    aria-current="page"
+    aria-label="Goto Page 15"
+    className="paginationButtons active"
+    onClick={[Function]}
+  >
+    15
+  </button>
+  <button
+    aria-label="Goto Page 16"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    16
+  </button>
+  <button
+    aria-label="Goto Page 17"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    17
+  </button>
+  <button
+    aria-label="Goto Page 18"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    18
+  </button>
+  <button
+    aria-label="Goto Page 19"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    19
+  </button>
+  <button
+    aria-label="Goto Page 20"
+    className="paginationButtons"
+    onClick={[Function]}
+  >
+    20
+  </button>
+  <button
+    aria-label="Goto Page 16"
+    className="paginationButtons"
+    disabled={false}
+    onClick={[Function]}
+  >
+    »
+  </button>
+</nav>
+`;

--- a/src/components/Grid/usePagination.js
+++ b/src/components/Grid/usePagination.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import styles from './Pagination.module.scss'
+import uuidv4 from 'uuid/v4'
+import { generatePagination, ELLIPSIS } from './PaginationHelper'
 
 /**
  * usePagination hook for getting paging number buttons
@@ -19,26 +21,42 @@ export const usePagination = ({ fetchPageCallback = null }) => {
    * @private
    *
    * @param {number} pageCount the number of pages
-   * @param {number}} currentPage the current page
+   * @param {number} currentPage the current page
+   * @param {number} displayedPagesCount number of pages to be displayed
    *
    * @returns JSX.Element
    */
-  const getPaginationNumbers = (pageCount, currentPage) => {
+  const getPaginationNumbers = (
+    pageCount,
+    currentPage,
+    displayedPagesCount
+  ) => {
     const pageNumbers = []
     const totalPages = pageCount
     let paginationNumbers
 
     if (totalPages) {
-      for (let i = 1; i <= totalPages; i++) {
-        pageNumbers.push(i)
-      }
+      pageNumbers.push(
+        ...generatePagination({ currentPage, pageCount, displayedPagesCount })
+      )
       paginationNumbers = pageNumbers.map((number) => {
         const isCurrentPage = currentPage === number
         const klasses = isCurrentPage
           ? `${styles.paginationButtons} ${styles.active}`
           : styles.paginationButtons
+        const isEllipsis = number === ELLIPSIS
 
-        return (
+        return isEllipsis ? (
+          <button
+            key={uuidv4()}
+            className={klasses}
+            onClick={() => {}}
+            aria-label={'More Pages'}
+            aria-disabled={true}
+          >
+            {number}
+          </button>
+        ) : (
           <button
             key={number}
             // eslint-disable-next-line
@@ -59,10 +77,15 @@ export const usePagination = ({ fetchPageCallback = null }) => {
    * @public
    *
    * @param {number} pageCount the number of pages
-   * @param {number}} currentPage the current page
+   * @param {number} currentPage the current page
+   * @param {number} displayedPagesCount number of pages to be displayed
    * @returns JSX.Element | null
    */
-  const conditionallyRenderPagingButtons = (pageCount, currentPage) => {
+  const conditionallyRenderPagingButtons = (
+    pageCount,
+    currentPage,
+    displayedPagesCount
+  ) => {
     const previousDisabled = currentPage === 1
     const nextDisabled = currentPage === pageCount
 
@@ -77,7 +100,7 @@ export const usePagination = ({ fetchPageCallback = null }) => {
           >
             &laquo;
           </button>
-          {getPaginationNumbers(pageCount, currentPage)}
+          {getPaginationNumbers(pageCount, currentPage, displayedPagesCount)}
           <button
             className={styles.paginationButtons}
             onClick={() => fetchPageCallback(currentPage + 1)}

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -499,10 +499,12 @@ export declare const Pagination: {
   ({
     currentPage,
     pageCount,
+    displayedPagesCount,
     fetchPageCallback,
   }: {
     currentPage: any
     pageCount: any
+    displayedPagesCount?: any
     /**
      * Ultimately, this returns the JSON.parse'd data
      */
@@ -511,6 +513,7 @@ export declare const Pagination: {
   propTypes: {
     currentPage: any
     pageCount: any
+    displayedPagesCount?: any
     /**
      * Ultimately, this returns the JSON.parse'd data
      */

--- a/src/components/index.tests.tsx
+++ b/src/components/index.tests.tsx
@@ -31,6 +31,7 @@ import { Tooltip } from './index'
 import { ValueProps } from './index'
 import { ZipInput } from './index'
 import { UniversalNavbar } from './index'
+import { Pagination } from './index'
 
 // Usage: `yarn test:types` -- see [package.json](../../package.json):
 
@@ -508,5 +509,34 @@ class Header extends React.Component<any, any> {
 class Tag extends React.Component<any, any> {
   render() {
     return <Tag type="approved">approved</Tag>
+  }
+}
+
+class PaginationTest extends React.Component<any, any> {
+  render() {
+    return (
+      <Pagination
+        currentPage={5}
+        pageCount={10}
+        fetchPageCallback={() => {
+          return {}
+        }}
+      />
+    )
+  }
+}
+
+class PaginationWithDisplayLimitTest extends React.Component<any, any> {
+  render() {
+    return (
+      <Pagination
+        currentPage={5}
+        pageCount={10}
+        displayedPagesCount={6}
+        fetchPageCallback={() => {
+          return {}
+        }}
+      />
+    )
   }
 }


### PR DESCRIPTION
**Description:**

- [Asana Task](https://app.asana.com/0/1150068311310825/1175073217963713/f)
- Adds start and end ellipsis based on current page, total pages and display limit

**Is this a new component? Please review these reminders: **
No

_Please pick one and delete options that are not relevant:_

- [x] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [x] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [x] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**

-

**Screenshots:**
![Screenshot 2020-05-13 at 10 53 53 PM](https://user-images.githubusercontent.com/63366004/81848034-205d0980-9572-11ea-9607-182ab0b42603.png)
