### PR TITLE
Explicitly define proptypes for valueprops, allow for element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.2.23",
+  "version": "1.2.22",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/ValueProps/ValueProps.js
+++ b/src/components/ValueProps/ValueProps.js
@@ -57,7 +57,15 @@ const defaultSections = [
 ]
 
 ValueProps.propTypes = {
-  sections: PropTypes.array,
+  sections: PropTypes.arrayOf(
+    PropTypes.shape({
+      iconUrl: PropTypes.string.isRequired,
+      header: PropTypes.oneOf([PropTypes.string, PropTypes.element]).isRequired,
+      subHeader: PropTypes.oneOf([PropTypes.string, PropTypes.element])
+        .isRequired,
+      alt: PropTypes.string,
+    })
+  ),
 }
 
 ValueProps.defaultProps = {


### PR DESCRIPTION
## [Jira Task](https://ethoslife.atlassian.net/browse/MX-412)

### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [x] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

-

### Screenshots and extra notes:
- allows for element as prop type so that text passed to value props can be bolded and changed