### PR TITLE
Add `disabled` prop to DateInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.214",
+  "version": "1.1.215",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/DateInput/DateInput.js
+++ b/src/components/DateInput/DateInput.js
@@ -25,6 +25,7 @@ const PrivateDateInput = (props) => {
     currentError,
     formTouched,
     setFieldTouched,
+    disabled,
     ...restProps
   } = props
 
@@ -105,6 +106,7 @@ const PrivateDateInput = (props) => {
         setFieldTouched={setFieldTouched}
         getTouched={touched}
         setTouched={setTouched}
+        disabled={disabled}
       />
       {getError(currentError, touched)}
     </>


### PR DESCRIPTION
**Description:**

- [Asana Task](https://app.asana.com/0/1135109139115239/1179984035109347)
- Date input wasn't passing `disabled` prop through, so you couldn't disabled it.


**Is this a new component? Please review these reminders: **

_Please pick one and delete options that are not relevant:_

- [ ] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [ ] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [ ] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**
-
https://github.com/getethos/ethos/pull/3891

**Screenshots:**
-
**Before**
<img width="1058" alt="Screen Shot 2020-07-01 at 11 22 37 AM" src="https://user-images.githubusercontent.com/11511539/86279641-3610a780-bb8f-11ea-8532-099003295d33.png">

**After**
<img width="1016" alt="Screen Shot 2020-07-01 at 11 22 20 AM" src="https://user-images.githubusercontent.com/11511539/86279691-4759b400-bb8f-11ea-95e6-7f38c98df4cc.png">
