### PR TITLE
remove extra chevron from summary tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.243",
+  "version": "1.1.244",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Faq/Faq.module.scss
+++ b/src/components/Faq/Faq.module.scss
@@ -30,9 +30,7 @@
   }
   summary {
     outline: none;
-  }
-  summary::-webkit-details-marker {
-    display: none;
+    list-style: none;
   }
 
   details[open] {


### PR DESCRIPTION
**Description:**
Removing the extra default chevron within the `<summary>` tag

- [Asana Task] 
- https://app.asana.com/0/1200303476344966/1200235184322292/f

**Is this a new component? Please review these reminders: **
No

**Screenshots:**
Before:
![image](https://user-images.githubusercontent.com/84357906/120713903-288f2c00-c488-11eb-97a8-93dec87db813.png)
After:
![Screen Shot 2021-06-03 at 4 00 17 PM](https://user-images.githubusercontent.com/84357906/120713850-19a87980-c488-11eb-86b4-1d6d16faab3e.png)
