### PR TITLE
Add rows to textarea

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.238",
+  "version": "1.1.239",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/TextAreaInput/BaseTextAreaInput.js
+++ b/src/components/TextAreaInput/BaseTextAreaInput.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types'
  * Required props:
  * @param {string} name
  * @param {string} 'data-tid'
+ * @param {number} rows the native text area rows attribute (https://www.w3schools.com/tags/att_textarea_rows.asp)
  */
 
 export const BaseTextAreaInput = ({
@@ -19,6 +20,7 @@ export const BaseTextAreaInput = ({
   onFocus,
   onChange,
   value,
+  rows,
   ...rest
 }) => {
   return (
@@ -32,6 +34,7 @@ export const BaseTextAreaInput = ({
       onBlur={onBlur}
       onFocus={onFocus}
       value={value}
+      rows={rows}
       data-tid={rest['data-tid']}
     />
   )
@@ -41,6 +44,7 @@ BaseTextAreaInput.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   name: PropTypes.string.isRequired,
+  rows: PropTypes.number,
   placeholder: PropTypes.string,
   onPaste: PropTypes.func,
   onBlur: PropTypes.func,

--- a/src/components/TextAreaInput/TextAreaInput.js
+++ b/src/components/TextAreaInput/TextAreaInput.js
@@ -26,6 +26,7 @@ function PrivateTextAreaInput({
   currentError,
   setFieldTouched,
   restrictIllegal,
+  rows,
   ...rest
 }) {
   // Verify that all required props were supplied
@@ -93,6 +94,7 @@ function PrivateTextAreaInput({
   if (getError(currentError, touched)) {
     classes.push(errorStyles.Error)
   }
+
   if (resize) {
     classes.push(styles.Resize)
   }
@@ -114,6 +116,7 @@ function PrivateTextAreaInput({
         onBlur={onBlur}
         value={value}
         data-tid={rest['data-tid']}
+        rows={rows}
       />
       {getError(currentError, touched)}
     </>
@@ -126,6 +129,7 @@ PrivateTextAreaInput.PUBLIC_PROPS = {
   disabled: PropTypes.bool,
   name: PropTypes.string.isRequired,
   allCaps: PropTypes.bool,
+  rows: PropTypes.number,
   /** text transform capitalize label */
   capitalize: PropTypes.bool,
   formChangeHandler: PropTypes.func,


### PR DESCRIPTION
**Description:**

- Adds the `rows` property which is native HTML to the textarea component to allow changing the height of the component

**Is this a new component? Please review these reminders: **

- [x] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**

- https://github.com/getethos/ethos/pull/6953

![image](https://user-images.githubusercontent.com/11672466/108783081-c6df2d80-753a-11eb-91af-ed4a059bbc4d.png)
