### PR TITLE
UniversalNavbarExpanded - hide icons and alternate cta icon options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/UniversalNavbarExpanded/DropdownNav/DropdownChildren.js
+++ b/src/components/UniversalNavbarExpanded/DropdownNav/DropdownChildren.js
@@ -65,6 +65,11 @@ const DropdownChildren = ({ containerClasses, child, LinkComponent }) => {
                   <DropdownCta
                     title={get(child, 'subnav.cta.title')}
                     subcopy={get(child, 'subnav.cta.subcopy')}
+                    alternateIcon={get(
+                      child,
+                      'subnav.cta.alternateIcon',
+                      false
+                    )}
                   />
                 </NavLink>
               )}

--- a/src/components/UniversalNavbarExpanded/DropdownNav/DropdownChildren.module.scss
+++ b/src/components/UniversalNavbarExpanded/DropdownNav/DropdownChildren.module.scss
@@ -43,6 +43,9 @@ $laptop-range-medium-end: 1050px;
       opacity: var(--HoverOpacity);
       text-decoration: underline;
     }
+    svg {
+      opacity: var(--HoverOpacity);
+    }
   }
 
   @include for-laptop-only {

--- a/src/components/UniversalNavbarExpanded/DropdownNav/DropdownCta.js
+++ b/src/components/UniversalNavbarExpanded/DropdownNav/DropdownCta.js
@@ -16,24 +16,30 @@ import IconIntegratedTitle from './IconIntegratedTitle'
  *
  * @param {string} title - A short title
  * @param {string} subcopy - A sentence of supporting copy
+ * @param {element | boolean} alternateIcon - Alternate icon to display in place of DropdownLinkIcon
  *
  * @return {JSX.Element}
  */
-const DropdownCta = ({ title, subcopy }) => (
-  <>
-    <TitleSmall.Serif.Book500>
-      <IconIntegratedTitle title={title}>
-        <DropdownLinkIcon />
-      </IconIntegratedTitle>
-    </TitleSmall.Serif.Book500>
-    <Spacer.H8 />
-    <Body.Regular400 color={COLORS.GRAY_SECONDARY}>{subcopy}</Body.Regular400>
-  </>
-)
+const DropdownCta = ({ title, subcopy, alternateIcon }) => {
+  const Icon = alternateIcon ? alternateIcon : DropdownLinkIcon
+
+  return (
+    <>
+      <TitleSmall.Serif.Book500>
+        <IconIntegratedTitle title={title}>
+          <Icon />
+        </IconIntegratedTitle>
+      </TitleSmall.Serif.Book500>
+      <Spacer.H8 />
+      <Body.Regular400 color={COLORS.GRAY_SECONDARY}>{subcopy}</Body.Regular400>
+    </>
+  )
+}
 
 DropdownCta.propTypes = {
   title: PropTypes.string.isRequired,
   subcopy: PropTypes.string.isRequired,
+  alternateIcon: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
 }
 
 export default DropdownCta

--- a/src/components/UniversalNavbarExpanded/DropdownNav/DropdownNav.js
+++ b/src/components/UniversalNavbarExpanded/DropdownNav/DropdownNav.js
@@ -58,6 +58,10 @@ DropdownNav.propTypes = {
             title: PropTypes.string,
             id: PropTypes.string,
             subcopy: PropTypes.string,
+            alternateIcon: PropTypes.oneOfType([
+              PropTypes.element,
+              PropTypes.bool,
+            ]),
           }),
           items: PropTypes.arrayOf(
             PropTypes.shape({

--- a/src/components/UniversalNavbarExpanded/DropdownNav/IconIntegratedTitle.js
+++ b/src/components/UniversalNavbarExpanded/DropdownNav/IconIntegratedTitle.js
@@ -31,5 +31,5 @@ IconIntegratedTitle.propTypes = {
   /** `title` - (string) Some text to integrate the icon into. */
   title: PropTypes.string,
   /** `children` - (ReactNode) Icon to integrate into title. */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.node]).isRequired,
 }

--- a/src/components/UniversalNavbarExpanded/SampleContent.js
+++ b/src/components/UniversalNavbarExpanded/SampleContent.js
@@ -1,3 +1,21 @@
+import React from 'react'
+
+const playIcon = () => (
+  <svg
+    width="21"
+    height="21"
+    viewBox="0 0 21 21"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M8.39941 5L15.1996 10.8002L8.39941 16.6005V10.8002L8.39941 5Z"
+      fill="#272727"
+    />
+    <circle cx="10.5" cy="10.5" r="10" stroke="black" />
+  </svg>
+)
+
 /**
  * Sample of UniversalNavbarExpanded links.
  * For demonstration in styleguide & test files (.md/.test.js files) only!
@@ -29,10 +47,11 @@ export const CMS_LINKS = {
       subnav: {
         cta: {
           href: '/#/Components/UniversalNavbarExpanded',
-          title: 'Our plans',
+          title: 'Watch the video',
           subcopy:
             'Learn more about term life insurance and the plans and options you have available.',
           id: 'NAVLINKS_MOCK_ID_2',
+          alternateIcon: playIcon,
         },
         items: [
           {
@@ -73,6 +92,7 @@ export const CMS_LINKS = {
           subcopy:
             'Wondering where to start? We’ve broken down the essentials for you.',
           id: 'NAVLINKS_MOCK_ID_9',
+          alternateIcon: false,
         },
         items: [
           {
@@ -114,6 +134,7 @@ export const CMS_LINKS = {
           subcopy:
             'We put people before profit. Find out how we bring our policyholders the best experience possible.',
           id: 'NAVLINKS_MOCK_ID_16',
+          alternateIcon: false,
         },
         items: [
           {
@@ -154,6 +175,7 @@ export const CMS_LINKS = {
           subcopy:
             'Life insurance can be complicated, but don’t worry. We’re here to help answer your questions.',
           id: 'NAVLINKS_MOCK_ID_23',
+          alternateIcon: false,
         },
         items: [
           {

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -30,6 +30,8 @@ import styles from './UniversalNavbarExpanded.module.scss'
  *
  * @param {boolean} hideMobileCta - Hide cta on mobile
  * @param {boolean} hideDesktopCta - Hide cta on desktop
+ * @param {boolean} hideSearchIcon - Hide search icon on desktop and link on mobile
+ * @param {boolean} hideAccountIcon - Hide account icon on desktop and link on mobile
  * @param {function} trackCtaClick - Analytics function run when CTA Button is clicked
  * @param {object} LinkComponent - Agnotistic Reach and React Router Link (ex. Gatsby's <Link>)
  * @param {string} logoHref - Href for the logo
@@ -42,12 +44,21 @@ const UniversalNavbarExpanded = ({
   LinkComponent,
   hideMobileCta,
   hideDesktopCta,
+  hideSearchIcon,
+  hideAccountIcon,
   logoHref,
   trackCtaClick,
   links,
   estimateExperiment,
 }) => {
-  const BELOW_ACCORDION_LINKS = [links.CTA, links.ACCOUNT, links.SEARCH]
+  let BELOW_ACCORDION_LINKS = [links.CTA]
+
+  if (!hideAccountIcon) {
+    BELOW_ACCORDION_LINKS.push(links.ACCOUNT)
+  }
+  if (!hideSearchIcon) {
+    BELOW_ACCORDION_LINKS.push(links.SEARCH)
+  }
 
   const SearchIconLink = () => (
     <NavLink className={styles.searchIcon} href={links.SEARCH.href}>
@@ -97,8 +108,8 @@ const UniversalNavbarExpanded = ({
               </div>
               <div className={layoutClasses.join(' ')}>
                 {estimateExperiment && <ExperimentCopy />}
-                <SearchIconLink />
-                <AccountIconLink />
+                {!hideSearchIcon && <SearchIconLink />}
+                {!hideAccountIcon && <AccountIconLink />}
                 <div className={styles.cta}>
                   {!hideDesktopCta && (
                     <CtaButton
@@ -122,6 +133,10 @@ UniversalNavbarExpanded.propTypes = {
   hideMobileCta: PropTypes.bool,
   /** Hide cta on desktop */
   hideDesktopCta: PropTypes.bool,
+  /** Hide search icon on desktop and link on mobile */
+  hideSearchIcon: PropTypes.bool,
+  /** Hide account icon on desktop and link on mobile */
+  hideAccountIcon: PropTypes.bool,
   /** Analytics function run when CTA Button is clicked */
   trackCtaClick: PropTypes.func,
   /** Agnotistic Reach and React Router Link (ex. Gatsby's <Link>) */
@@ -169,6 +184,10 @@ UniversalNavbarExpanded.propTypes = {
             title: PropTypes.string,
             id: PropTypes.string,
             subcopy: PropTypes.string,
+            alternateIcon: PropTypes.oneOfType([
+              PropTypes.element,
+              PropTypes.bool,
+            ]),
           }),
           items: PropTypes.arrayOf(
             PropTypes.shape({
@@ -188,6 +207,8 @@ UniversalNavbarExpanded.propTypes = {
 UniversalNavbarExpanded.defaultProps = {
   hideMobileCta: false,
   hideDesktopCta: false,
+  hideSearchIcon: false,
+  hideAccountIcon: false,
   logoHref: '/',
   trackCtaClick: () => {},
   links: {},

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.md
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.md
@@ -5,4 +5,7 @@ import { CMS_LINKS } from './SampleContent';
 <UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS} estimateExperiment={true}/>
 
 // <UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS}/>
+// <UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS} hideSearchIcon={true}/>
+// <UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS} hideAccountIcon={true}/>
+// <UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS} hideAccountIcon={true} hideSearchIcon={true}/>
 ```

--- a/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
+++ b/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
@@ -33,10 +33,11 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                 "id": "NAVLINKS_MOCK_ID_1",
                 "subnav": Object {
                   "cta": Object {
+                    "alternateIcon": [Function],
                     "href": "/#/Components/UniversalNavbarExpanded",
                     "id": "NAVLINKS_MOCK_ID_2",
                     "subcopy": "Learn more about term life insurance and the plans and options you have available.",
-                    "title": "Our plans",
+                    "title": "Watch the video",
                   },
                   "items": Array [
                     Object {
@@ -72,6 +73,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                 "id": "NAVLINKS_MOCK_ID_8",
                 "subnav": Object {
                   "cta": Object {
+                    "alternateIcon": false,
                     "href": "/life/life-insurance-basics/",
                     "id": "NAVLINKS_MOCK_ID_9",
                     "subcopy": "Wondering where to start? We’ve broken down the essentials for you.",
@@ -111,6 +113,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                 "id": "NAVLINKS_MOCK_ID_15",
                 "subnav": Object {
                   "cta": Object {
+                    "alternateIcon": false,
                     "href": "/why-ethos/",
                     "id": "NAVLINKS_MOCK_ID_16",
                     "subcopy": "We put people before profit. Find out how we bring our policyholders the best experience possible.",
@@ -150,6 +153,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                 "id": "NAVLINKS_MOCK_ID_22",
                 "subnav": Object {
                   "cta": Object {
+                    "alternateIcon": false,
                     "href": "/faq/",
                     "id": "NAVLINKS_MOCK_ID_23",
                     "subcopy": "Life insurance can be complicated, but don’t worry. We’re here to help answer your questions.",
@@ -257,10 +261,11 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                       "id": "NAVLINKS_MOCK_ID_1",
                       "subnav": Object {
                         "cta": Object {
+                          "alternateIcon": [Function],
                           "href": "/#/Components/UniversalNavbarExpanded",
                           "id": "NAVLINKS_MOCK_ID_2",
                           "subcopy": "Learn more about term life insurance and the plans and options you have available.",
-                          "title": "Our plans",
+                          "title": "Watch the video",
                         },
                         "items": Array [
                           Object {
@@ -296,6 +301,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                       "id": "NAVLINKS_MOCK_ID_8",
                       "subnav": Object {
                         "cta": Object {
+                          "alternateIcon": false,
                           "href": "/life/life-insurance-basics/",
                           "id": "NAVLINKS_MOCK_ID_9",
                           "subcopy": "Wondering where to start? We’ve broken down the essentials for you.",
@@ -335,6 +341,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                       "id": "NAVLINKS_MOCK_ID_15",
                       "subnav": Object {
                         "cta": Object {
+                          "alternateIcon": false,
                           "href": "/why-ethos/",
                           "id": "NAVLINKS_MOCK_ID_16",
                           "subcopy": "We put people before profit. Find out how we bring our policyholders the best experience possible.",
@@ -374,6 +381,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                       "id": "NAVLINKS_MOCK_ID_22",
                       "subnav": Object {
                         "cta": Object {
+                          "alternateIcon": false,
                           "href": "/faq/",
                           "id": "NAVLINKS_MOCK_ID_23",
                           "subcopy": "Life insurance can be complicated, but don’t worry. We’re here to help answer your questions.",
@@ -473,10 +481,11 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                 "id": "NAVLINKS_MOCK_ID_1",
                 "subnav": Object {
                   "cta": Object {
+                    "alternateIcon": [Function],
                     "href": "/#/Components/UniversalNavbarExpanded",
                     "id": "NAVLINKS_MOCK_ID_2",
                     "subcopy": "Learn more about term life insurance and the plans and options you have available.",
-                    "title": "Our plans",
+                    "title": "Watch the video",
                   },
                   "items": Array [
                     Object {
@@ -512,6 +521,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                 "id": "NAVLINKS_MOCK_ID_8",
                 "subnav": Object {
                   "cta": Object {
+                    "alternateIcon": false,
                     "href": "/life/life-insurance-basics/",
                     "id": "NAVLINKS_MOCK_ID_9",
                     "subcopy": "Wondering where to start? We’ve broken down the essentials for you.",
@@ -551,6 +561,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                 "id": "NAVLINKS_MOCK_ID_15",
                 "subnav": Object {
                   "cta": Object {
+                    "alternateIcon": false,
                     "href": "/why-ethos/",
                     "id": "NAVLINKS_MOCK_ID_16",
                     "subcopy": "We put people before profit. Find out how we bring our policyholders the best experience possible.",
@@ -590,6 +601,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                 "id": "NAVLINKS_MOCK_ID_22",
                 "subnav": Object {
                   "cta": Object {
+                    "alternateIcon": false,
                     "href": "/faq/",
                     "id": "NAVLINKS_MOCK_ID_23",
                     "subcopy": "Life insurance can be complicated, but don’t worry. We’re here to help answer your questions.",
@@ -697,10 +709,11 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                       "id": "NAVLINKS_MOCK_ID_1",
                       "subnav": Object {
                         "cta": Object {
+                          "alternateIcon": [Function],
                           "href": "/#/Components/UniversalNavbarExpanded",
                           "id": "NAVLINKS_MOCK_ID_2",
                           "subcopy": "Learn more about term life insurance and the plans and options you have available.",
-                          "title": "Our plans",
+                          "title": "Watch the video",
                         },
                         "items": Array [
                           Object {
@@ -736,6 +749,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                       "id": "NAVLINKS_MOCK_ID_8",
                       "subnav": Object {
                         "cta": Object {
+                          "alternateIcon": false,
                           "href": "/life/life-insurance-basics/",
                           "id": "NAVLINKS_MOCK_ID_9",
                           "subcopy": "Wondering where to start? We’ve broken down the essentials for you.",
@@ -775,6 +789,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                       "id": "NAVLINKS_MOCK_ID_15",
                       "subnav": Object {
                         "cta": Object {
+                          "alternateIcon": false,
                           "href": "/why-ethos/",
                           "id": "NAVLINKS_MOCK_ID_16",
                           "subcopy": "We put people before profit. Find out how we bring our policyholders the best experience possible.",
@@ -814,6 +829,7 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                       "id": "NAVLINKS_MOCK_ID_22",
                       "subnav": Object {
                         "cta": Object {
+                          "alternateIcon": false,
                           "href": "/faq/",
                           "id": "NAVLINKS_MOCK_ID_23",
                           "subcopy": "Life insurance can be complicated, but don’t worry. We’re here to help answer your questions.",


### PR DESCRIPTION
**Description:**
- Adds an option to pass an alternate icon through to CTA subnav items.
- Adds options to hide the account and search icons.
- [Jira Task for alternate icon](https://ethoslife.atlassian.net/browse/ALP-16?atlOrigin=eyJpIjoiM2ZjNTNkMDE3ZmM3NGM5NmEzY2MyMGM4MmQzMGIzOWIiLCJwIjoiaiJ9)
- [Jira Task for hiding icons](https://ethoslife.atlassian.net/browse/ALP-13?atlOrigin=eyJpIjoiNTgxODZjMTEyODM2NGM3NmFjOGQwNjBjZDI3Mjc0ZmUiLCJwIjoiaiJ9)

**Screenshots:**
Alternate play icon with hidden search & account icons.
<img width="1150" alt="Screen Shot 2021-09-16 at 10 30 16 AM" src="https://user-images.githubusercontent.com/87672141/133660585-d37ebd6a-ed21-4241-8dd2-f72237e71684.png">
*
