### PR TITLE
Add an icon option for TextInput EmailInput NumberInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/BirthdateInput/__snapshots__/BirthdateInput.test.js.snap
+++ b/src/components/BirthdateInput/__snapshots__/BirthdateInput.test.js.snap
@@ -17,35 +17,40 @@ Array [
       }
     }
   />,
-  <input
-    autoComplete="bday"
-    className="TextMaskedInput TextInputCommon TextInputStylable"
-    data-tid="le-birthdate"
-    disabled={false}
-    guide={true}
-    keepCharPositions={true}
-    mask={
-      Array [
-        /\\\\d/,
-        /\\\\d/,
-        "/",
-        /\\\\d/,
-        /\\\\d/,
-        "/",
-        /\\\\d/,
-        /\\\\d/,
-        /\\\\d/,
-        /\\\\d/,
-      ]
-    }
-    name="birthDate"
-    onBlur={[Function]}
-    onChange={[Function]}
-    pipe={[Function]}
-    placeholder="mm/dd/yyyy"
-    type="tel"
-    value=""
-  />,
+  <div
+    className="TextInputWrapper"
+  >
+    <input
+      autoComplete="bday"
+      className="TextMaskedInput TextInputCommon TextInputStylable"
+      data-tid="le-birthdate"
+      disabled={false}
+      guide={true}
+      keepCharPositions={true}
+      mask={
+        Array [
+          /\\\\d/,
+          /\\\\d/,
+          "/",
+          /\\\\d/,
+          /\\\\d/,
+          "/",
+          /\\\\d/,
+          /\\\\d/,
+          /\\\\d/,
+          /\\\\d/,
+        ]
+      }
+      name="birthDate"
+      onBlur={[Function]}
+      onChange={[Function]}
+      pipe={[Function]}
+      placeholder="mm/dd/yyyy"
+      type="tel"
+      value=""
+    />
+    
+  </div>,
   "",
 ]
 `;

--- a/src/components/BirthdateInput/__snapshots__/BirthdateInput.test.js.snap
+++ b/src/components/BirthdateInput/__snapshots__/BirthdateInput.test.js.snap
@@ -49,7 +49,6 @@ Array [
       type="tel"
       value=""
     />
-    
   </div>,
   "",
 ]

--- a/src/components/DateInput/__snapshots__/DateInput.test.js.snap
+++ b/src/components/DateInput/__snapshots__/DateInput.test.js.snap
@@ -17,32 +17,37 @@ Array [
       }
     }
   />,
-  <input
-    autoComplete="date"
-    className="TextMaskedInput TextInputCommon TextInputStylable"
-    data-tid="when-applied-for"
-    disabled={false}
-    guide={true}
-    keepCharPositions={true}
-    mask={
-      Array [
-        /\\\\d/,
-        /\\\\d/,
-        "/",
-        /\\\\d/,
-        /\\\\d/,
-        /\\\\d/,
-        /\\\\d/,
-      ]
-    }
-    name="whenapplied"
-    onBlur={[Function]}
-    onChange={[Function]}
-    pipe={[Function]}
-    placeholder="mm/yyyy"
-    type="tel"
-    value=""
-  />,
+  <div
+    className="TextInputWrapper"
+  >
+    <input
+      autoComplete="date"
+      className="TextMaskedInput TextInputCommon TextInputStylable"
+      data-tid="when-applied-for"
+      disabled={false}
+      guide={true}
+      keepCharPositions={true}
+      mask={
+        Array [
+          /\\\\d/,
+          /\\\\d/,
+          "/",
+          /\\\\d/,
+          /\\\\d/,
+          /\\\\d/,
+          /\\\\d/,
+        ]
+      }
+      name="whenapplied"
+      onBlur={[Function]}
+      onChange={[Function]}
+      pipe={[Function]}
+      placeholder="mm/yyyy"
+      type="tel"
+      value=""
+    />
+    
+  </div>,
   "",
 ]
 `;

--- a/src/components/DateInput/__snapshots__/DateInput.test.js.snap
+++ b/src/components/DateInput/__snapshots__/DateInput.test.js.snap
@@ -46,7 +46,6 @@ Array [
       type="tel"
       value=""
     />
-    
   </div>,
   "",
 ]

--- a/src/components/EmailInput/EmailInput.js
+++ b/src/components/EmailInput/EmailInput.js
@@ -61,10 +61,10 @@ EmailInput.propTypes = {
   initialValue: PropTypes.string,
   autoComplete: PropTypes.string,
   classOverrides: PropTypes.string,
-  iconPrefix: PropTypes.string,
   /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
-  iconName: PropTypes.string,
+  iconPrefix: PropTypes.string,
   /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
+  iconName: PropTypes.string,
 }
 
 EmailInput.defaultProps = {

--- a/src/components/EmailInput/EmailInput.js
+++ b/src/components/EmailInput/EmailInput.js
@@ -62,7 +62,9 @@ EmailInput.propTypes = {
   autoComplete: PropTypes.string,
   classOverrides: PropTypes.string,
   iconPrefix: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
   iconName: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
 }
 
 EmailInput.defaultProps = {

--- a/src/components/EmailInput/EmailInput.js
+++ b/src/components/EmailInput/EmailInput.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { TextInput } from '../TextInput'
 import EmailFormatValidator from '../../validators/EmailValidator'
-import { valid_icons } from '../../helpers/constants'
+import { VALID_ICONS } from '../../helpers/constants'
 
 export const EmailInput = (props) => {
   const {
@@ -60,8 +60,8 @@ EmailInput.propTypes = {
   initialValue: PropTypes.string,
   autoComplete: PropTypes.string,
   classOverrides: PropTypes.string,
-  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by valid_icons at src/helpers/constants.js */
-  icon: PropTypes.oneOf(Object.keys(valid_icons)),
+  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js */
+  icon: PropTypes.oneOf(Object.keys(VALID_ICONS)),
 }
 
 EmailInput.defaultProps = {

--- a/src/components/EmailInput/EmailInput.js
+++ b/src/components/EmailInput/EmailInput.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { TextInput } from '../TextInput'
 import EmailFormatValidator from '../../validators/EmailValidator'
+import { valid_icons } from '../../helpers/constants'
 
 export const EmailInput = (props) => {
   const {
@@ -14,8 +15,7 @@ export const EmailInput = (props) => {
     placeholder,
     disabled,
     autoComplete,
-    iconPrefix,
-    iconName,
+    icon,
     ...restProps
   } = props
 
@@ -36,8 +36,7 @@ export const EmailInput = (props) => {
         placeholder={placeholder}
         validator={EmailFormatValidator}
         autoComplete={autoComplete}
-        iconPrefix={iconPrefix}
-        iconName={iconName}
+        icon={icon}
         {...restProps}
       />
     </>
@@ -61,15 +60,11 @@ EmailInput.propTypes = {
   initialValue: PropTypes.string,
   autoComplete: PropTypes.string,
   classOverrides: PropTypes.string,
-  /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
-  iconPrefix: PropTypes.string,
-  /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
-  iconName: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by valid_icons at src/helpers/constants.js */
+  icon: PropTypes.oneOf(Object.keys(valid_icons)),
 }
 
 EmailInput.defaultProps = {
   labelCopy: 'Email',
   placeholder: '',
-  iconPrefix: '',
-  iconName: '',
 }

--- a/src/components/EmailInput/EmailInput.js
+++ b/src/components/EmailInput/EmailInput.js
@@ -14,6 +14,8 @@ export const EmailInput = (props) => {
     placeholder,
     disabled,
     autoComplete,
+    iconPrefix,
+    iconName,
     ...restProps
   } = props
 
@@ -34,6 +36,8 @@ export const EmailInput = (props) => {
         placeholder={placeholder}
         validator={EmailFormatValidator}
         autoComplete={autoComplete}
+        iconPrefix={iconPrefix}
+        iconName={iconName}
         {...restProps}
       />
     </>
@@ -57,9 +61,13 @@ EmailInput.propTypes = {
   initialValue: PropTypes.string,
   autoComplete: PropTypes.string,
   classOverrides: PropTypes.string,
+  iconPrefix: PropTypes.string,
+  iconName: PropTypes.string,
 }
 
 EmailInput.defaultProps = {
   labelCopy: 'Email',
   placeholder: '',
+  iconPrefix: '',
+  iconName: '',
 }

--- a/src/components/EmailInput/EmailInput.md
+++ b/src/components/EmailInput/EmailInput.md
@@ -52,7 +52,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `solid lock icon`, which results in the email input with solid lock icon.
+This one sets a `solid lock icon`, which results in the email input with solid lock icon. `iconPrefix="fas"` is the prefix for solid icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name.
 ```jsx
 import EmailFormatValidator from '../../validators/EmailValidator'
 import { EmailInput } from './index.js'
@@ -70,7 +70,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `regular eye-slash icon`, which results in the email input with regular eye-slash icon.
+This one sets a `regular eye-slash icon`, which results in the email input with regular eye-slash icon. `iconPrefix="far"` is the prefix for regular icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name.
 ```jsx
 import EmailFormatValidator from '../../validators/EmailValidator'
 import { EmailInput } from './index.js'
@@ -85,5 +85,23 @@ const formChangeHandlerStub = () => {}
   formChangeHandler={formChangeHandlerStub}
   iconPrefix="far"
   iconName="eye-slash"
+/>
+```
+
+This one sets a random/invalid input for iconPrefix and iconName, which results in the email input with NO icon.
+```jsx
+import EmailFormatValidator from '../../validators/EmailValidator'
+import { EmailInput } from './index.js'
+const formChangeHandlerStub = () => {}
+;<EmailInput
+  name="the-email-input-example"
+  allCaps={true}
+  labelCopy="Your email"
+  data-tid="the-email-input"
+  placeholder="example@ethoslife.com"
+  validator={EmailFormatValidator}
+  formChangeHandler={formChangeHandlerStub}
+  iconPrefix="dgdsgadg"
+  iconName="4dsagag"
 />
 ```

--- a/src/components/EmailInput/EmailInput.md
+++ b/src/components/EmailInput/EmailInput.md
@@ -52,7 +52,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `solid lock icon`, which results in the email input with solid lock icon. `iconPrefix="fas"` is the prefix for solid icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name.
+This one sets a `solid lock icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
 ```jsx
 import EmailFormatValidator from '../../validators/EmailValidator'
 import { EmailInput } from './index.js'
@@ -65,12 +65,11 @@ const formChangeHandlerStub = () => {}
   placeholder="example@ethoslife.com"
   validator={EmailFormatValidator}
   formChangeHandler={formChangeHandlerStub}
-  iconPrefix="fas"
-  iconName="lock"
+  icon="lock"
 />
 ```
 
-This one sets a `regular eye-slash icon`, which results in the email input with regular eye-slash icon. `iconPrefix="far"` is the prefix for regular icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name.
+This one sets a `regular eye-slash icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
 ```jsx
 import EmailFormatValidator from '../../validators/EmailValidator'
 import { EmailInput } from './index.js'
@@ -83,12 +82,12 @@ const formChangeHandlerStub = () => {}
   placeholder="example@ethoslife.com"
   validator={EmailFormatValidator}
   formChangeHandler={formChangeHandlerStub}
-  iconPrefix="far"
-  iconName="eye-slash"
+  icon="eye_slash"
 />
 ```
 
-This one sets a random/invalid input for iconPrefix and iconName, which results in the email input with NO icon.
+
+This one sets a random/invalid input for icon, which results in the email input with NO icon. Currently allowed icons are defined by valid_icons at src/helpers/constants.js
 ```jsx
 import EmailFormatValidator from '../../validators/EmailValidator'
 import { EmailInput } from './index.js'
@@ -101,7 +100,6 @@ const formChangeHandlerStub = () => {}
   placeholder="example@ethoslife.com"
   validator={EmailFormatValidator}
   formChangeHandler={formChangeHandlerStub}
-  iconPrefix="dgdsgadg"
-  iconName="4dsagag"
+  icon="4dsagag"
 />
 ```

--- a/src/components/EmailInput/EmailInput.md
+++ b/src/components/EmailInput/EmailInput.md
@@ -51,3 +51,39 @@ const formChangeHandlerStub = () => {}
   formChangeHandler={formChangeHandlerStub}
 />
 ```
+
+This one sets a `solid lock icon`, which results in the email input with solid lock icon.
+```jsx
+import EmailFormatValidator from '../../validators/EmailValidator'
+import { EmailInput } from './index.js'
+const formChangeHandlerStub = () => {}
+;<EmailInput
+  name="the-email-input-example"
+  allCaps={true}
+  labelCopy="Your email"
+  data-tid="the-email-input"
+  placeholder="example@ethoslife.com"
+  validator={EmailFormatValidator}
+  formChangeHandler={formChangeHandlerStub}
+  iconPrefix="fas"
+  iconName="lock"
+/>
+```
+
+This one sets a `regular eye-slash icon`, which results in the email input with regular eye-slash icon.
+```jsx
+import EmailFormatValidator from '../../validators/EmailValidator'
+import { EmailInput } from './index.js'
+const formChangeHandlerStub = () => {}
+;<EmailInput
+  name="the-email-input-example"
+  allCaps={true}
+  labelCopy="Your email"
+  data-tid="the-email-input"
+  placeholder="example@ethoslife.com"
+  validator={EmailFormatValidator}
+  formChangeHandler={formChangeHandlerStub}
+  iconPrefix="far"
+  iconName="eye-slash"
+/>
+```

--- a/src/components/EmailInput/EmailInput.md
+++ b/src/components/EmailInput/EmailInput.md
@@ -52,7 +52,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `solid lock icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
+This one sets a `solid lock icon`. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js.
 ```jsx
 import EmailFormatValidator from '../../validators/EmailValidator'
 import { EmailInput } from './index.js'
@@ -69,7 +69,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `regular eye-slash icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
+This one sets a `regular eye-slash icon`. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js.
 ```jsx
 import EmailFormatValidator from '../../validators/EmailValidator'
 import { EmailInput } from './index.js'
@@ -87,7 +87,7 @@ const formChangeHandlerStub = () => {}
 ```
 
 
-This one sets a random/invalid input for icon, which results in the email input with NO icon. Currently allowed icons are defined by valid_icons at src/helpers/constants.js
+This one sets a random/invalid input for icon, which results in the email input with NO icon. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js
 ```jsx
 import EmailFormatValidator from '../../validators/EmailValidator'
 import { EmailInput } from './index.js'

--- a/src/components/EmailInput/__snapshots__/EmailInput.test.js.snap
+++ b/src/components/EmailInput/__snapshots__/EmailInput.test.js.snap
@@ -17,18 +17,23 @@ Array [
       }
     }
   />,
-  <input
-    aria-label="the-email-input-example"
-    autoComplete="email"
-    className="TextInputCommon TextInputStylable"
-    data-tid="the-email-input"
-    name="the-email-input-example"
-    onBlur={[Function]}
-    onChange={[Function]}
-    placeholder="example@ethoslife.com"
-    type="email"
-    value=""
-  />,
+  <div
+    className="TextInputWrapper"
+  >
+    <input
+      aria-label="the-email-input-example"
+      autoComplete="email"
+      className="TextInputCommon TextInputStylable"
+      data-tid="the-email-input"
+      name="the-email-input-example"
+      onBlur={[Function]}
+      onChange={[Function]}
+      placeholder="example@ethoslife.com"
+      type="email"
+      value=""
+    />
+    
+  </div>,
   "",
 ]
 `;

--- a/src/components/EmailInput/__snapshots__/EmailInput.test.js.snap
+++ b/src/components/EmailInput/__snapshots__/EmailInput.test.js.snap
@@ -32,7 +32,6 @@ Array [
       type="email"
       value=""
     />
-    
   </div>,
   "",
 ]

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 // https://github.com/text-mask/text-mask/tree/master/addons
 import createNumberMask from 'text-mask-addons/dist/createNumberMask'
 import { TextMaskedInput } from '../TextMaskedInput'
+import { valid_icons } from '../../helpers/constants'
 
 export const integerMask = createNumberMask({
   allowDecimal: false,
@@ -33,8 +34,7 @@ export const NumberInput = (props) => {
     keepCharPositions = true,
     autoComplete,
     maxLength,
-    iconPrefix,
-    iconName,
+    icon,
     ...restProps
   } = props
 
@@ -63,8 +63,7 @@ export const NumberInput = (props) => {
         keepCharPositions={keepCharPositions}
         autoComplete={autoComplete}
         maxLength={maxLength}
-        iconPrefix={iconPrefix}
-        iconName={iconName}
+        icon={icon}
       />
     </>
   )
@@ -92,15 +91,11 @@ NumberInput.propTypes = {
   keepCharPositions: PropTypes.bool,
   autoComplete: PropTypes.string,
   maxLength: PropTypes.number,
-  /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
-  iconPrefix: PropTypes.string,
-  /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
-  iconName: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by valid_icons at src/helpers/constants.js */
+  icon: PropTypes.oneOf(Object.keys(valid_icons)),
 }
 
 NumberInput.defaultProps = {
   type: 'tel',
   mask: integerMask,
-  iconPrefix: '',
-  iconName: '',
 }

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 // https://github.com/text-mask/text-mask/tree/master/addons
 import createNumberMask from 'text-mask-addons/dist/createNumberMask'
 import { TextMaskedInput } from '../TextMaskedInput'
-import { valid_icons } from '../../helpers/constants'
+import { VALID_ICONS } from '../../helpers/constants'
 
 export const integerMask = createNumberMask({
   allowDecimal: false,
@@ -91,8 +91,8 @@ NumberInput.propTypes = {
   keepCharPositions: PropTypes.bool,
   autoComplete: PropTypes.string,
   maxLength: PropTypes.number,
-  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by valid_icons at src/helpers/constants.js */
-  icon: PropTypes.oneOf(Object.keys(valid_icons)),
+  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js */
+  icon: PropTypes.oneOf(Object.keys(VALID_ICONS)),
 }
 
 NumberInput.defaultProps = {

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -33,6 +33,8 @@ export const NumberInput = (props) => {
     keepCharPositions = true,
     autoComplete,
     maxLength,
+    iconPrefix,
+    iconName,
     ...restProps
   } = props
 
@@ -61,6 +63,8 @@ export const NumberInput = (props) => {
         keepCharPositions={keepCharPositions}
         autoComplete={autoComplete}
         maxLength={maxLength}
+        iconPrefix={iconPrefix}
+        iconName={iconName}
       />
     </>
   )
@@ -88,9 +92,13 @@ NumberInput.propTypes = {
   keepCharPositions: PropTypes.bool,
   autoComplete: PropTypes.string,
   maxLength: PropTypes.number,
+  iconPrefix: PropTypes.string,
+  iconName: PropTypes.string,
 }
 
 NumberInput.defaultProps = {
   type: 'tel',
   mask: integerMask,
+  iconPrefix: '',
+  iconName: '',
 }

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -92,10 +92,10 @@ NumberInput.propTypes = {
   keepCharPositions: PropTypes.bool,
   autoComplete: PropTypes.string,
   maxLength: PropTypes.number,
-  iconPrefix: PropTypes.string,
   /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
-  iconName: PropTypes.string,
+  iconPrefix: PropTypes.string,
   /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
+  iconName: PropTypes.string,
 }
 
 NumberInput.defaultProps = {

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -93,7 +93,9 @@ NumberInput.propTypes = {
   autoComplete: PropTypes.string,
   maxLength: PropTypes.number,
   iconPrefix: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
   iconName: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
 }
 
 NumberInput.defaultProps = {

--- a/src/components/NumberInput/NumberInput.md
+++ b/src/components/NumberInput/NumberInput.md
@@ -49,7 +49,7 @@ const dollarMaskFunction = createNumberMask({
 />
 ```
 
-This one sets a `solid lock icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
+This one sets a `solid lock icon`. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js.
 ```jsx
 import { NumberInput } from './index.js';
 // formChangeHandler gets wired up automatically if using <Form /> component
@@ -72,7 +72,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `regular eye-slash icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
+This one sets a `regular eye-slash icon`. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js.
 ```jsx
 import createNumberMask from 'text-mask-addons/dist/createNumberMask'
 import { NumberInput } from './index.js';
@@ -101,7 +101,7 @@ const dollarMaskFunction = createNumberMask({
   icon="eye_slash"
 />
 ```
-This one sets a random/invalid input for icon, which results in the number input with NO icon. Currently allowed icons are defined by valid_icons at src/helpers/constants.js
+This one sets a random/invalid input for icon, which results in the number input with NO icon. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js
 ```jsx
 import createNumberMask from 'text-mask-addons/dist/createNumberMask'
 import { NumberInput } from './index.js';

--- a/src/components/NumberInput/NumberInput.md
+++ b/src/components/NumberInput/NumberInput.md
@@ -48,3 +48,58 @@ const dollarMaskFunction = createNumberMask({
   }}
 />
 ```
+
+This one sets a `solid lock icon`, which results in the number input with solid lock icon.
+```jsx
+import { NumberInput } from './index.js';
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+;<NumberInput
+  initialValue="123"
+  name="the-number-input-example"
+  allCaps={true}
+  labelCopy="Enter a number (must be even to validate)"
+  data-tid='the-number-input'
+  placeholder='number input'
+  formChangeHandler={formChangeHandlerStub}
+  validator={(n) => {
+    if (n > Number.MAX_SAFE_INTEGER) {
+      return 'Number too large—you have exceeded JavaScript\s powers!!'
+    }
+    return n % 2 === 0 ? '' : 'Must be an even number'
+  }}
+  iconPrefix="fas"
+  iconName="lock"
+/>
+```
+
+This one sets a `regular eye-slash icon`, which results in the number input with regular eye-slash icon.
+```jsx
+import createNumberMask from 'text-mask-addons/dist/createNumberMask'
+import { NumberInput } from './index.js';
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+
+const dollarMaskFunction = createNumberMask({
+  allowDecimal: false,
+  allowLeadingZeroes: false,
+  guide: false,
+  includeThousandsSeparator: true,
+  prefix: '$',
+})
+
+;<NumberInput
+  mask={dollarMaskFunction}
+  name="dollar-input-example"
+  allCaps={true}
+  labelCopy="Enter a number (Must be less then $100,000)"
+  data-tid='dollar-number-input'
+  placeholder='Dollar via number input...'
+  formChangeHandler={formChangeHandlerStub}
+  validator={(n) => {
+    return n > 0 && n < 100000 ? '' : 'Must be less then $100,000'
+  }}
+  iconPrefix="far"
+  iconName="eye-slash"
+/>
+```

--- a/src/components/NumberInput/NumberInput.md
+++ b/src/components/NumberInput/NumberInput.md
@@ -49,7 +49,7 @@ const dollarMaskFunction = createNumberMask({
 />
 ```
 
-This one sets a `solid lock icon`, which results in the number input with solid lock icon. `iconPrefix="fas"` is the prefix for solid icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix.
+This one sets a `solid lock icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
 ```jsx
 import { NumberInput } from './index.js';
 // formChangeHandler gets wired up automatically if using <Form /> component
@@ -68,12 +68,11 @@ const formChangeHandlerStub = () => {}
     }
     return n % 2 === 0 ? '' : 'Must be an even number'
   }}
-  iconPrefix="fas"
-  iconName="lock"
+  icon="lock"
 />
 ```
 
-This one sets a `regular eye-slash icon`, which results in the number input with regular eye-slash icon. `iconPrefix="far"` is the prefix for regular icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix.
+This one sets a `regular eye-slash icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
 ```jsx
 import createNumberMask from 'text-mask-addons/dist/createNumberMask'
 import { NumberInput } from './index.js';
@@ -99,11 +98,10 @@ const dollarMaskFunction = createNumberMask({
   validator={(n) => {
     return n > 0 && n < 100000 ? '' : 'Must be less then $100,000'
   }}
-  iconPrefix="far"
-  iconName="eye-slash"
+  icon="eye_slash"
 />
 ```
-This one sets a random/invalid input for iconPrefix and iconName, which results in the number input with NO icon.
+This one sets a random/invalid input for icon, which results in the number input with NO icon. Currently allowed icons are defined by valid_icons at src/helpers/constants.js
 ```jsx
 import createNumberMask from 'text-mask-addons/dist/createNumberMask'
 import { NumberInput } from './index.js';
@@ -129,7 +127,6 @@ const dollarMaskFunction = createNumberMask({
   validator={(n) => {
     return n > 0 && n < 100000 ? '' : 'Must be less then $100,000'
   }}
-  iconPrefix="sdjgoaeug"
-  iconName="ewguoui"
+  icon="ewguoui"
 />
 ```

--- a/src/components/NumberInput/NumberInput.md
+++ b/src/components/NumberInput/NumberInput.md
@@ -49,7 +49,7 @@ const dollarMaskFunction = createNumberMask({
 />
 ```
 
-This one sets a `solid lock icon`, which results in the number input with solid lock icon.
+This one sets a `solid lock icon`, which results in the number input with solid lock icon. `iconPrefix="fas"` is the prefix for solid icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix.
 ```jsx
 import { NumberInput } from './index.js';
 // formChangeHandler gets wired up automatically if using <Form /> component
@@ -73,7 +73,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `regular eye-slash icon`, which results in the number input with regular eye-slash icon.
+This one sets a `regular eye-slash icon`, which results in the number input with regular eye-slash icon. `iconPrefix="far"` is the prefix for regular icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix.
 ```jsx
 import createNumberMask from 'text-mask-addons/dist/createNumberMask'
 import { NumberInput } from './index.js';
@@ -101,5 +101,35 @@ const dollarMaskFunction = createNumberMask({
   }}
   iconPrefix="far"
   iconName="eye-slash"
+/>
+```
+This one sets a random/invalid input for iconPrefix and iconName, which results in the number input with NO icon.
+```jsx
+import createNumberMask from 'text-mask-addons/dist/createNumberMask'
+import { NumberInput } from './index.js';
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+
+const dollarMaskFunction = createNumberMask({
+  allowDecimal: false,
+  allowLeadingZeroes: false,
+  guide: false,
+  includeThousandsSeparator: true,
+  prefix: '$',
+})
+
+;<NumberInput
+  mask={dollarMaskFunction}
+  name="dollar-input-example"
+  allCaps={true}
+  labelCopy="Enter a number (Must be less then $100,000)"
+  data-tid='dollar-number-input'
+  placeholder='Dollar via number input...'
+  formChangeHandler={formChangeHandlerStub}
+  validator={(n) => {
+    return n > 0 && n < 100000 ? '' : 'Must be less then $100,000'
+  }}
+  iconPrefix="sdjgoaeug"
+  iconName="ewguoui"
 />
 ```

--- a/src/components/NumberInput/__snapshots__/NumberInput.test.js.snap
+++ b/src/components/NumberInput/__snapshots__/NumberInput.test.js.snap
@@ -17,19 +17,24 @@ Array [
       }
     }
   />,
-  <input
-    autoComplete="tel"
-    className="TextMaskedInput TextInputCommon TextInputStylable"
-    data-tid="the-number-input"
-    disabled={false}
-    mask={[Function]}
-    name="the-number-input-example"
-    onBlur={[Function]}
-    onChange={[Function]}
-    placeholder="number input"
-    type="tel"
-    value="123"
-  />,
+  <div
+    className="TextInputWrapper"
+  >
+    <input
+      autoComplete="tel"
+      className="TextMaskedInput TextInputCommon TextInputStylable"
+      data-tid="the-number-input"
+      disabled={false}
+      mask={[Function]}
+      name="the-number-input-example"
+      onBlur={[Function]}
+      onChange={[Function]}
+      placeholder="number input"
+      type="tel"
+      value="123"
+    />
+    
+  </div>,
   "",
 ]
 `;

--- a/src/components/NumberInput/__snapshots__/NumberInput.test.js.snap
+++ b/src/components/NumberInput/__snapshots__/NumberInput.test.js.snap
@@ -33,7 +33,6 @@ Array [
       type="tel"
       value="123"
     />
-    
   </div>,
   "",
 ]

--- a/src/components/PasswordInput/__snapshots__/PasswordInput.test.js.snap
+++ b/src/components/PasswordInput/__snapshots__/PasswordInput.test.js.snap
@@ -31,7 +31,6 @@ Array [
       type="password"
       value=""
     />
-    
   </div>,
   "",
 ]

--- a/src/components/PasswordInput/__snapshots__/PasswordInput.test.js.snap
+++ b/src/components/PasswordInput/__snapshots__/PasswordInput.test.js.snap
@@ -17,17 +17,22 @@ Array [
       }
     }
   />,
-  <input
-    aria-label="password-example"
-    className="TextInputCommon TextInputStylable"
-    data-tid="the-password-input"
-    name="password-example"
-    onBlur={[Function]}
-    onChange={[Function]}
-    placeholder=""
-    type="password"
-    value=""
-  />,
+  <div
+    className="TextInputWrapper"
+  >
+    <input
+      aria-label="password-example"
+      className="TextInputCommon TextInputStylable"
+      data-tid="the-password-input"
+      name="password-example"
+      onBlur={[Function]}
+      onChange={[Function]}
+      placeholder=""
+      type="password"
+      value=""
+    />
+    
+  </div>,
   "",
 ]
 `;

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -127,7 +127,10 @@ function PrivateTextInput({
       returnClasses = `${styles.TextInputCommon} ${styles.TextInputStylable}`
     }
     // hasIcon class indicates the text input has icon, to give more padding-right in stylings,to prevent overlapping between icon and long input
-    if (iconPrefix && iconName) {
+    if (
+      (iconPrefix === 'fas' && iconName === 'lock') ||
+      (iconPrefix === 'far' && iconName === 'eye-slash')
+    ) {
       returnClasses += ` ${styles.hasIcon}`
     }
     return returnClasses
@@ -160,7 +163,8 @@ function PrivateTextInput({
           aria-label={name} // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
           autoComplete={autoComplete}
         />
-        {iconPrefix && iconName && (
+        {((iconPrefix === 'fas' && iconName === 'lock') ||
+          (iconPrefix === 'far' && iconName === 'eye-slash')) && (
           <div className={styles.TextInputIconWrapper}>
             <FontAwesomeIcon
               icon={[iconPrefix, iconName]}

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -9,6 +9,7 @@ import useInputValidation from '../../hooks/useInputValidation.js'
 import restrict from '../../helpers/restrict.js'
 import styles from './TextInput.module.scss'
 import errorStyles from '../Errors.module.scss'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 /**
  * @param type
@@ -51,6 +52,8 @@ function PrivateTextInput({
   labelColor,
   labelWeight,
   labelClasses,
+  iconPrefix,
+  iconName,
   ...rest
 }) {
   // Verify that all required props were supplied
@@ -123,7 +126,10 @@ function PrivateTextInput({
     } else {
       returnClasses = `${styles.TextInputCommon} ${styles.TextInputStylable}`
     }
-
+    // hasIcon class indicates the text input has icon, to give more padding-right in stylings,to prevent overlapping between icon and long input
+    if (iconPrefix && iconName) {
+      returnClasses += ` ${styles.hasIcon}`
+    }
     return returnClasses
   }
 
@@ -140,19 +146,29 @@ function PrivateTextInput({
           capitalize={capitalize}
         />
       )}
-      <input
-        type={type}
-        className={getClasses()}
-        disabled={disabled}
-        name={name}
-        placeholder={rest.placeholder}
-        onChange={onChange}
-        onBlur={onBlur}
-        value={value}
-        data-tid={rest['data-tid']}
-        aria-label={name} // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
-        autoComplete={autoComplete}
-      />
+      <div className={styles.TextInputWrapper}>
+        <input
+          type={type}
+          className={getClasses()}
+          disabled={disabled}
+          name={name}
+          placeholder={rest.placeholder}
+          onChange={onChange}
+          onBlur={onBlur}
+          value={value}
+          data-tid={rest['data-tid']}
+          aria-label={name} // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
+          autoComplete={autoComplete}
+        />
+        {iconPrefix && iconName && (
+          <div className={styles.TextInputIconWrapper}>
+            <FontAwesomeIcon
+              icon={[iconPrefix, iconName]}
+              className={styles.TextInputIcon}
+            />
+          </div>
+        )}
+      </div>
       {getError(currentError, touched)}
     </>
   )
@@ -178,6 +194,8 @@ PrivateTextInput.PUBLIC_PROPS = {
   restrictIllegal: PropTypes.bool,
   autoComplete: PropTypes.string,
   classOverrides: PropTypes.string,
+  iconPrefix: PropTypes.string,
+  iconName: PropTypes.string,
 }
 
 PrivateTextInput.propTypes = {
@@ -188,6 +206,8 @@ PrivateTextInput.defaultProps = {
   type: 'text',
   placeholder: '',
   restrictIllegal: true,
+  iconPrefix: '',
+  iconName: '',
 }
 
 function TextInputFactory(privateProps) {

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -10,7 +10,7 @@ import restrict from '../../helpers/restrict.js'
 import styles from './TextInput.module.scss'
 import errorStyles from '../Errors.module.scss'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { valid_icons } from '../../helpers/constants'
+import { VALID_ICONS } from '../../helpers/constants'
 
 /**
  * @param type
@@ -127,7 +127,7 @@ function PrivateTextInput({
       returnClasses = `${styles.TextInputCommon} ${styles.TextInputStylable}`
     }
     // hasIcon class indicates the text input has icon, to give more padding-right in stylings,to prevent overlapping between icon and long input
-    if (Object.keys(valid_icons).includes(icon)) {
+    if (Object.keys(VALID_ICONS).includes(icon)) {
       returnClasses += ` ${styles.hasIcon}`
     }
     return returnClasses
@@ -160,10 +160,10 @@ function PrivateTextInput({
           aria-label={name} // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
           autoComplete={autoComplete}
         />
-        {Object.keys(valid_icons).includes(icon) && (
+        {Object.keys(VALID_ICONS).includes(icon) && (
           <div className={styles.TextInputIconWrapper}>
             <FontAwesomeIcon
-              icon={[valid_icons[icon].prefix, valid_icons[icon].name]}
+              icon={[VALID_ICONS[icon].prefix, VALID_ICONS[icon].name]}
               className={styles.TextInputIcon}
             />
           </div>
@@ -194,16 +194,16 @@ PrivateTextInput.PUBLIC_PROPS = {
   restrictIllegal: PropTypes.bool,
   autoComplete: PropTypes.string,
   classOverrides: PropTypes.string,
-  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by valid_icons at src/helpers/constants.js */
-  icon: PropTypes.oneOf(Object.keys(valid_icons)),
+  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js */
+  icon: PropTypes.oneOf(Object.keys(VALID_ICONS)),
 }
 
 PrivateTextInput.propTypes = {
   ...PrivateTextInput.PUBLIC_PROPS,
   /** text transform capitalize label */
   capitalize: PropTypes.bool,
-  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by valid_icons at src/helpers/constants.js */
-  icon: PropTypes.oneOf(Object.keys(valid_icons)),
+  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js */
+  icon: PropTypes.oneOf(Object.keys(VALID_ICONS)),
 }
 
 PrivateTextInput.defaultProps = {

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -10,6 +10,7 @@ import restrict from '../../helpers/restrict.js'
 import styles from './TextInput.module.scss'
 import errorStyles from '../Errors.module.scss'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { valid_icons } from '../../helpers/constants'
 
 /**
  * @param type
@@ -52,8 +53,7 @@ function PrivateTextInput({
   labelColor,
   labelWeight,
   labelClasses,
-  iconPrefix,
-  iconName,
+  icon,
   ...rest
 }) {
   // Verify that all required props were supplied
@@ -127,10 +127,7 @@ function PrivateTextInput({
       returnClasses = `${styles.TextInputCommon} ${styles.TextInputStylable}`
     }
     // hasIcon class indicates the text input has icon, to give more padding-right in stylings,to prevent overlapping between icon and long input
-    if (
-      (iconPrefix === 'fas' && iconName === 'lock') ||
-      (iconPrefix === 'far' && iconName === 'eye-slash')
-    ) {
+    if (Object.keys(valid_icons).includes(icon)) {
       returnClasses += ` ${styles.hasIcon}`
     }
     return returnClasses
@@ -163,11 +160,10 @@ function PrivateTextInput({
           aria-label={name} // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
           autoComplete={autoComplete}
         />
-        {((iconPrefix === 'fas' && iconName === 'lock') ||
-          (iconPrefix === 'far' && iconName === 'eye-slash')) && (
+        {Object.keys(valid_icons).includes(icon) && (
           <div className={styles.TextInputIconWrapper}>
             <FontAwesomeIcon
-              icon={[iconPrefix, iconName]}
+              icon={[valid_icons[icon].prefix, valid_icons[icon].name]}
               className={styles.TextInputIcon}
             />
           </div>
@@ -198,28 +194,22 @@ PrivateTextInput.PUBLIC_PROPS = {
   restrictIllegal: PropTypes.bool,
   autoComplete: PropTypes.string,
   classOverrides: PropTypes.string,
-  /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
-  iconPrefix: PropTypes.string,
-  /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
-  iconName: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by valid_icons at src/helpers/constants.js */
+  icon: PropTypes.oneOf(Object.keys(valid_icons)),
 }
 
 PrivateTextInput.propTypes = {
   ...PrivateTextInput.PUBLIC_PROPS,
   /** text transform capitalize label */
   capitalize: PropTypes.bool,
-  /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
-  iconPrefix: PropTypes.string,
-  /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
-  iconName: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by valid_icons at src/helpers/constants.js */
+  icon: PropTypes.oneOf(Object.keys(valid_icons)),
 }
 
 PrivateTextInput.defaultProps = {
   type: 'text',
   placeholder: '',
   restrictIllegal: true,
-  iconPrefix: '',
-  iconName: '',
 }
 
 function TextInputFactory(privateProps) {

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -194,14 +194,20 @@ PrivateTextInput.PUBLIC_PROPS = {
   restrictIllegal: PropTypes.bool,
   autoComplete: PropTypes.string,
   classOverrides: PropTypes.string,
-  iconPrefix: PropTypes.string,
   /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
-  iconName: PropTypes.string,
+  iconPrefix: PropTypes.string,
   /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
+  iconName: PropTypes.string,
 }
 
 PrivateTextInput.propTypes = {
   ...PrivateTextInput.PUBLIC_PROPS,
+  /** text transform capitalize label */
+  capitalize: PropTypes.bool,
+  /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
+  iconPrefix: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
+  iconName: PropTypes.string,
 }
 
 PrivateTextInput.defaultProps = {

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -195,7 +195,9 @@ PrivateTextInput.PUBLIC_PROPS = {
   autoComplete: PropTypes.string,
   classOverrides: PropTypes.string,
   iconPrefix: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
   iconName: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
 }
 
 PrivateTextInput.propTypes = {

--- a/src/components/TextInput/TextInput.md
+++ b/src/components/TextInput/TextInput.md
@@ -45,7 +45,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `solid lock icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
+This one sets a `solid lock icon`. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js.
 
 ```jsx
 import validateMinMaxFactory from '../../validators/validateMinMax'
@@ -69,7 +69,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `regular eye-slash icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
+This one sets a `regular eye-slash icon`. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js.
 
 ```jsx
 import validateMinMaxFactory from '../../validators/validateMinMax'
@@ -93,7 +93,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a random/invalid input for icon, which results in the text input with NO icon. Currently allowed icons are defined by valid_icons at src/helpers/constants.js
+This one sets a random/invalid input for icon, which results in the text input with NO icon. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js
 
 ```jsx
 import validateMinMaxFactory from '../../validators/validateMinMax'

--- a/src/components/TextInput/TextInput.md
+++ b/src/components/TextInput/TextInput.md
@@ -45,7 +45,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `solid lock icon`, which results in the text input with solid lock icon. `iconPrefix="fas"` is the prefix for solid icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix.
+This one sets a `solid lock icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
 
 ```jsx
 import validateMinMaxFactory from '../../validators/validateMinMax'
@@ -65,12 +65,11 @@ const formChangeHandlerStub = () => {}
     if (!!minMaxErr) return minMaxErr
     return x.length % 2 ? 'Text does not have an even number of characters' : ''
   }}
-  iconPrefix="fas"
-  iconName="lock"
+  icon='lock'
 />
 ```
 
-This one sets a `regular eye-slash icon`, which results in the text input with regular eye-slash icon. `iconPrefix="far"` is the prefix for regular icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix.
+This one sets a `regular eye-slash icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
 
 ```jsx
 import validateMinMaxFactory from '../../validators/validateMinMax'
@@ -90,12 +89,11 @@ const formChangeHandlerStub = () => {}
     if (!!minMaxErr) return minMaxErr
     return x.length % 2 ? 'Text does not have an even number of characters' : ''
   }}
-  iconPrefix="far"
-  iconName="eye-slash"
+  icon='eye_slash'
 />
 ```
 
-This one sets a random/invalid input for iconPrefix and iconName, which results in the text input with NO icon.
+This one sets a random/invalid input for icon, which results in the text input with NO icon. Currently allowed icons are defined by valid_icons at src/helpers/constants.js
 
 ```jsx
 import validateMinMaxFactory from '../../validators/validateMinMax'
@@ -115,7 +113,6 @@ const formChangeHandlerStub = () => {}
     if (!!minMaxErr) return minMaxErr
     return x.length % 2 ? 'Text does not have an even number of characters' : ''
   }}
-  iconPrefix="random1"
-  iconName="radom2"
+  icon='notallowed'
 />
 ```

--- a/src/components/TextInput/TextInput.md
+++ b/src/components/TextInput/TextInput.md
@@ -44,3 +44,53 @@ const formChangeHandlerStub = () => {}
   }}
 />
 ```
+
+This one sets a `solid lock icon`, which results in the text input with solid lock icon.
+
+```jsx
+import validateMinMaxFactory from '../../validators/validateMinMax'
+import validateExists from '../../validators/validateExists'
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+
+;<TextInput
+  name="example"
+  labelCopy="Validation happens after first blur ('touched')—Value's length % 2"
+  data-tid="the-text-input"
+  formChangeHandler={formChangeHandlerStub}
+  validator={(x) => {
+    const truthyErr = validateExists(x)
+    if (!!truthyErr) return truthyErr
+    const minMaxErr = validateMinMaxFactory(5, 20)(x)
+    if (!!minMaxErr) return minMaxErr
+    return x.length % 2 ? 'Text does not have an even number of characters' : ''
+  }}
+  iconPrefix="fas"
+  iconName="lock"
+/>
+```
+
+This one sets a `regular eye-slash icon`, which results in the text input with regular eye-slash icon.
+
+```jsx
+import validateMinMaxFactory from '../../validators/validateMinMax'
+import validateExists from '../../validators/validateExists'
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+
+;<TextInput
+  name="example"
+  labelCopy="Validation happens after first blur ('touched')—Value's length % 2"
+  data-tid="the-text-input"
+  formChangeHandler={formChangeHandlerStub}
+  validator={(x) => {
+    const truthyErr = validateExists(x)
+    if (!!truthyErr) return truthyErr
+    const minMaxErr = validateMinMaxFactory(5, 20)(x)
+    if (!!minMaxErr) return minMaxErr
+    return x.length % 2 ? 'Text does not have an even number of characters' : ''
+  }}
+  iconPrefix="far"
+  iconName="eye-slash"
+/>
+```

--- a/src/components/TextInput/TextInput.md
+++ b/src/components/TextInput/TextInput.md
@@ -45,7 +45,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `solid lock icon`, which results in the text input with solid lock icon.
+This one sets a `solid lock icon`, which results in the text input with solid lock icon. `iconPrefix="fas"` is the prefix for solid icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix.
 
 ```jsx
 import validateMinMaxFactory from '../../validators/validateMinMax'
@@ -70,7 +70,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `regular eye-slash icon`, which results in the text input with regular eye-slash icon.
+This one sets a `regular eye-slash icon`, which results in the text input with regular eye-slash icon. `iconPrefix="far"` is the prefix for regular icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix.
 
 ```jsx
 import validateMinMaxFactory from '../../validators/validateMinMax'
@@ -92,5 +92,30 @@ const formChangeHandlerStub = () => {}
   }}
   iconPrefix="far"
   iconName="eye-slash"
+/>
+```
+
+This one sets a random/invalid input for iconPrefix and iconName, which results in the text input with NO icon.
+
+```jsx
+import validateMinMaxFactory from '../../validators/validateMinMax'
+import validateExists from '../../validators/validateExists'
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+
+;<TextInput
+  name="example"
+  labelCopy="Validation happens after first blur ('touched')—Value's length % 2"
+  data-tid="the-text-input"
+  formChangeHandler={formChangeHandlerStub}
+  validator={(x) => {
+    const truthyErr = validateExists(x)
+    if (!!truthyErr) return truthyErr
+    const minMaxErr = validateMinMaxFactory(5, 20)(x)
+    if (!!minMaxErr) return minMaxErr
+    return x.length % 2 ? 'Text does not have an even number of characters' : ''
+  }}
+  iconPrefix="random1"
+  iconName="radom2"
 />
 ```

--- a/src/components/TextInput/TextInput.module.scss
+++ b/src/components/TextInput/TextInput.module.scss
@@ -59,12 +59,12 @@
 }
 
 .TextInputIcon{
-  width:14px;
-  height:18px;
+  width: 14px;
+  height: 18px;
   margin: 3px 5px;
   color: #c2c2c2;
 }
 
 .hasIcon{
-  padding-right:50px;
+  padding-right: 50px;
 }

--- a/src/components/TextInput/TextInput.module.scss
+++ b/src/components/TextInput/TextInput.module.scss
@@ -46,3 +46,25 @@
   background-color: var(--GrayStrokeAndDisabled--translucent);
   border-color: transparent;
 }
+
+.TextInputWrapper{
+  position: relative;
+}
+
+.TextInputIconWrapper{
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 16px;
+}
+
+.TextInputIcon{
+  width:14px;
+  height:18px;
+  margin: 3px 5px;
+  color: #c2c2c2;
+}
+
+.hasIcon{
+  padding-right:50px;
+}

--- a/src/components/TextInput/TextInput.module.scss
+++ b/src/components/TextInput/TextInput.module.scss
@@ -47,24 +47,24 @@
   border-color: transparent;
 }
 
-.TextInputWrapper{
+.TextInputWrapper {
   position: relative;
 }
 
-.TextInputIconWrapper{
+.TextInputIconWrapper {
   position: absolute;
   top: 0;
   right: 0;
   padding: 16px;
 }
 
-.TextInputIcon{
+.TextInputIcon {
   width: 14px;
   height: 18px;
   margin: 3px 5px;
   color: #c2c2c2;
 }
 
-.hasIcon{
+.hasIcon {
   padding-right: 50px;
 }

--- a/src/components/TextInput/__snapshots__/TextInput.test.js.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.js.snap
@@ -32,7 +32,6 @@ Array [
       type="text"
       value=""
     />
-    
   </div>,
   "",
 ]

--- a/src/components/TextInput/__snapshots__/TextInput.test.js.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.js.snap
@@ -17,18 +17,23 @@ Array [
       }
     }
   />,
-  <input
-    aria-label="nombre"
-    autoComplete="name"
-    className="TextInputCommon TextInputStylable"
-    data-tid="the-text-input"
-    name="nombre"
-    onBlur={[Function]}
-    onChange={[Function]}
-    placeholder=""
-    type="text"
-    value=""
-  />,
+  <div
+    className="TextInputWrapper"
+  >
+    <input
+      aria-label="nombre"
+      autoComplete="name"
+      className="TextInputCommon TextInputStylable"
+      data-tid="the-text-input"
+      name="nombre"
+      onBlur={[Function]}
+      onChange={[Function]}
+      placeholder=""
+      type="text"
+      value=""
+    />
+    
+  </div>,
   "",
 ]
 `;

--- a/src/components/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/TextMaskedInput/TextMaskedInput.js
@@ -181,14 +181,20 @@ TextMaskedInput.PUBLIC_PROPS = {
   labelWeight: PropTypes.string,
   labelClasses: PropTypes.string,
   maxLength: PropTypes.number,
-  iconPrefix: PropTypes.string,
   /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
-  iconName: PropTypes.string,
+  iconPrefix: PropTypes.string,
   /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
+  iconName: PropTypes.string,
 }
 
 TextMaskedInput.propTypes = {
   ...TextMaskedInput.PUBLIC_PROPS,
+  /** text transform capitalize label */
+  capitalize: PropTypes.bool,
+  /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
+  iconPrefix: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
+  iconName: PropTypes.string,
 }
 
 TextMaskedInput.defaultProps = {

--- a/src/components/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/TextMaskedInput/TextMaskedInput.js
@@ -9,6 +9,7 @@ import cleanse from '../../helpers/cleanse.js'
 
 import styles from '../TextInput/TextInput.module.scss'
 import errorStyles from '../Errors.module.scss'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 export const TextMaskedInput = (props) => {
   const {
@@ -30,6 +31,8 @@ export const TextMaskedInput = (props) => {
     autoComplete,
     classOverrides,
     maxLength,
+    iconPrefix,
+    iconName,
     ...restProps
   } = props
 
@@ -118,6 +121,9 @@ export const TextMaskedInput = (props) => {
     maskedInputProps.pipe = restProps.pipe
   }
 
+  // hasIcon class indicates the text input has icon, to give more padding-right in stylings,to prevent overlapping between icon and long input
+  const maskedInputClass = `${styles.TextInputCommon} ${styles.TextInputStylable} ${styles.hasIcon}`
+
   return (
     <>
       <InputLabel
@@ -129,9 +135,21 @@ export const TextMaskedInput = (props) => {
         allCaps={allCaps}
         capitalize={capitalize}
       />
-
-      <MaskedInput {...maskedInputProps} />
-
+      <div className={styles.TextInputWrapper}>
+        {iconPrefix && iconName ? (
+          <MaskedInput {...maskedInputProps} className={maskedInputClass} />
+        ) : (
+          <MaskedInput {...maskedInputProps} />
+        )}
+        {iconPrefix && iconName && (
+          <div className={styles.TextInputIconWrapper}>
+            <FontAwesomeIcon
+              icon={[iconPrefix, iconName]}
+              className={styles.TextInputIcon}
+            />
+          </div>
+        )}
+      </div>
       {!doValidation && getError(currentError, whichTouched)}
     </>
   )
@@ -163,6 +181,8 @@ TextMaskedInput.PUBLIC_PROPS = {
   labelWeight: PropTypes.string,
   labelClasses: PropTypes.string,
   maxLength: PropTypes.number,
+  iconPrefix: PropTypes.string,
+  iconName: PropTypes.string,
 }
 
 TextMaskedInput.propTypes = {
@@ -175,4 +195,6 @@ TextMaskedInput.defaultProps = {
   keepCharPositions: true,
   disabled: false,
   allCaps: true,
+  iconPrefix: '',
+  iconName: '',
 }

--- a/src/components/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/TextMaskedInput/TextMaskedInput.js
@@ -182,7 +182,9 @@ TextMaskedInput.PUBLIC_PROPS = {
   labelClasses: PropTypes.string,
   maxLength: PropTypes.number,
   iconPrefix: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
   iconName: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
 }
 
 TextMaskedInput.propTypes = {

--- a/src/components/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/TextMaskedInput/TextMaskedInput.js
@@ -10,6 +10,7 @@ import cleanse from '../../helpers/cleanse.js'
 import styles from '../TextInput/TextInput.module.scss'
 import errorStyles from '../Errors.module.scss'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { valid_icons } from '../../helpers/constants.js'
 
 export const TextMaskedInput = (props) => {
   const {
@@ -31,8 +32,7 @@ export const TextMaskedInput = (props) => {
     autoComplete,
     classOverrides,
     maxLength,
-    iconPrefix,
-    iconName,
+    icon,
     ...restProps
   } = props
 
@@ -136,17 +136,15 @@ export const TextMaskedInput = (props) => {
         capitalize={capitalize}
       />
       <div className={styles.TextInputWrapper}>
-        {(iconPrefix === 'fas' && iconName === 'lock') ||
-        (iconPrefix === 'far' && iconName === 'eye-slash') ? (
+        {icon ? (
           <MaskedInput {...maskedInputProps} className={maskedInputClass} />
         ) : (
           <MaskedInput {...maskedInputProps} />
         )}
-        {((iconPrefix === 'fas' && iconName === 'lock') ||
-          (iconPrefix === 'far' && iconName === 'eye-slash')) && (
+        {Object.keys(valid_icons).includes(icon) && (
           <div className={styles.TextInputIconWrapper}>
             <FontAwesomeIcon
-              icon={[iconPrefix, iconName]}
+              icon={[valid_icons[icon].prefix, valid_icons[icon].name]}
               className={styles.TextInputIcon}
             />
           </div>
@@ -183,20 +181,16 @@ TextMaskedInput.PUBLIC_PROPS = {
   labelWeight: PropTypes.string,
   labelClasses: PropTypes.string,
   maxLength: PropTypes.number,
-  /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
-  iconPrefix: PropTypes.string,
-  /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
-  iconName: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by valid_icons at src/helpers/constants.js */
+  icon: PropTypes.oneOf(Object.keys(valid_icons)),
 }
 
 TextMaskedInput.propTypes = {
   ...TextMaskedInput.PUBLIC_PROPS,
   /** text transform capitalize label */
   capitalize: PropTypes.bool,
-  /** iconPrefix and iconName work together to render icon in input; Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. e.g. `iconPrefix="fas"` is the prefix for solid icons; `iconPrefix="far"` is the prefix for regular icons.*/
-  iconPrefix: PropTypes.string,
-  /** iconPrefix and iconName work together to render icon in input; Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. */
-  iconName: PropTypes.string,
+  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by valid_icons at src/helpers/constants.js */
+  icon: PropTypes.oneOf(Object.keys(valid_icons)),
 }
 
 TextMaskedInput.defaultProps = {
@@ -205,6 +199,4 @@ TextMaskedInput.defaultProps = {
   keepCharPositions: true,
   disabled: false,
   allCaps: true,
-  iconPrefix: '',
-  iconName: '',
 }

--- a/src/components/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/TextMaskedInput/TextMaskedInput.js
@@ -10,7 +10,7 @@ import cleanse from '../../helpers/cleanse.js'
 import styles from '../TextInput/TextInput.module.scss'
 import errorStyles from '../Errors.module.scss'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { valid_icons } from '../../helpers/constants.js'
+import { VALID_ICONS } from '../../helpers/constants.js'
 
 export const TextMaskedInput = (props) => {
   const {
@@ -141,10 +141,10 @@ export const TextMaskedInput = (props) => {
         ) : (
           <MaskedInput {...maskedInputProps} />
         )}
-        {Object.keys(valid_icons).includes(icon) && (
+        {Object.keys(VALID_ICONS).includes(icon) && (
           <div className={styles.TextInputIconWrapper}>
             <FontAwesomeIcon
-              icon={[valid_icons[icon].prefix, valid_icons[icon].name]}
+              icon={[VALID_ICONS[icon].prefix, VALID_ICONS[icon].name]}
               className={styles.TextInputIcon}
             />
           </div>
@@ -181,16 +181,16 @@ TextMaskedInput.PUBLIC_PROPS = {
   labelWeight: PropTypes.string,
   labelClasses: PropTypes.string,
   maxLength: PropTypes.number,
-  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by valid_icons at src/helpers/constants.js */
-  icon: PropTypes.oneOf(Object.keys(valid_icons)),
+  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js */
+  icon: PropTypes.oneOf(Object.keys(VALID_ICONS)),
 }
 
 TextMaskedInput.propTypes = {
   ...TextMaskedInput.PUBLIC_PROPS,
   /** text transform capitalize label */
   capitalize: PropTypes.bool,
-  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by valid_icons at src/helpers/constants.js */
-  icon: PropTypes.oneOf(Object.keys(valid_icons)),
+  /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js */
+  icon: PropTypes.oneOf(Object.keys(VALID_ICONS)),
 }
 
 TextMaskedInput.defaultProps = {

--- a/src/components/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/TextMaskedInput/TextMaskedInput.js
@@ -136,12 +136,14 @@ export const TextMaskedInput = (props) => {
         capitalize={capitalize}
       />
       <div className={styles.TextInputWrapper}>
-        {iconPrefix && iconName ? (
+        {(iconPrefix === 'fas' && iconName === 'lock') ||
+        (iconPrefix === 'far' && iconName === 'eye-slash') ? (
           <MaskedInput {...maskedInputProps} className={maskedInputClass} />
         ) : (
           <MaskedInput {...maskedInputProps} />
         )}
-        {iconPrefix && iconName && (
+        {((iconPrefix === 'fas' && iconName === 'lock') ||
+          (iconPrefix === 'far' && iconName === 'eye-slash')) && (
           <div className={styles.TextInputIconWrapper}>
             <FontAwesomeIcon
               icon={[iconPrefix, iconName]}

--- a/src/components/TextMaskedInput/TextMaskedInput.md
+++ b/src/components/TextMaskedInput/TextMaskedInput.md
@@ -47,7 +47,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `solid lock icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
+This one sets a `solid lock icon`. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js.
 ```jsx
 // formChangeHandler gets wired up automatically if using <Form /> component
 const formChangeHandlerStub = () => {}
@@ -66,7 +66,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `regular eye-slash icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
+This one sets a `regular eye-slash icon`. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js.
 ```jsx
 // formChangeHandler gets wired up automatically if using <Form /> component
 const formChangeHandlerStub = () => {}
@@ -85,7 +85,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a random/invalid input for icon, which results in the text masked input with NO icon. Currently allowed icons are defined by valid_icons at src/helpers/constants.js
+This one sets a random/invalid input for icon, which results in the text masked input with NO icon. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js
 ```jsx
 // formChangeHandler gets wired up automatically if using <Form /> component
 const formChangeHandlerStub = () => {}

--- a/src/components/TextMaskedInput/TextMaskedInput.md
+++ b/src/components/TextMaskedInput/TextMaskedInput.md
@@ -46,3 +46,67 @@ const formChangeHandlerStub = () => {}
   }}
 />
 ```
+
+This one sets a `solid lock icon`, which results in the text masked input with solid lock icon. `iconPrefix="fas"` is the prefix for solid icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix.
+```jsx
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+;<TextMaskedInput
+  placeholder="0000"
+  mask={[/\d/, /\d/, /\d/, /\d/]}
+  guide={true}
+  keepCharPositions={true}
+  type='text'
+  formChangeHandler={formChangeHandlerStub}
+  name="last4-ssn"
+  labelCopy="Last 4 SSN Example"
+  data-tid="last4-ssn-example"
+  validator={(value) => value && value.length === 4 ? '' : 'Four digits required'}
+  iconPrefix="fas"
+  iconName="lock"
+/>
+```
+
+This one sets a `regular eye-slash icon`, which results in the text masked input with regular eye-slash icon. `iconPrefix="far"` is the prefix for regular icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix.
+```jsx
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+;<TextMaskedInput
+  placeholder="0000"
+  mask={[/\d/, /\d/, /\d/, /\d/]}
+  guide={true}
+  keepCharPositions={true}
+  type='text'
+  formChangeHandler={formChangeHandlerStub}
+  name="last4-ssn"
+  labelCopy="Last 4 SSN Example"
+  data-tid="last4-ssn-example"
+  validator={(value) => value && value.length === 4 ? '' : 'Four digits required'}
+  iconPrefix="fas"
+  iconName="lock"
+  iconPrefix="far"
+  iconName="eye-slash"
+/>
+```
+
+This one sets a random/invalid input for iconPrefix and iconName, which results in the text masked input with NO icon.
+```jsx
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+;<TextMaskedInput
+  placeholder="0000"
+  mask={[/\d/, /\d/, /\d/, /\d/]}
+  guide={true}
+  keepCharPositions={true}
+  type='text'
+  formChangeHandler={formChangeHandlerStub}
+  name="last4-ssn"
+  labelCopy="Last 4 SSN Example"
+  data-tid="last4-ssn-example"
+  validator={(value) => value && value.length === 4 ? '' : 'Four digits required'}
+  iconPrefix="fas"
+  iconName="lock"
+  iconPrefix="dgiouee"
+  iconName="46436"
+/>
+```

--- a/src/components/TextMaskedInput/TextMaskedInput.md
+++ b/src/components/TextMaskedInput/TextMaskedInput.md
@@ -47,7 +47,7 @@ const formChangeHandlerStub = () => {}
 />
 ```
 
-This one sets a `solid lock icon`, which results in the text masked input with solid lock icon. `iconPrefix="fas"` is the prefix for solid icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix.
+This one sets a `solid lock icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
 ```jsx
 // formChangeHandler gets wired up automatically if using <Form /> component
 const formChangeHandlerStub = () => {}
@@ -62,12 +62,11 @@ const formChangeHandlerStub = () => {}
   labelCopy="Last 4 SSN Example"
   data-tid="last4-ssn-example"
   validator={(value) => value && value.length === 4 ? '' : 'Four digits required'}
-  iconPrefix="fas"
-  iconName="lock"
+  icon='lock'
 />
 ```
 
-This one sets a `regular eye-slash icon`, which results in the text masked input with regular eye-slash icon. `iconPrefix="far"` is the prefix for regular icons. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix.
+This one sets a `regular eye-slash icon`. Currently allowed icons are defined by valid_icons at src/helpers/constants.js.
 ```jsx
 // formChangeHandler gets wired up automatically if using <Form /> component
 const formChangeHandlerStub = () => {}
@@ -82,14 +81,11 @@ const formChangeHandlerStub = () => {}
   labelCopy="Last 4 SSN Example"
   data-tid="last4-ssn-example"
   validator={(value) => value && value.length === 4 ? '' : 'Four digits required'}
-  iconPrefix="fas"
-  iconName="lock"
-  iconPrefix="far"
-  iconName="eye-slash"
+  icon='eye_slash'
 />
 ```
 
-This one sets a random/invalid input for iconPrefix and iconName, which results in the text masked input with NO icon.
+This one sets a random/invalid input for icon, which results in the text masked input with NO icon. Currently allowed icons are defined by valid_icons at src/helpers/constants.js
 ```jsx
 // formChangeHandler gets wired up automatically if using <Form /> component
 const formChangeHandlerStub = () => {}
@@ -104,9 +100,6 @@ const formChangeHandlerStub = () => {}
   labelCopy="Last 4 SSN Example"
   data-tid="last4-ssn-example"
   validator={(value) => value && value.length === 4 ? '' : 'Four digits required'}
-  iconPrefix="fas"
-  iconName="lock"
-  iconPrefix="dgiouee"
-  iconName="46436"
+  icon='random'
 />
 ```

--- a/src/components/ZipInput/__snapshots__/ZipInput.test.js.snap
+++ b/src/components/ZipInput/__snapshots__/ZipInput.test.js.snap
@@ -43,7 +43,6 @@ Array [
       type="tel"
       value=""
     />
-    
   </div>,
   "",
 ]

--- a/src/components/ZipInput/__snapshots__/ZipInput.test.js.snap
+++ b/src/components/ZipInput/__snapshots__/ZipInput.test.js.snap
@@ -17,29 +17,34 @@ Array [
       }
     }
   />,
-  <input
-    autoComplete="postal-code"
-    className="TextMaskedInput TextInputCommon TextInputStylable"
-    data-tid="le-zip"
-    disabled={false}
-    guide={true}
-    keepCharPositions={true}
-    mask={
-      Array [
-        /\\\\d/,
-        /\\\\d/,
-        /\\\\d/,
-        /\\\\d/,
-        /\\\\d/,
-      ]
-    }
-    name="le-zip"
-    onBlur={[Function]}
-    onChange={[Function]}
-    placeholder=""
-    type="tel"
-    value=""
-  />,
+  <div
+    className="TextInputWrapper"
+  >
+    <input
+      autoComplete="postal-code"
+      className="TextMaskedInput TextInputCommon TextInputStylable"
+      data-tid="le-zip"
+      disabled={false}
+      guide={true}
+      keepCharPositions={true}
+      mask={
+        Array [
+          /\\\\d/,
+          /\\\\d/,
+          /\\\\d/,
+          /\\\\d/,
+          /\\\\d/,
+        ]
+      }
+      name="le-zip"
+      onBlur={[Function]}
+      onChange={[Function]}
+      placeholder=""
+      type="tel"
+      value=""
+    />
+    
+  </div>,
   "",
 ]
 `;

--- a/src/components/fa.js
+++ b/src/components/fa.js
@@ -22,6 +22,8 @@ import { faHamburger } from '@fortawesome/pro-regular-svg-icons/faHamburger'
 import { faSort } from '@fortawesome/pro-solid-svg-icons/faSort'
 import { faSortDown } from '@fortawesome/pro-solid-svg-icons/faSortDown'
 import { faSortUp } from '@fortawesome/pro-solid-svg-icons/faSortUp'
+import { faLock } from '@fortawesome/pro-solid-svg-icons/faLock'
+import { faEyeSlash } from '@fortawesome/pro-regular-svg-icons/faEyeSlash'
 
 // Nora Icons
 import { faAlignLeft } from '@fortawesome/pro-solid-svg-icons/faAlignLeft'
@@ -119,5 +121,7 @@ library.add(
   faWindowClose,
   faSignOut,
   faSyncAlt,
-  faBell
+  faBell,
+  faLock,
+  faEyeSlash
 )

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -792,7 +792,7 @@ export declare const Tooltip: {
   propTypes: TooltipProps
 }
 
-// Icontypes, consistent with valid_icons at src/helpers/constants.js
+// Icontypes, consistent with VALID_ICONS at src/helpers/constants.js
 export type IconTypes = 
  |'eye_slash'
  | 'lock'

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -747,14 +747,11 @@ export declare const EmailInput: {
     labelClasses?: string
     validator?: (value: string) => string
     initialValue?: string
-    iconPrefix?: string
-    iconName?: string
+    icon?: IconTypes
   }
   defaultProps: {
     labelCopy: string
     placeholder: string
-    iconPrefix: string
-    iconName: string
   }
 }
 
@@ -795,6 +792,11 @@ export declare const Tooltip: {
   propTypes: TooltipProps
 }
 
+// Icontypes, consistent with valid_icons at src/helpers/constants.js
+export type IconTypes = 
+ |'eye_slash'
+ | 'lock'
+
 export declare const TextMaskedInput: {
   (props: any): JSX.Element
   PUBLIC_PROPS: {
@@ -818,8 +820,7 @@ export declare const TextMaskedInput: {
     placeholderChar?: string
     formChangeHandler?: (value: string, errorValue: string) => void
     maxLength?: number
-    iconPrefix?: string
-    iconName?: string
+    icon?: IconTypes
   }
   propTypes: {
     mask: (mask: (string | RegExp)[]) => any
@@ -842,8 +843,7 @@ export declare const TextMaskedInput: {
     placeholderChar?: string
     formChangeHandler?: (value: string, errorValue: string) => void
     maxLength?: number
-    iconPrefix?: string
-    iconName?: string
+    icon?: IconTypes
   }
   defaultProps: {
     placeholder: string
@@ -851,8 +851,6 @@ export declare const TextMaskedInput: {
     keepCharPositions: boolean
     disabled: boolean
     allCaps: boolean
-    iconPrefix: string
-    iconName: string
   }
 }
 
@@ -1258,14 +1256,11 @@ export declare const NumberInput: {
     guide?: boolean
     keepCharPositions?: boolean
     maxLength?: number
-    iconPrefix?: string
-    iconName?: string
+    icon?: IconTypes
   }
   defaultProps: {
     type: string
     mask: (mask: (string | RegExp)[]) => any
-    iconPrefix: string
-    iconName: string
   }
 }
 

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -739,10 +739,14 @@ export declare const EmailInput: {
     labelClasses?: string
     validator?: (value: string) => string
     initialValue?: string
+    iconPrefix?: string
+    iconName?: string
   }
   defaultProps: {
     labelCopy: string
     placeholder: string
+    iconPrefix: string
+    iconName: string
   }
 }
 
@@ -806,6 +810,8 @@ export declare const TextMaskedInput: {
     placeholderChar?: string
     formChangeHandler?: (value: string, errorValue: string) => void
     maxLength?: number
+    iconPrefix?: string
+    iconName?: string
   }
   propTypes: {
     mask: (mask: (string | RegExp)[]) => any
@@ -828,6 +834,8 @@ export declare const TextMaskedInput: {
     placeholderChar?: string
     formChangeHandler?: (value: string, errorValue: string) => void
     maxLength?: number
+    iconPrefix?: string
+    iconName?: string
   }
   defaultProps: {
     placeholder: string
@@ -835,6 +843,8 @@ export declare const TextMaskedInput: {
     keepCharPositions: boolean
     disabled: boolean
     allCaps: boolean
+    iconPrefix: string
+    iconName: string
   }
 }
 
@@ -1240,10 +1250,14 @@ export declare const NumberInput: {
     guide?: boolean
     keepCharPositions?: boolean
     maxLength?: number
+    iconPrefix?: string
+    iconName?: string
   }
   defaultProps: {
     type: string
     mask: (mask: (string | RegExp)[]) => any
+    iconPrefix: string
+    iconName: string
   }
 }
 

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -17,7 +17,7 @@ export const codes = {
   TAB: 9,
 }
 
-export const valid_icons = {
+export const VALID_ICONS = {
   eye_slash: {
     prefix: 'far',
     name: 'eye-slash',

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -16,3 +16,14 @@ export const codes = {
   DOWN: 40,
   TAB: 9,
 }
+
+export const valid_icons = {
+  eye_slash: {
+    prefix: 'far',
+    name: 'eye-slash',
+  },
+  lock: {
+    prefix: 'fas',
+    name: 'lock',
+  },
+}


### PR DESCRIPTION
## [Jira Task](https://ethoslife.atlassian.net/browse/GC-812)
## [Jira Task](https://ethoslife.atlassian.net/browse/GC-813)

### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)
- [x] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version? (=> will do after review)

### Referencing PR or Branch (e.g. in CMS or monorepo):

-

### Screenshots and extra notes:
- added options: iconName and iconPrefix to TextInput, EmailInput, NumberInput to allow icon display inside input
- related examples are added at markdown file for TextInput, EmailInput, NumberInput 
## email input screenshots
<img width="825" alt="image" src="https://user-images.githubusercontent.com/84494313/163015072-c2bd0d77-f585-4014-9b4a-b202648908be.png">

## number input screenshots
<img width="804" alt="image" src="https://user-images.githubusercontent.com/84494313/163015607-2e886031-65c7-4d2a-8747-72d14159cdad.png">

## text input screenshots
<img width="828" alt="image" src="https://user-images.githubusercontent.com/84494313/163015690-44bc9b7a-ce08-4db3-997e-51df74b210be.png">
