### PR TITLE
Adjust universal navbar width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.244",
+  "version": "1.1.245",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/UniversalNavbar/UniversalNavbar.module.scss
+++ b/src/components/UniversalNavbar/UniversalNavbar.module.scss
@@ -53,7 +53,7 @@ $tablet-small-end: 670px;
 }
 
 .tabletAndUpContainer {
-  max-width: 1440px;
+  max-width: 1376px;
   margin: 0 auto;
   padding: var(--Space-24);
   height: var(--Space-64);

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.module.scss
@@ -25,7 +25,7 @@ $laptop-range-small-end: 929px;
 }
 
 .laptopAndUpContainer {
-  max-width: 1440px;
+  max-width: 1376px;
   margin: 0 auto;
   padding: var(--Space-24);
   height: var(--Space-64);


### PR DESCRIPTION
**Description:**
- Reduces width of navbar on desktop viewports to match container width of modules on CMS.
- [Deploy preview](https://deploy-preview-4418--ethos-cms.netlify.app/)
- [Asana Task](https://app.asana.com/0/1200303476344966/1200517990013519/f)
- [Related CMS PR](https://github.com/getethos/cms/pull/4418)
- [Figma](https://www.figma.com/file/ZPTR8VwjUphHpOTD9njzxS/Homepage-markup?node-id=0%3A1)

Reduces UniversalNavbarExpanded and UniversalNavbar components width. 

**Screenshots:**
<img width="1429" alt="Screen Shot 2021-07-26 at 4 37 54 PM" src="https://user-images.githubusercontent.com/87672141/127072728-01380ae4-f767-43c1-b7a5-bba4ab95f14d.png">
