### PR TITLE
CtaButton copy parameter in UniversalNavbarExpanded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.245",
+  "version": "1.1.246",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/UniversalNavbarExpanded/CtaButton.js
+++ b/src/components/UniversalNavbarExpanded/CtaButton.js
@@ -15,10 +15,11 @@ import styles from './CtaButton.module.scss'
  * @param {string} href - URL for the button to link to
  * @param {function} trackingFunction - Analytics function run when CTA Button is clicked
  * @param {boolean} hideOnMobile - Hide the CTA on phone only
+ * @param {string} copy - Copy text for the button
  *
  * @return {JSX.Element}
  */
-const CtaButton = ({ href, trackingFunction, hideOnMobile }) => {
+const CtaButton = ({ href, trackingFunction, hideOnMobile, copy }) => {
   // We still rely on some legacy UniversalNavbar styles from FancyAnimatedLogo.scss
   // TODO convert these to module.scss capable styles
   const CtaButtonClasses = [
@@ -37,7 +38,7 @@ const CtaButton = ({ href, trackingFunction, hideOnMobile }) => {
       onClick={trackingFunction}
       href={href}
     >
-      <Button.Small.Black>Check my price</Button.Small.Black>
+      <Button.Small.Black>{copy}</Button.Small.Black>
     </a>
   )
 }
@@ -46,6 +47,7 @@ CtaButton.propTypes = {
   href: PropTypes.string.isRequired,
   trackingFunction: PropTypes.func.isRequired,
   hideOnMobile: PropTypes.bool,
+  copy: PropTypes.string.isRequired,
 }
 
 export default CtaButton

--- a/src/components/UniversalNavbarExpanded/CtaButton.js
+++ b/src/components/UniversalNavbarExpanded/CtaButton.js
@@ -15,11 +15,11 @@ import styles from './CtaButton.module.scss'
  * @param {string} href - URL for the button to link to
  * @param {function} trackingFunction - Analytics function run when CTA Button is clicked
  * @param {boolean} hideOnMobile - Hide the CTA on phone only
- * @param {string} copy - Copy text for the button
+ * @param {string} title - Title text for the button
  *
  * @return {JSX.Element}
  */
-const CtaButton = ({ href, trackingFunction, hideOnMobile, copy }) => {
+const CtaButton = ({ href, trackingFunction, hideOnMobile, title }) => {
   // We still rely on some legacy UniversalNavbar styles from FancyAnimatedLogo.scss
   // TODO convert these to module.scss capable styles
   const CtaButtonClasses = [
@@ -38,7 +38,7 @@ const CtaButton = ({ href, trackingFunction, hideOnMobile, copy }) => {
       onClick={trackingFunction}
       href={href}
     >
-      <Button.Small.Black>{copy}</Button.Small.Black>
+      <Button.Small.Black>{title}</Button.Small.Black>
     </a>
   )
 }
@@ -47,7 +47,7 @@ CtaButton.propTypes = {
   href: PropTypes.string.isRequired,
   trackingFunction: PropTypes.func.isRequired,
   hideOnMobile: PropTypes.bool,
-  copy: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
 }
 
 export default CtaButton

--- a/src/components/UniversalNavbarExpanded/MobileNav/MobileNav.js
+++ b/src/components/UniversalNavbarExpanded/MobileNav/MobileNav.js
@@ -153,6 +153,7 @@ const MobileNav = ({
           href={links.CTA.href}
           trackingFunction={ctaButtonTrackingFunction}
           hideOnMobile={hideMobileCta}
+          copy={links.CTA.title}
         />
       </div>
     </>

--- a/src/components/UniversalNavbarExpanded/MobileNav/MobileNav.js
+++ b/src/components/UniversalNavbarExpanded/MobileNav/MobileNav.js
@@ -153,7 +153,7 @@ const MobileNav = ({
           href={links.CTA.href}
           trackingFunction={ctaButtonTrackingFunction}
           hideOnMobile={hideMobileCta}
-          copy={links.CTA.title}
+          title={links.CTA.title}
         />
       </div>
     </>

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -104,6 +104,7 @@ const UniversalNavbarExpanded = ({
                     <CtaButton
                       href={links.CTA.href}
                       trackingFunction={trackCtaClick}
+                      copy={links.CTA.title}
                     />
                   )}
                 </div>

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -104,7 +104,7 @@ const UniversalNavbarExpanded = ({
                     <CtaButton
                       href={links.CTA.href}
                       trackingFunction={trackCtaClick}
-                      copy={links.CTA.title}
+                      title={links.CTA.title}
                     />
                   )}
                 </div>

--- a/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
+++ b/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
@@ -427,8 +427,8 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
               className="cta"
             >
               <CtaButton
-                copy="Check my price"
                 href="/term"
+                title="Check my price"
                 trackingFunction={[Function]}
               />
             </div>
@@ -868,8 +868,8 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
               className="cta"
             >
               <CtaButton
-                copy="Check my price"
                 href="/term"
+                title="Check my price"
                 trackingFunction={[Function]}
               />
             </div>

--- a/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
+++ b/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
@@ -427,6 +427,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
               className="cta"
             >
               <CtaButton
+                copy="Check my price"
                 href="/term"
                 trackingFunction={[Function]}
               />
@@ -867,6 +868,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
               className="cta"
             >
               <CtaButton
+                copy="Check my price"
                 href="/term"
                 trackingFunction={[Function]}
               />


### PR DESCRIPTION
**Description:**
- As part of the changes for agent landing pages in the CMS, we required an alternate CTA button title for the `UniversalNavbarExpanded`. 
- This PR removes the hardcoded "Check my price" value from the `CtaButton` and replaces it with the value of the `links.CTA.title` that is passed into the `UniversalNavbarExpanded` component.

**Referencing PR or Branch (e.g. in CMS or monorepo):**
- https://github.com/getethos/cms/pull/4476

**Screenshots:**
Using this new branch in the CMS to test. "Get started"
<img width="1634" alt="Screen Shot 2021-08-12 at 8 43 45 AM" src="https://user-images.githubusercontent.com/87672141/129226855-b8f519e3-0cc5-4d10-9f17-d5108e0bbd38.png">

Styleguide running locally. "Check my price"
<img width="1621" alt="Screen Shot 2021-08-12 at 8 43 36 AM" src="https://user-images.githubusercontent.com/87672141/129226868-9dc34215-2a50-4cc4-a229-71169e03e8b3.png">
