### PR TITLE
button select group supports currentValue being set post inital-render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .vscode/
 .nova/
+.idea
 
 node_modules
 yarn-error.log

--- a/src/components/ButtonSelectGroup/ButtonSelectGroup.js
+++ b/src/components/ButtonSelectGroup/ButtonSelectGroup.js
@@ -6,6 +6,7 @@ import { OptionButton } from './OptionButton'
 import { InputLabel } from '../InputLabel'
 
 import styles from './ButtonGroup.module.scss'
+import isUndefined from 'lodash/isUndefined'
 
 /**
  **/
@@ -65,6 +66,9 @@ export const ButtonSelectGroup = ({
   const [isAnswered, setIsAnswered] = useState(false)
   // Set up validation hooks
   const [getError, setError, , validate] = useErrorMessage(validator)
+  if (!isUndefined(currentValue) && selectedValue !== currentValue) {
+    setSelectedValue(currentValue)
+  }
 
   useEffect(() => {
     // `isSelectedValue` allows `false` to work properly and validate

--- a/src/components/ButtonSelectGroup/ButtonSelectGroup.md
+++ b/src/components/ButtonSelectGroup/ButtonSelectGroup.md
@@ -137,3 +137,4 @@ import { OPTION_BUTTON_STYLES } from './index.js'
   </ButtonSelectGroup.Option>
 </ButtonSelectGroup>
 ```
+

--- a/src/components/ButtonSelectGroup/ButtonSelectGroup.test.js
+++ b/src/components/ButtonSelectGroup/ButtonSelectGroup.test.js
@@ -126,6 +126,36 @@ describe('ButtonSelectGroup', () => {
     })
   })
 
+  test('The ButtonSelectGroup renders with currentValue set and changed', () => {
+    const tree = renderer
+      .create(
+      <ButtonSelectGroup labelCopy="options" currentValue="first">
+        <ButtonSelectGroup.Option value="first">foo</ButtonSelectGroup.Option>
+        <ButtonSelectGroup.Option value="last">bar</ButtonSelectGroup.Option>
+      </ButtonSelectGroup>
+    )
+
+    // Grab the group
+    let group = tree.root
+    let options = group.findAllByType(ButtonSelectGroup.Option)
+    let [first, last] = options
+    expect(first.props.isSelected).toBe(true)
+    expect(last.props.isSelected).toBe(false)
+
+    tree.update(
+      <ButtonSelectGroup labelCopy="options" currentValue="last">
+        <ButtonSelectGroup.Option value="first">foo</ButtonSelectGroup.Option>
+        <ButtonSelectGroup.Option value="last">bar</ButtonSelectGroup.Option>
+      </ButtonSelectGroup>
+    )
+
+    group = tree.root
+    options = group.findAllByType(ButtonSelectGroup.Option)
+    ;[first, last] = options
+    expect(first.props.isSelected).toBe(false)
+    expect(last.props.isSelected).toBe(true)
+  })
+
   test('When a click handler is passed to an option, it fires', () => {
     const onSelectStub = jest.fn()
     const onClickStub = jest.fn()


### PR DESCRIPTION
**Description:**

- [Asana Task]()
-

**Is this a new component? Please review these reminders: **

_Please pick one and delete options that are not relevant:_

- [ ] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [ ] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [ ] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**

-

**Screenshots:**
