### PR TITLE
Add timeout to onBlur for MaskedInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.236",
+  "version": "1.1.237",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/TextMaskedInput/TextMaskedInput.js
@@ -96,7 +96,7 @@ export const TextMaskedInput = (props) => {
           type={restProps.type}
           data-tid={restProps['data-tid']}
           onChange={onChange}
-          onBlur={onBlur}
+          onBlur={() => setTimeout(onBlur, 100)}
           name={props.name}
           placeholder={restProps.placeholder}
           className={getClasses()}
@@ -113,7 +113,7 @@ export const TextMaskedInput = (props) => {
           data-tid={restProps['data-tid']}
           guide={restProps.guide}
           onChange={onChange}
-          onBlur={onBlur}
+          onBlur={() => setTimeout(onBlur, 100)}
           name={props.name}
           placeholder={restProps.placeholder}
           className={getClasses()}

--- a/src/components/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/TextMaskedInput/TextMaskedInput.js
@@ -73,12 +73,15 @@ export const TextMaskedInput = (props) => {
   }, [])
 
   const onBlur = (ev) => {
-    // We set touched to change the react state, but it's async and
-    // processing still, so, we use a flag for doValidation
-    setAllTouched()
-    const val = ev.target.value
-    const cleansed = cleanse(val)
-    whichDoValidation(cleansed, true)
+    ev.persist()
+    setTimeout(() => {
+      // We set touched to change the react state, but it's async and
+      // processing still, so, we use a flag for doValidation
+      setAllTouched()
+      const val = ev.target.value
+      const cleansed = cleanse(val)
+      whichDoValidation(cleansed, true)
+    }, 100)
   }
 
   const getClasses = () => {
@@ -96,12 +99,13 @@ export const TextMaskedInput = (props) => {
           type={restProps.type}
           data-tid={restProps['data-tid']}
           onChange={onChange}
-          onBlur={() => setTimeout(onBlur, 100)}
+          onBlur={onBlur}
           name={props.name}
           placeholder={restProps.placeholder}
           className={getClasses()}
           disabled={restProps.disabled}
           placeholderChar={placeholderChar}
+          autoComplete={autoComplete}
         />
       )
     } else {
@@ -113,7 +117,7 @@ export const TextMaskedInput = (props) => {
           data-tid={restProps['data-tid']}
           guide={restProps.guide}
           onChange={onChange}
-          onBlur={() => setTimeout(onBlur, 100)}
+          onBlur={onBlur}
           name={props.name}
           placeholder={restProps.placeholder}
           className={getClasses()}
@@ -121,6 +125,7 @@ export const TextMaskedInput = (props) => {
           keepCharPositions={restProps.keepCharPositions}
           pipe={restProps.pipe}
           placeholderChar={placeholderChar}
+          autoComplete={autoComplete}
         />
       )
     }

--- a/src/components/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/TextMaskedInput/TextMaskedInput.js
@@ -105,7 +105,6 @@ export const TextMaskedInput = (props) => {
           className={getClasses()}
           disabled={restProps.disabled}
           placeholderChar={placeholderChar}
-          autoComplete={autoComplete}
         />
       )
     } else {
@@ -125,7 +124,6 @@ export const TextMaskedInput = (props) => {
           keepCharPositions={restProps.keepCharPositions}
           pipe={restProps.pipe}
           placeholderChar={placeholderChar}
-          autoComplete={autoComplete}
         />
       )
     }


### PR DESCRIPTION
**Description:**
-
- Fixing a bug found in this PR: https://github.com/getethos/ethos/pull/6885
- The `onBlur` validator was jacking the `onClick` event making it so you had to click a button twice after the validation in order to register a click.
- This solution fires the `onBlur` event after a timeout, which allows the `onClick` to register and then the `onBlur` to occur afterwards.

**Notes**
----

- [x] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [x] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [x] Bumped the yarn version?


**Screenshots:**
----

**Previous version**
![old](https://user-images.githubusercontent.com/11511539/108276405-9f4c2780-712c-11eb-9ccb-eaa7c876ebb7.gif)

**Updated version**
![new](https://user-images.githubusercontent.com/11511539/108276402-9e1afa80-712c-11eb-97fb-45773b08c89d.gif)


**Updated - validation still occurs**
![validation-still-occurs-2](https://user-images.githubusercontent.com/11511539/108276386-9a877380-712c-11eb-8068-87f8db928f7d.gif)
**Updated - validation still occurs**
![validation-still-occurs](https://user-images.githubusercontent.com/11511539/108276396-9ce9cd80-712c-11eb-9209-ffc2c03a6c17.gif)