### PR TITLE
Add secondary cta to navbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/UniversalNavbarExpanded/SampleContent.js
+++ b/src/components/UniversalNavbarExpanded/SampleContent.js
@@ -31,6 +31,10 @@ export const CMS_LINKS = {
     href: '/term',
     title: 'Check my price',
   },
+  SECONDARY_CTA: {
+    href: '/login',
+    title: 'Login'
+  },
   ACCOUNT: {
     href: '/login/',
     title: 'Account',

--- a/src/components/UniversalNavbarExpanded/SampleContent.js
+++ b/src/components/UniversalNavbarExpanded/SampleContent.js
@@ -33,7 +33,7 @@ export const CMS_LINKS = {
   },
   SECONDARY_CTA: {
     href: '/login',
-    title: 'Login'
+    title: 'Login',
   },
   ACCOUNT: {
     href: '/login/',

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -32,7 +32,9 @@ import styles from './UniversalNavbarExpanded.module.scss'
  * @param {boolean} hideDesktopCta - Hide cta on desktop
  * @param {boolean} hideSearchIcon - Hide search icon on desktop and link on mobile
  * @param {boolean} hideAccountIcon - Hide account icon on desktop and link on mobile
+ * @param {boolean} showSecondaryCta - Show secondary CTA text link on desktop and mobile
  * @param {function} trackCtaClick - Analytics function run when CTA Button is clicked
+ * @param {function} trackSecondaryCtaClick - Analytics function run when secondary CTA text link is clicked
  * @param {object} LinkComponent - Agnotistic Reach and React Router Link (ex. Gatsby's <Link>)
  * @param {string} logoHref - Href for the logo
  * @param {object} links - URLs and text
@@ -46,12 +48,18 @@ const UniversalNavbarExpanded = ({
   hideDesktopCta,
   hideSearchIcon,
   hideAccountIcon,
+  showSecondaryCta,
   logoHref,
   trackCtaClick,
+  trackSecondaryCtaClick,
   links,
   estimateExperiment,
 }) => {
   let BELOW_ACCORDION_LINKS = [links.CTA]
+
+  if (showSecondaryCta) {
+    BELOW_ACCORDION_LINKS.push(links.SECONDARY_CTA)
+  }
 
   if (!hideAccountIcon) {
     BELOW_ACCORDION_LINKS.push(links.ACCOUNT)
@@ -110,6 +118,14 @@ const UniversalNavbarExpanded = ({
                 {estimateExperiment && <ExperimentCopy />}
                 {!hideSearchIcon && <SearchIconLink />}
                 {!hideAccountIcon && <AccountIconLink />}
+                {showSecondaryCta && (
+                  <a
+                    href={links.SECONDARY_CTA.href}
+                    onClick={trackSecondaryCtaClick}
+                  >
+                    {links.SECONDARY_CTA.title}
+                  </a>
+                )}
                 <div className={styles.cta}>
                   {!hideDesktopCta && (
                     <CtaButton
@@ -137,8 +153,12 @@ UniversalNavbarExpanded.propTypes = {
   hideSearchIcon: PropTypes.bool,
   /** Hide account icon on desktop and link on mobile */
   hideAccountIcon: PropTypes.bool,
+  /** Show secondary CTA text link */
+  showSecondaryCta: PropTypes.bool,
   /** Analytics function run when CTA Button is clicked */
   trackCtaClick: PropTypes.func,
+  /** Analytics function run when secondary CTA text link is clicked */
+  trackSecondaryCtaClick: PropTypes.func,
   /** Agnotistic Reach and React Router Link (ex. Gatsby's <Link>) */
   LinkComponent: PropTypes.object,
   /** Href for the logo */
@@ -151,6 +171,11 @@ UniversalNavbarExpanded.propTypes = {
     }),
     /** CTA button link & text { href: string, title: string } */
     CTA: PropTypes.shape({
+      href: PropTypes.string,
+      title: PropTypes.string,
+    }),
+    /** CTA text link { href: string, title: string } */
+    SECONDARY_CTA: PropTypes.shape({
       href: PropTypes.string,
       title: PropTypes.string,
     }),

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.md
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.md
@@ -2,10 +2,11 @@ This element has a fixed position at the top of the screen which you can see her
 
 ```jsx
 import { CMS_LINKS } from './SampleContent';
-<UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS} estimateExperiment={true}/>
+//<UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS} estimateExperiment={true}/>
 
 // <UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS}/>
 // <UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS} hideSearchIcon={true}/>
 // <UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS} hideAccountIcon={true}/>
 // <UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS} hideAccountIcon={true} hideSearchIcon={true}/>
+<UniversalNavbarExpanded logoHref={'/#/Components/UniversalNavbarExpanded'} links={CMS_LINKS} hideAccountIcon={true} hideSearchIcon={true} showSecondaryCta={true}/>
 ```

--- a/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
+++ b/src/components/UniversalNavbarExpanded/__snapshots__/UniversalNavbarExpanded.test.js.snap
@@ -194,6 +194,10 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
               "href": "/search/",
               "title": "Search",
             },
+            "SECONDARY_CTA": Object {
+              "href": "/login",
+              "title": "Login",
+            },
           }
         }
         logoHref="/"
@@ -421,6 +425,10 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                   "SEARCH": Object {
                     "href": "/search/",
                     "title": "Search",
+                  },
+                  "SECONDARY_CTA": Object {
+                    "href": "/login",
+                    "title": "Login",
                   },
                 }
               }
@@ -642,6 +650,10 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
               "href": "/search/",
               "title": "Search",
             },
+            "SECONDARY_CTA": Object {
+              "href": "/login",
+              "title": "Login",
+            },
           }
         }
         logoHref="/"
@@ -869,6 +881,10 @@ exports[`<UniversalNavbarExpanded> matches snapshot builds with sample links pro
                   "SEARCH": Object {
                     "href": "/search/",
                     "title": "Search",
+                  },
+                  "SECONDARY_CTA": Object {
+                    "href": "/login",
+                    "title": "Login",
                   },
                 }
               }


### PR DESCRIPTION
**Description:**
- [Jira Task](https://ethoslife.atlassian.net/browse/ALPP-9?atlOrigin=eyJpIjoiZmVlMjY3YjIyZGZmNDVmOTk3ZDc2NmRhMjkwYjUxYzUiLCJwIjoiaiJ9)
- Adds a new secondary cta text link to the UniversalNavbarExpanded component

**Screenshots:**
New "login" link
<img width="499" alt="Screen Shot 2021-09-30 at 9 55 37 AM" src="https://user-images.githubusercontent.com/87672141/135498470-afcb1bae-68ab-49da-a24a-76f727b87ef5.png">
<img width="1791" alt="Screen Shot 2021-09-30 at 9 55 31 AM" src="https://user-images.githubusercontent.com/87672141/135498478-928ad025-b6f0-4c92-b480-9ddae0e3869e.png">

