### PR TITLE
Add data-tid for button select group options

### DIFF
--- a/src/components/ButtonSelectGroup/OptionButton.js
+++ b/src/components/ButtonSelectGroup/OptionButton.js
@@ -25,12 +25,14 @@ export const OptionButton = ({
   isSelected,
   onClick,
   buttonStyle,
+  'data-tid': dataTid,
 }) => {
   const props = {
     ariaLabelId: `selection-option-${uuidv4()}`,
     role: 'radio',
     onClick: onClick,
     isSelected: isSelected,
+    'data-tid': dataTid,
   }
 
   switch (buttonStyle) {
@@ -60,4 +62,5 @@ OptionButton.propTypes = {
   isSelected: PropTypes.bool,
   /** An optional onClick handler that fires **after** an option has been selected */
   onClick: PropTypes.func,
+  'data-tid': PropTypes.string,
 }


### PR DESCRIPTION
**Description:**
- Adds data-tid for button select group options. Helpful for E2E testing
-

**Is this a new component? Please review these reminders: **

_Please pick one and delete options that are not relevant:_

- [ ] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [ ] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [ ] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**

-

**Screenshots:**
