### PR TITLE
Tag version fix: v1.2.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",


### PR DESCRIPTION
I accidentally used the tag [v1.2.14](https://github.com/getethos/ethos-design-system/releases/tag/v1.2.14) for #418 which only bumped the package.json version to v1.2.13. So when Harry bumped to v1.2.14 in package.json for #421, the tag was already taken. 

This PR resolves the issue by bumping the version to v1.2.15 and introducing the [v1.2.15](https://github.com/getethos/ethos-design-system/releases/tag/v1.2.15) tag after Harry's work has been merged.