### PR TITLE
Bug fix for select component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -77,10 +77,10 @@ export const Select = ({
     let resolvedValues = ''
     // react-select multi select case
     if (Array.isArray(userSelection)) {
-      resolvedValues = userSelection.map((selection) => selection.value)
+      resolvedValues = userSelection?.map((selection) => selection?.value)
     } else {
       // react-select single select case
-      resolvedValues = userSelection.value
+      resolvedValues = userSelection?.value
     }
 
     errorMessage = validate(resolvedValues)

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -77,7 +77,9 @@ export const Select = ({
     let resolvedValues = ''
     // react-select multi select case
     if (Array.isArray(userSelection)) {
-      resolvedValues = userSelection?.map((selection) => selection?.value)
+      resolvedValues = userSelection
+        ?.filter((selection) => selection !== undefined)
+        ?.map((selection) => selection?.value)
     } else {
       // react-select single select case
       resolvedValues = userSelection?.value

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -78,8 +78,8 @@ export const Select = ({
     // react-select multi select case
     if (Array.isArray(userSelection)) {
       resolvedValues = userSelection
-        ?.filter((selection) => selection !== undefined)
         ?.map((selection) => selection?.value)
+        ?.filter((selection) => selection !== undefined)
     } else {
       // react-select single select case
       resolvedValues = userSelection?.value

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -50,10 +50,7 @@ export const Select = ({
   //    {value: "CA", label: "CA"}
   // for multi (array):
   //    [{"value": "CA", "label": "CA"}, {"value": "NY", "label": "NY"}]
-  const [userSelection, updateUserSelection] = useState({
-    value: '',
-    label: '',
-  })
+  const [userSelection, updateUserSelection] = useState(undefined)
   const onChangeHandler = (lastSelection, actionMeta) => {
     /**
      * For multi selects, react-select allows the user to remove all the


### PR DESCRIPTION


### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [ ] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

- reverts what happened in https://github.com/getethos/ethos-design-system/pull/436

### Screenshots and extra notes:

- Basically the validators for select didn't like that we used empty string for value [code](https://github.com/getethos/ethos/blob/d9e593a68944a7e94c9159dc1e295fee947825ec/frontend/src/main/InsuranceApp/PreInterview/Questions/validators.ts#L110)
- This fixes that while still fixing the underlying issue of the console error being thrown on initial select Blur
