### PR TITLE
Enable maxLength for NumberInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -32,6 +32,7 @@ export const NumberInput = (props) => {
     guide = true,
     keepCharPositions = true,
     autoComplete,
+    maxLength,
     ...restProps
   } = props
 
@@ -59,6 +60,7 @@ export const NumberInput = (props) => {
         guide={guide}
         keepCharPositions={keepCharPositions}
         autoComplete={autoComplete}
+        maxLength={maxLength}
       />
     </>
   )
@@ -85,6 +87,7 @@ NumberInput.propTypes = {
   guide: PropTypes.bool,
   keepCharPositions: PropTypes.bool,
   autoComplete: PropTypes.string,
+  maxLength: PropTypes.number,
 }
 
 NumberInput.defaultProps = {

--- a/src/components/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/TextMaskedInput/TextMaskedInput.js
@@ -29,6 +29,7 @@ export const TextMaskedInput = (props) => {
     placeholderChar,
     autoComplete,
     classOverrides,
+    maxLength,
     ...restProps
   } = props
 
@@ -108,6 +109,7 @@ export const TextMaskedInput = (props) => {
     disabled: restProps.disabled,
     placeholderChar,
     autoComplete,
+    maxLength,
   }
 
   if (typeof mask !== 'function') {
@@ -160,6 +162,7 @@ TextMaskedInput.PUBLIC_PROPS = {
   labelColor: PropTypes.string,
   labelWeight: PropTypes.string,
   labelClasses: PropTypes.string,
+  maxLength: PropTypes.number,
 }
 
 TextMaskedInput.propTypes = {

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -803,6 +803,7 @@ export declare const TextMaskedInput: {
     getTouched?: boolean
     placeholderChar?: string
     formChangeHandler?: (value: string, errorValue: string) => void
+    maxLength?: number
   }
   propTypes: {
     mask: (mask: (string | RegExp)[]) => any
@@ -824,6 +825,7 @@ export declare const TextMaskedInput: {
     getTouched?: boolean
     placeholderChar?: string
     formChangeHandler?: (value: string, errorValue: string) => void
+    maxLength?: number
   }
   defaultProps: {
     placeholder: string

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -1235,6 +1235,7 @@ export declare const NumberInput: {
     placeholderChar?: string
     guide?: boolean
     keepCharPositions?: boolean
+    maxLength?: number
   }
   defaultProps: {
     type: string


### PR DESCRIPTION
### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [x] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?

### Screenshots and extra notes:
https://user-images.githubusercontent.com/84357906/146617248-4ca54122-a601-4bdf-ba14-80d0966b7f6f.mov

Home Page:
![Screen Shot 2021-12-17 at 5 04 20 PM](https://user-images.githubusercontent.com/84357906/146617689-12559623-cf15-4c9c-b052-e67824503cc7.png)

- now we can use `maxLength` to control the max number of characters allowed in `NumberInput` component