### PR TITLE
Remove border from NoraButton

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.211",
+  "version": "1.1.213",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/nora/components/NoraButton/NoraButton.module.scss
+++ b/src/nora/components/NoraButton/NoraButton.module.scss
@@ -10,6 +10,7 @@
   border-radius: var(--Radius-3);
   text-align: center;
   display: inline-block;
+  border: none;
 
   &[disabled] {
     opacity: 0.65;


### PR DESCRIPTION
**Description:**

- [Asana Task](https://app.asana.com/0/1150068311310825/1178718765502761/f)

All blue buttons in Nora have black outline:
<img width="149" alt="Screenshot 2020-06-05 at 11 57 26 AM" src="https://user-images.githubusercontent.com/1223778/83835589-c04a2500-a723-11ea-9a79-26f7cc7aec70.png">
<img width="610" alt="Screenshot 2020-06-05 at 11 56 58 AM" src="https://user-images.githubusercontent.com/1223778/83835591-c2ac7f00-a723-11ea-9b98-0505507551cb.png">


But none of the blue buttons have black border in Figma:
<img width="319" alt="Screenshot 2020-06-05 at 11 55 34 AM" src="https://user-images.githubusercontent.com/1223778/83835493-811bd400-a723-11ea-876b-45e3456b9e60.png">
<img width="414" alt="Screenshot 2020-06-05 at 11 55 12 AM" src="https://user-images.githubusercontent.com/1223778/83835497-837e2e00-a723-11ea-9ff7-7d59290157b4.png">


**Is this a new component? Please review these reminders: **

_Please pick one and delete options that are not relevant:_

- [x] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [ ] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [x] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**

-

**Screenshots:**
