### PR TITLE
allow lazy load disabling on CloudinaryImage

### DIFF
--- a/src/components/Images/Images.js
+++ b/src/components/Images/Images.js
@@ -31,6 +31,7 @@ export const CloudinaryImage = ({
   width,
   height,
   crop,
+  lazyLoad,
   ...rest
 }) => {
   // Verify that all required props were supplied
@@ -56,7 +57,11 @@ export const CloudinaryImage = ({
     fetchFormat: 'auto',
     flags: ['progressive:semi'],
   }
-  let imageClasses = ['lazyload', className]
+  let imageClasses = [className]
+  if (lazyLoad) {
+    imageClasses.push('lazyload')
+  }
+
   let reverseWidth, reverseHeight
 
   if (width) {
@@ -77,14 +82,21 @@ export const CloudinaryImage = ({
 
     // srcSet is the LQIP image, src is the fallback image for older browsers
     // that do not support the 'srcSet' attribute (IE zero support)
+
+    const srcString = cld.url(filePath(publicId), {
+      transformation: 'unsupported',
+      ...baseImageSettings,
+    })
+
+    if (lazyLoad) {
+      imageClasses.push(styles['blurUp'])
+    }
+
     return (
       <img
         key={`${uuidv4()}`}
-        className={[styles.Image, styles['blurUp'], ...imageClasses].join(' ')}
-        src={cld.url(filePath(publicId), {
-          transformation: 'unsupported',
-          ...baseImageSettings,
-        })}
+        className={[styles.Image, ...imageClasses].join(' ')}
+        src={srcString}
         srcSet={srcSetString}
         alt={alt}
       />
@@ -133,12 +145,22 @@ export const CloudinaryImage = ({
       const urlWithChainedTransformation = cld
         .imageTag(filePath(publicId), imageSettings)
         .transformation()
+        .getParent()
+        .getAttr('src')
+
+      const urlWithChainedLqipTransformation = cld
+        .imageTag(filePath(publicId), imageSettings)
+        .transformation()
         .chain()
         .transformation('lqip')
         .getParent()
         .getAttr('src')
 
-      imageSrcSet.push(urlWithChainedTransformation)
+      if (lazyLoad) {
+        imageSrcSet.push(urlWithChainedLqipTransformation)
+      } else {
+        imageSrcSet.push(urlWithChainedTransformation)
+      }
     }
 
     tags.push(buildImageTag(imageSrcSet))
@@ -189,11 +211,13 @@ CloudinaryImage.PUBLIC_PROPS = {
   alt: PropTypes.string,
   publicId: PropTypes.string.isRequired,
   crop: PropTypes.oneOf(Object.values(CloudinaryImage.CROP_METHODS)),
+  lazyLoad: PropTypes.bool,
 }
 
 CloudinaryImage.defaultProps = {
   crop: CloudinaryImage.CROP_METHODS.FILL,
   alt: '',
+  lazyLoad: true,
 }
 
 CloudinaryImage.propTypes = CloudinaryImage.PUBLIC_PROPS

--- a/src/components/Images/Images.md
+++ b/src/components/Images/Images.md
@@ -76,6 +76,18 @@ import {
   alt="icon test"
   publicId="https://res.cloudinary.com/getethos/image/upload/v1565206784/02_Icons/Icon_slot_3_Duckegg_ktjkor.svg"
   />
+
+  <TitleSmall.Serif.Book500>Lazy load false</TitleSmall.Serif.Book500>
+  <Spacer.H24/>
+  <CloudinaryImage
+    alt="father and kids playing"
+    publicId="https://res.cloudinary.com/getethos/image/upload/v1565712179/01_NEW%20Lifestyle%20%28Rebrand%29/life-insurance-father-and-kids-playing.jpg"
+    height={[100,200,300,400]}
+    width={[100,200,300,400]}
+    crop="fit"
+    lazyLoad={false}
+  />
+  <Spacer.H24/>
      
 </div>
 ```

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -305,6 +305,7 @@ export declare const CloudinaryImage: {
     width,
     height,
     crop,
+    lazyLoad,
     ...rest
   }: {
     [x: string]: any
@@ -314,6 +315,7 @@ export declare const CloudinaryImage: {
     width: any
     height: any
     crop: any
+    lazyLoad?: boolean
   }): JSX.Element
   CROP_METHODS: {
     FILL: string
@@ -327,10 +329,12 @@ export declare const CloudinaryImage: {
     alt: any
     publicId: any
     crop: any
+    lazyLoad: boolean
   }
   defaultProps: {
     crop: string
     alt: string
+    lazyLoad?: boolean
   }
   propTypes: {
     height: any
@@ -339,6 +343,7 @@ export declare const CloudinaryImage: {
     alt: any
     publicId: any
     crop: any
+    lazyLoad?: boolean
   }
 }
 export declare const filePath: (publicId: any) => any


### PR DESCRIPTION
## [Jira Task]()

### Please review these reminders and either check the box or explain why not:

- [ ] Read and followed the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [ ] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

-

### Screenshots and extra notes:
