### PR TITLE
[Chore] updating uuid/v4 imports statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.208",
+  "version": "1.1.209",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",
@@ -57,7 +57,8 @@
     "react-popper": "^1.3.7",
     "react-select": "^3.0.8",
     "react-text-mask": "^5.4.3",
-    "text-mask-addons": "^3.8.0"
+    "text-mask-addons": "^3.8.0",
+    "uuid": "^8.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/src/components/ButtonSelectGroup/ButtonSelectGroup.js
+++ b/src/components/ButtonSelectGroup/ButtonSelectGroup.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 import useErrorMessage from '../../hooks/useErrorMessage.js'
 import { OptionButton } from './OptionButton'
 import { InputLabel } from '../InputLabel'

--- a/src/components/ButtonSelectGroup/ButtonSelectGroup.test.js
+++ b/src/components/ButtonSelectGroup/ButtonSelectGroup.test.js
@@ -3,9 +3,9 @@ import { OPTION_BUTTON_STYLES } from './OptionButton'
 import { ButtonSelectGroup } from './ButtonSelectGroup'
 import renderer from 'react-test-renderer'
 
-jest.mock('uuid/v4', () => {
-  return jest.fn(() => 1)
-})
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 1),
+}))
 
 describe('ButtonSelectGroup', () => {
   test('The ButtonSelectGroup renders (default button style, `buttonStyle` not passed)', () => {

--- a/src/components/ButtonSelectGroup/OptionButton.js
+++ b/src/components/ButtonSelectGroup/OptionButton.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 import { Button } from '../Button'
 
 export const OPTION_BUTTON_STYLES = {

--- a/src/components/Faq/Faq.js
+++ b/src/components/Faq/Faq.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 import { TitleLarge, TitleMedium, Body } from '../index'
 
 import styles from './Faq.module.scss'

--- a/src/components/Grid/Grid.md
+++ b/src/components/Grid/Grid.md
@@ -28,7 +28,7 @@ Nora application which utilizes this.
 
 ```jsx
 import React, { useState } from 'react'
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Grid } from './Grid.js'
 import { Row } from './Row.js'

--- a/src/components/Grid/Pagination.md
+++ b/src/components/Grid/Pagination.md
@@ -2,7 +2,7 @@ Used in tandem with the DataGrid component:
 
 ```jsx
 import React, { memo, useEffect, useState } from 'react'
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Grid } from '../Grid/Grid.js'
 import { Row } from '../Grid/Row.js'

--- a/src/components/Grid/usePagination.js
+++ b/src/components/Grid/usePagination.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styles from './Pagination.module.scss'
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 import { generatePagination, ELLIPSIS } from './PaginationHelper'
 
 /**

--- a/src/components/Images/Images.js
+++ b/src/components/Images/Images.js
@@ -4,7 +4,7 @@ import useRequired from '../../hooks/useRequired.js'
 import useInvalid from '../../hooks/useInvalid.js'
 
 import cloudinary from 'cloudinary-core'
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 // eslint-disable-next-line
 import lazysizes from 'lazysizes'
 

--- a/src/components/Popover/Options.js
+++ b/src/components/Popover/Options.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Option } from './Option'
 import styles from './Options.module.scss'
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 
 /**
  * @param {object} props -- the props

--- a/src/components/RadioButtons/RadioButtons.js
+++ b/src/components/RadioButtons/RadioButtons.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 
 import useErrorMessage from '../../hooks/useErrorMessage.js'
 import useIncludes from '../../hooks/useIncludes.js'

--- a/src/components/Stepper/Stepper.js
+++ b/src/components/Stepper/Stepper.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { COLORS, Caption2, Icon } from '../index'
 import PropTypes from 'prop-types'
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 import styles from './Stepper.module.scss'
 
 export const Stepper = ({ steps }) => {

--- a/src/components/UniversalNavbar/constants.js
+++ b/src/components/UniversalNavbar/constants.js
@@ -1,4 +1,4 @@
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 
 export const LINKS = {
   // These are used e.g. in the logo and CTA button:

--- a/src/components/ValueProps/ValueProps.js
+++ b/src/components/ValueProps/ValueProps.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 import { TitleSmall, Body, CloudinaryImage } from '../index'
 
 import styles from './ValueProps.module.scss'

--- a/yarn.lock
+++ b/yarn.lock
@@ -10409,6 +10409,11 @@ uuid@^3.0.1, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
+  integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
+
 v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"


### PR DESCRIPTION
**Description:**
The `uuid` package recently published a breaking change that changed the packages exports from a deep `export` to named `exports`. This PR explicitly pulls in `uuid` as a dependency, which prior to this change was being pulled in transitively, and updates the import statements to match the new `export` strategy.
 
**Is this a new component? Please review these reminders: **

_Please pick one and delete options that are not relevant:_

- [x] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [ ] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [x] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**

-

**Screenshots:**
