### PR TITLE
Ab/add aria label

### DIFF
--- a/src/components/EmailInput/__snapshots__/EmailInput.test.js.snap
+++ b/src/components/EmailInput/__snapshots__/EmailInput.test.js.snap
@@ -18,6 +18,7 @@ Array [
     }
   />,
   <input
+    aria-label="the-email-input-example"
     className="TextInput"
     data-tid="the-email-input"
     name="the-email-input-example"

--- a/src/components/PasswordInput/__snapshots__/PasswordInput.test.js.snap
+++ b/src/components/PasswordInput/__snapshots__/PasswordInput.test.js.snap
@@ -18,6 +18,7 @@ Array [
     }
   />,
   <input
+    aria-label="password-example"
     className="TextInput"
     data-tid="the-password-input"
     name="password-example"

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -111,6 +111,7 @@ function PrivateTextInput({
         onBlur={onBlur}
         value={value}
         data-tid={rest['data-tid']}
+        aria-label={name} // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
       />
       {getError(currentError, touched)}
     </>

--- a/src/components/TextInput/__snapshots__/TextInput.test.js.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.js.snap
@@ -18,6 +18,7 @@ Array [
     }
   />,
   <input
+    aria-label="nombre"
     className="TextInput"
     data-tid="the-text-input"
     name="nombre"


### PR DESCRIPTION
**Description:**

- [Asana Task](https://app.asana.com/0/1116481661798430/1172907631940805)
- Adds an `aria-label` to the `TextInput` which is a `critical` failing check on the Microsoft Accessibility audit

**Referencing PR or Branch (e.g. in CMS or monorepo):**

- https://github.com/getethos/ethos/pull/3393

