### PR TITLE
[Fix Warning Error] add empty string as one of Icon option for EmailInput, NumberInput, T…

### DIFF
--- a/src/components/EmailInput/EmailInput.js
+++ b/src/components/EmailInput/EmailInput.js
@@ -61,7 +61,7 @@ EmailInput.propTypes = {
   autoComplete: PropTypes.string,
   classOverrides: PropTypes.string,
   /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js */
-  icon: PropTypes.oneOf(Object.keys(VALID_ICONS)),
+  icon: PropTypes.oneOf([...Object.keys(VALID_ICONS), '']),
 }
 
 EmailInput.defaultProps = {

--- a/src/components/EmailInput/EmailInput.md
+++ b/src/components/EmailInput/EmailInput.md
@@ -103,3 +103,20 @@ const formChangeHandlerStub = () => {}
   icon="4dsagag"
 />
 ```
+
+This one sets an empty input for icon, which results in the email input with NO icon. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js
+```jsx
+import EmailFormatValidator from '../../validators/EmailValidator'
+import { EmailInput } from './index.js'
+const formChangeHandlerStub = () => {}
+;<EmailInput
+  name="the-email-input-example"
+  allCaps={true}
+  labelCopy="Your email"
+  data-tid="the-email-input"
+  placeholder="example@ethoslife.com"
+  validator={EmailFormatValidator}
+  formChangeHandler={formChangeHandlerStub}
+  icon=""
+/>
+```

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -92,7 +92,7 @@ NumberInput.propTypes = {
   autoComplete: PropTypes.string,
   maxLength: PropTypes.number,
   /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js */
-  icon: PropTypes.oneOf(Object.keys(VALID_ICONS)),
+  icon: PropTypes.oneOf([...Object.keys(VALID_ICONS), '']),
 }
 
 NumberInput.defaultProps = {

--- a/src/components/NumberInput/NumberInput.md
+++ b/src/components/NumberInput/NumberInput.md
@@ -130,3 +130,34 @@ const dollarMaskFunction = createNumberMask({
   icon="ewguoui"
 />
 ```
+
+
+This one sets an empty input for icon, which results in the number input with NO icon. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js
+```jsx
+import createNumberMask from 'text-mask-addons/dist/createNumberMask'
+import { NumberInput } from './index.js';
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+
+const dollarMaskFunction = createNumberMask({
+  allowDecimal: false,
+  allowLeadingZeroes: false,
+  guide: false,
+  includeThousandsSeparator: true,
+  prefix: '$',
+})
+
+;<NumberInput
+  mask={dollarMaskFunction}
+  name="dollar-input-example"
+  allCaps={true}
+  labelCopy="Enter a number (Must be less then $100,000)"
+  data-tid='dollar-number-input'
+  placeholder='Dollar via number input...'
+  formChangeHandler={formChangeHandlerStub}
+  validator={(n) => {
+    return n > 0 && n < 100000 ? '' : 'Must be less then $100,000'
+  }}
+  icon=""
+/>
+```

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -195,7 +195,7 @@ PrivateTextInput.PUBLIC_PROPS = {
   autoComplete: PropTypes.string,
   classOverrides: PropTypes.string,
   /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js */
-  icon: PropTypes.oneOf(Object.keys(VALID_ICONS)),
+  icon: PropTypes.oneOf([...Object.keys(VALID_ICONS), '']),
 }
 
 PrivateTextInput.propTypes = {
@@ -203,7 +203,7 @@ PrivateTextInput.propTypes = {
   /** text transform capitalize label */
   capitalize: PropTypes.bool,
   /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js */
-  icon: PropTypes.oneOf(Object.keys(VALID_ICONS)),
+  icon: PropTypes.oneOf([...Object.keys(VALID_ICONS), '']),
 }
 
 PrivateTextInput.defaultProps = {

--- a/src/components/TextInput/TextInput.md
+++ b/src/components/TextInput/TextInput.md
@@ -116,3 +116,26 @@ const formChangeHandlerStub = () => {}
   icon='notallowed'
 />
 ```
+This one sets an empty input for icon, which results in the text input with NO icon. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js
+
+```jsx
+import validateMinMaxFactory from '../../validators/validateMinMax'
+import validateExists from '../../validators/validateExists'
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+
+;<TextInput
+  name="example"
+  labelCopy="Validation happens after first blur ('touched')—Value's length % 2"
+  data-tid="the-text-input"
+  formChangeHandler={formChangeHandlerStub}
+  validator={(x) => {
+    const truthyErr = validateExists(x)
+    if (!!truthyErr) return truthyErr
+    const minMaxErr = validateMinMaxFactory(5, 20)(x)
+    if (!!minMaxErr) return minMaxErr
+    return x.length % 2 ? 'Text does not have an even number of characters' : ''
+  }}
+  icon=''
+/>
+```

--- a/src/components/TextMaskedInput/TextMaskedInput.js
+++ b/src/components/TextMaskedInput/TextMaskedInput.js
@@ -182,7 +182,7 @@ TextMaskedInput.PUBLIC_PROPS = {
   labelClasses: PropTypes.string,
   maxLength: PropTypes.number,
   /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js */
-  icon: PropTypes.oneOf(Object.keys(VALID_ICONS)),
+  icon: PropTypes.oneOf([...Object.keys(VALID_ICONS), '']),
 }
 
 TextMaskedInput.propTypes = {
@@ -190,7 +190,7 @@ TextMaskedInput.propTypes = {
   /** text transform capitalize label */
   capitalize: PropTypes.bool,
   /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js */
-  icon: PropTypes.oneOf(Object.keys(VALID_ICONS)),
+  icon: PropTypes.oneOf([...Object.keys(VALID_ICONS), '']),
 }
 
 TextMaskedInput.defaultProps = {

--- a/src/components/TextMaskedInput/TextMaskedInput.md
+++ b/src/components/TextMaskedInput/TextMaskedInput.md
@@ -103,3 +103,22 @@ const formChangeHandlerStub = () => {}
   icon='random'
 />
 ```
+
+This one sets an empty input for icon, which results in the text masked input with NO icon. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js
+```jsx
+// formChangeHandler gets wired up automatically if using <Form /> component
+const formChangeHandlerStub = () => {}
+;<TextMaskedInput
+  placeholder="0000"
+  mask={[/\d/, /\d/, /\d/, /\d/]}
+  guide={true}
+  keepCharPositions={true}
+  type='text'
+  formChangeHandler={formChangeHandlerStub}
+  name="last4-ssn"
+  labelCopy="Last 4 SSN Example"
+  data-tid="last4-ssn-example"
+  validator={(value) => value && value.length === 4 ? '' : 'Four digits required'}
+  icon=''
+/>
+```


### PR DESCRIPTION
…extInput, TestMaskedInput

## [No Jira Task]()

- fix warning error when inputting ''/empty string as one of icon option, to NOT show icon on EmailInput, NumberInput, TextInput, MaskedTextInput
- QA locally in .md file( screenshot below),  and also main app ( when ab testing for GC812&813&814 is original, with no icon), which do not have warning error in browser inspect

### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.ethoslabs.io/#/Guidelines?id=section-contribute)?
- [ ] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

-

### Screenshots and extra notes:

#### Updated .md file for EmailInput, NumberInput, TextInput, MaskedTextInput, to have icon = '', Which shows no warning error at inspect.

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/84494313/165977088-e6a45a82-ceef-40be-a2b5-6d844745c1b9.png">
