### PR TITLE
Zip Input Disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.1.247",
+  "version": "1.1.248",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/ZipInput/ZipInput.js
+++ b/src/components/ZipInput/ZipInput.js
@@ -22,6 +22,7 @@ export const ZipInput = (props) => {
     guide = true,
     keepCharPositions = true,
     autoComplete,
+    disabled = false,
     ...restProps
   } = props
 
@@ -89,6 +90,7 @@ export const ZipInput = (props) => {
         getTouched={touched}
         setTouched={setTouched}
         autoComplete={autoComplete}
+        disabled={disabled}
       />
       {getError(currentError, touched)}
     </>


### PR DESCRIPTION
**Description:**
- Missing `disabled` prop for zip input
-

**Is this a new component? Please review these reminders: **

_Please pick one and delete options that are not relevant:_

- [ ] Have you read the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [ ] Have exported the component from the main [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Have you exported it from the [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Followed the checklist at the bottom of the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute) guide?
- [ ] Bumped the yarn version?

**Referencing PR or Branch (e.g. in CMS or monorepo):**

-

**Screenshots:**
