### PR TITLE
Enable white background for checkbox

### DIFF
--- a/src/components/CheckboxInput/CheckboxInput.js
+++ b/src/components/CheckboxInput/CheckboxInput.js
@@ -22,6 +22,7 @@ export const CheckboxInput = ({
   // TODO: pushed in from Form.js but not used here
   formTouched, // eslint-disable-line no-unused-vars
   checked,
+  useWhiteBackground,
   ...rest
 }) => {
   const initialChecked = currentValue || initialValue || false
@@ -76,10 +77,15 @@ export const CheckboxInput = ({
       return <Facade classes={klasses} />
     }
   }
+
+  const facadeBackground = useWhiteBackground
+    ? styles.FacadeWhiteBackground
+    : styles.FacadeDefaultBackground
+
   const getFacadeClasses = () => {
     return getError(currentError, touched)
-      ? `${styles.Facade} FacadeError ${errorStyles.Error}`
-      : `${styles.Facade} ${styles.FacadeBorder}`
+      ? `${styles.Facade} ${facadeBackground} FacadeError ${errorStyles.Error}`
+      : `${styles.Facade} ${facadeBackground} ${styles.FacadeBorder}`
   }
 
   const getClasses = () => {
@@ -149,4 +155,6 @@ CheckboxInput.propTypes = {
   /** only useful if you need to completely override the checkbox facade e.g
    * NoraCheckboxInput does this */
   facadeRenderer: PropTypes.func,
+  /** Indicate whether to use white background or the default transparent background */
+  useWhiteBackground: PropTypes.bool,
 }

--- a/src/components/CheckboxInput/CheckboxInput.module.scss
+++ b/src/components/CheckboxInput/CheckboxInput.module.scss
@@ -82,13 +82,20 @@ label:focus-within ~ .tooltip {
   width: 18px;
   height: 18px;
   overflow: hidden;
-  background-color: transparent;
 }
 
 .FacadeBorder {
   border-color: var(--GrayStrokeAndDisabled--translucent);
   border-style: solid;
   border-width: 1px;
+}
+
+.FacadeWhiteBackground {
+  background-color: white;
+}
+
+.FacadeDefaultBackground {
+  background-color: transparent;
 }
 
 .CheckboxInput {

--- a/src/components/CheckboxInput/__snapshots__/CheckboxInput.test.js.snap
+++ b/src/components/CheckboxInput/__snapshots__/CheckboxInput.test.js.snap
@@ -20,7 +20,7 @@ Array [
         type="checkbox"
       />
       <svg
-        className="Facade FacadeBorder"
+        className="Facade FacadeDefaultBackground FacadeBorder"
         fill="none"
         height="18"
         width="18"
@@ -62,7 +62,7 @@ Array [
         type="checkbox"
       />
       <svg
-        className="Facade FacadeBorder"
+        className="Facade FacadeDefaultBackground FacadeBorder"
         fill="none"
         height="18"
         width="18"

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -136,6 +136,7 @@ export declare const CheckboxInput: {
     currentError,
     setFieldTouched,
     formTouched,
+    useWhiteBackground,
     ...rest
   }: {
     [x: string]: any
@@ -151,6 +152,7 @@ export declare const CheckboxInput: {
     currentError?: string
     setFieldTouched?: (touched: boolean) => void
     formTouched?: boolean
+    useWhiteBackground?: boolean
   }): JSX.Element
   propTypes: {
     formTouched?: boolean
@@ -165,6 +167,7 @@ export declare const CheckboxInput: {
     allCaps?: boolean
     validator?: (value: string) => string
     formChangeHandler?: (value: string, errorValue: string) => void
+    useWhiteBackground?: boolean
   }
 }
 

--- a/src/nora/components/NoraCheckboxInput/__snapshots__/NoraCheckboxInput.test.js.snap
+++ b/src/nora/components/NoraCheckboxInput/__snapshots__/NoraCheckboxInput.test.js.snap
@@ -22,7 +22,7 @@ exports[`NoraCheckboxInput default rendering 1`] = `
         type="checkbox"
       />
       <svg
-        className="Facade FacadeBorder"
+        className="Facade FacadeDefaultBackground FacadeBorder"
         fill="none"
         height="18"
         width="18"


### PR DESCRIPTION
### Description:
- Enable white background for CheckboxInput by introducing `useWhiteBackground` property

### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [x] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?