### PR TITLE
change padding for all screen sizes to 16px for full width arrow icon button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.235",
+  "version": "1.1.236",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -59,14 +59,8 @@
 }
 
 .Button.arrowIcon.fullWidth {
-  @include for-tablet-and-laptop {
-    padding-right: 40px;
-    padding-left: 40px;
-  }
-  @include for-desktop-only {
-    padding-right: 48px;
-    padding-left: 48px;
-  }
+  padding-right: var(--Space-16);
+  padding-left: var(--Space-16);
 }
 
 /* Styles */

--- a/src/components/fa.js
+++ b/src/components/fa.js
@@ -68,7 +68,7 @@ import { faMoneyCheckEditAlt } from '@fortawesome/pro-regular-svg-icons/faMoneyC
 import { faHashtag } from '@fortawesome/pro-regular-svg-icons/faHashtag'
 import { faSignOut } from '@fortawesome/pro-regular-svg-icons/faSignOut'
 import { faSyncAlt } from '@fortawesome/pro-regular-svg-icons/faSyncAlt'
-import { faBell } from '@fortawesome/pro-regular-svg-icons/faBell';
+import { faBell } from '@fortawesome/pro-regular-svg-icons/faBell'
 
 library.add(
   faHamburger,


### PR DESCRIPTION
**Description:**

- [Asana Task](https://app.asana.com/0/1116481661798430/1198986488532933)
- change padding for all screen sizes to 16px for full width arrow icon button


**Is this a new component? Please review these reminders: **

_Please pick one and delete options that are not relevant:_

- [x] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [x] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [x] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**

-

**Screenshots:**
<img width="679" alt="Screen Shot 2020-11-19 at 9 00 33 PM" src="https://user-images.githubusercontent.com/7144337/99761411-e59cd680-2aaa-11eb-8647-a64fff46b8bf.png">
