### PR TITLE
Add autoComplete attribute to input fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.236",
+  "version": "1.1.237",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/BirthdateInput/BirthdateInput.js
+++ b/src/components/BirthdateInput/BirthdateInput.js
@@ -18,6 +18,7 @@ export const BirthdateInput = (props) => {
     currentError,
     formTouched,
     setFieldTouched,
+    autoComplete,
     ...restProps
   } = props
 
@@ -35,6 +36,7 @@ export const BirthdateInput = (props) => {
       currentError={currentError}
       formTouched={formTouched}
       setFieldTouched={setFieldTouched}
+      autoComplete={autoComplete}
       {...restProps}
     />
   )
@@ -71,6 +73,8 @@ BirthdateInput.propTypes = {
   currentError: PropTypes.string,
   /** formChangeHandler is a low level prop used only by the form engine */
   formChangeHandler: PropTypes.func,
+  /** autoComplete value for auto fill */
+  autoComplete: PropTypes.string,
 }
 
 export const BirthdateInputValidators = Validators

--- a/src/components/BirthdateInput/BirthdateInput.test.js
+++ b/src/components/BirthdateInput/BirthdateInput.test.js
@@ -18,6 +18,7 @@ describe('BirthdateInput', () => {
           name="birthDate"
           minAge={20}
           maxAge={65}
+          autoComplete="bday"
         />
       )
       .toJSON()

--- a/src/components/BirthdateInput/__snapshots__/BirthdateInput.test.js.snap
+++ b/src/components/BirthdateInput/__snapshots__/BirthdateInput.test.js.snap
@@ -18,6 +18,7 @@ Array [
     }
   />,
   <input
+    autoComplete="bday"
     className="TextMaskedInput TextInput"
     data-tid="le-birthdate"
     disabled={false}

--- a/src/components/DateInput/DateInput.js
+++ b/src/components/DateInput/DateInput.js
@@ -32,6 +32,7 @@ const PrivateDateInput = (props) => {
     name = 'birthdate-auto-corrected',
     pipe = createAutoCorrectedDatePipe(dateFormat),
     mask = dateMaskByFormat[dateFormat],
+    autoComplete,
     ...restProps
   } = props
 
@@ -113,6 +114,7 @@ const PrivateDateInput = (props) => {
         getTouched={touched}
         setTouched={setTouched}
         disabled={disabled}
+        autoComplete={autoComplete}
       />
       {getError(currentError, touched)}
     </>
@@ -133,6 +135,7 @@ PrivateDateInput.PUBLIC_PROPS = {
   initialValue: PropTypes.string,
   guide: PropTypes.bool,
   keepCharPositions: PropTypes.bool,
+  autoComplete: PropTypes.string,
 }
 
 PrivateDateInput.propTypes = {

--- a/src/components/DateInput/DateInput.test.js
+++ b/src/components/DateInput/DateInput.test.js
@@ -15,6 +15,7 @@ describe('DateInput', () => {
           data-tid="when-applied-for"
           validator={() => {}}
           name="whenapplied"
+          autoComplete="date"
         />
       )
       .toJSON()

--- a/src/components/DateInput/__snapshots__/DateInput.test.js.snap
+++ b/src/components/DateInput/__snapshots__/DateInput.test.js.snap
@@ -18,6 +18,7 @@ Array [
     }
   />,
   <input
+    autoComplete="date"
     className="TextMaskedInput TextInput"
     data-tid="when-applied-for"
     disabled={false}

--- a/src/components/EmailInput/EmailInput.js
+++ b/src/components/EmailInput/EmailInput.js
@@ -13,6 +13,7 @@ export const EmailInput = (props) => {
     initialValue,
     placeholder,
     disabled,
+    autoComplete,
     ...restProps
   } = props
 
@@ -32,6 +33,7 @@ export const EmailInput = (props) => {
         disabled={disabled}
         placeholder={placeholder}
         validator={EmailFormatValidator}
+        autoComplete={autoComplete}
         {...restProps}
       />
     </>
@@ -50,6 +52,7 @@ EmailInput.propTypes = {
   labelCopy: PropTypes.string,
   validator: PropTypes.func,
   initialValue: PropTypes.string,
+  autoComplete: PropTypes.string,
 }
 
 EmailInput.defaultProps = {

--- a/src/components/EmailInput/EmailInput.test.js
+++ b/src/components/EmailInput/EmailInput.test.js
@@ -12,6 +12,7 @@ describe('EmailInput', () => {
           labelCopy="Your email"
           data-tid="the-email-input"
           placeholder="example@ethoslife.com"
+          autoComplete="email"
         />
       )
       .toJSON()

--- a/src/components/EmailInput/__snapshots__/EmailInput.test.js.snap
+++ b/src/components/EmailInput/__snapshots__/EmailInput.test.js.snap
@@ -19,6 +19,7 @@ Array [
   />,
   <input
     aria-label="the-email-input-example"
+    autoComplete="email"
     className="TextInput"
     data-tid="the-email-input"
     name="the-email-input-example"

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -31,6 +31,7 @@ export const NumberInput = (props) => {
     placeholderChar,
     guide = true,
     keepCharPositions = true,
+    autoComplete,
     ...restProps
   } = props
 
@@ -57,6 +58,7 @@ export const NumberInput = (props) => {
         placeholderChar={placeholderChar}
         guide={guide}
         keepCharPositions={keepCharPositions}
+        autoComplete={autoComplete}
       />
     </>
   )
@@ -82,6 +84,7 @@ NumberInput.propTypes = {
   placeholderChar: PropTypes.string,
   guide: PropTypes.bool,
   keepCharPositions: PropTypes.bool,
+  autoComplete: PropTypes.string,
 }
 
 NumberInput.defaultProps = {

--- a/src/components/NumberInput/NumberInput.test.js
+++ b/src/components/NumberInput/NumberInput.test.js
@@ -23,6 +23,7 @@ describe('NumberInput', () => {
           validator={(n) => {
             return n % 2 === 0 ? '' : 'Must be an even number'
           }}
+          autoComplete="tel"
         />
       )
       .toJSON()

--- a/src/components/NumberInput/__snapshots__/NumberInput.test.js.snap
+++ b/src/components/NumberInput/__snapshots__/NumberInput.test.js.snap
@@ -18,6 +18,7 @@ Array [
     }
   />,
   <input
+    autoComplete="tel"
     className="TextMaskedInput TextInput"
     data-tid="the-number-input"
     disabled={false}

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -16,6 +16,7 @@ import errorStyles from '../Errors.module.scss'
  * @param  {Boolean}  props.allCaps     Whether to text-trasform: uppercase
  * @param  {Function} props.validator   Function for validating input
  * @param  {Boolean}  props.disabled
+ * @param  {String}   props.autoComplete  Autocomplete label
  */
 
 function PrivateTextInput({
@@ -32,6 +33,7 @@ function PrivateTextInput({
   currentError,
   setFieldTouched,
   restrictIllegal,
+  autoComplete,
   ...rest
 }) {
   // Verify that all required props were supplied
@@ -121,6 +123,7 @@ function PrivateTextInput({
         value={value}
         data-tid={rest['data-tid']}
         aria-label={name} // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
+        autoComplete={autoComplete}
       />
       {getError(currentError, touched)}
     </>
@@ -142,6 +145,7 @@ PrivateTextInput.PUBLIC_PROPS = {
   onBlur: PropTypes.func,
   onFocus: PropTypes.func,
   restrictIllegal: PropTypes.bool,
+  autoComplete: PropTypes.string,
 }
 
 PrivateTextInput.propTypes = {

--- a/src/components/TextInput/TextInput.test.js
+++ b/src/components/TextInput/TextInput.test.js
@@ -16,6 +16,7 @@ describe('TextInput', () => {
               ? 'Text does not have an even number of characters'
               : ''
           }
+          autoComplete="name"
         />
       )
       .toJSON()

--- a/src/components/TextInput/__snapshots__/TextInput.test.js.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.js.snap
@@ -19,6 +19,7 @@ Array [
   />,
   <input
     aria-label="nombre"
+    autoComplete="name"
     className="TextInput"
     data-tid="the-text-input"
     name="nombre"

--- a/src/components/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/TextMaskedInput/TextMaskedInput.js
@@ -27,6 +27,7 @@ export const TextMaskedInput = (props) => {
     setFieldTouched,
     doValidation,
     placeholderChar,
+    autoComplete,
     ...restProps
   } = props
 
@@ -102,6 +103,7 @@ export const TextMaskedInput = (props) => {
           className={getClasses()}
           disabled={restProps.disabled}
           placeholderChar={placeholderChar}
+          autoComplete={autoComplete}
         />
       )
     } else {
@@ -121,6 +123,7 @@ export const TextMaskedInput = (props) => {
           keepCharPositions={restProps.keepCharPositions}
           pipe={restProps.pipe}
           placeholderChar={placeholderChar}
+          autoComplete={autoComplete}
         />
       )
     }
@@ -160,6 +163,7 @@ TextMaskedInput.PUBLIC_PROPS = {
   setTouched: PropTypes.func,
   getTouched: PropTypes.bool,
   placeholderChar: PropTypes.string,
+  autoComplete: PropTypes.string,
 }
 
 TextMaskedInput.propTypes = {

--- a/src/components/ZipInput/ZipInput.js
+++ b/src/components/ZipInput/ZipInput.js
@@ -21,6 +21,7 @@ export const ZipInput = (props) => {
     formTouched,
     guide = true,
     keepCharPositions = true,
+    autoComplete,
     ...restProps
   } = props
 
@@ -87,6 +88,7 @@ export const ZipInput = (props) => {
         setFieldTouched={restProps.setFieldTouched}
         getTouched={touched}
         setTouched={setTouched}
+        autoComplete={autoComplete}
       />
       {getError(currentError, touched)}
     </>
@@ -105,6 +107,7 @@ ZipInput.PUBLIC_PROPS = {
   initialValue: PropTypes.string,
   guide: PropTypes.bool,
   keepCharPositions: PropTypes.bool,
+  autoComplete: PropTypes.string,
 }
 
 ZipInput.propTypes = {

--- a/src/components/ZipInput/ZipInput.test.js
+++ b/src/components/ZipInput/ZipInput.test.js
@@ -16,6 +16,7 @@ describe('ZipInput', () => {
           labelCopy="What is your zip code?"
           data-tid="le-zip"
           validator={() => {}}
+          autoComplete="postal-code"
         />
       )
       .toJSON()

--- a/src/components/ZipInput/__snapshots__/ZipInput.test.js.snap
+++ b/src/components/ZipInput/__snapshots__/ZipInput.test.js.snap
@@ -18,6 +18,7 @@ Array [
     }
   />,
   <input
+    autoComplete="postal-code"
     className="TextMaskedInput TextInput"
     data-tid="le-zip"
     disabled={false}


### PR DESCRIPTION
**Description:**

- [Asana Task](https://app.asana.com/0/1116481661798430/1199675528419605)
- Add autoComplete attribute to various fields

**Is this a new component? Please review these reminders: **

_Please pick one and delete options that are not relevant:_

- [x] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [ ] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [x] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**

-

**Screenshots:**
