### PR TITLE
Fix Modal X button in Safari and Add style overrides for `NumberInput` Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.2.27",
+  "version": "1.2.28",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -35,6 +35,7 @@ export const NumberInput = (props) => {
     autoComplete,
     maxLength,
     icon,
+    classOverrides,
     ...restProps
   } = props
 
@@ -64,6 +65,7 @@ export const NumberInput = (props) => {
         autoComplete={autoComplete}
         maxLength={maxLength}
         icon={icon}
+        classOverrides={classOverrides}
       />
     </>
   )
@@ -93,6 +95,8 @@ NumberInput.propTypes = {
   maxLength: PropTypes.number,
   /** iconPrefix and iconName work together to render icon in input. Please refer to https://fontawesome.com/v5/docs/apis/javascript/import-icons for more information about iconPrefix. Please refer to `fa.js` and https://fontawesome.com for more info about icon's name. Currently allowed icons are defined by VALID_ICONS at src/helpers/constants.js */
   icon: PropTypes.oneOf(Object.keys(VALID_ICONS)),
+  /** passed down through component to override Inputstyles */
+  classOverrides: PropTypes.string,
 }
 
 NumberInput.defaultProps = {

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -36,6 +36,8 @@ export const NumberInput = (props) => {
     maxLength,
     icon,
     classOverrides,
+    labelWeight,
+    labelColor,
     ...restProps
   } = props
 
@@ -66,6 +68,8 @@ export const NumberInput = (props) => {
         maxLength={maxLength}
         icon={icon}
         classOverrides={classOverrides}
+        labelWeight={labelWeight}
+        labelColor={labelColor}
       />
     </>
   )
@@ -97,6 +101,10 @@ NumberInput.propTypes = {
   icon: PropTypes.oneOf(Object.keys(VALID_ICONS)),
   /** passed down through component to override Inputstyles */
   classOverrides: PropTypes.string,
+  /** passed down through component to override label weight */
+  labelWeight: PropTypes.string,
+  /** passed down through component to override label color */
+  labelColor: PropTypes.string,
 }
 
 NumberInput.defaultProps = {

--- a/src/components/Tooltip/Tooltip.module.scss
+++ b/src/components/Tooltip/Tooltip.module.scss
@@ -120,7 +120,7 @@
   width: calc(100vw - var(--Space-24));
   padding: var(--Space-64) var(--Space-24) var(--Space-80) var(--Space-24);
   max-height: 95vh;
-  overflow-y: scroll;
+  overflow-y: none;
 
   background: white;
   outline: none;

--- a/src/components/Tooltip/Tooltip.module.scss
+++ b/src/components/Tooltip/Tooltip.module.scss
@@ -120,8 +120,7 @@
   width: calc(100vw - var(--Space-24));
   padding: var(--Space-64) var(--Space-24) var(--Space-80) var(--Space-24);
   max-height: 95vh;
-  overflow-y: none;
-
+  overflow-y: auto;
   background: white;
   outline: none;
 
@@ -140,8 +139,8 @@
   }
 
   .closeButtonCircle {
-    width: var(--Space-12);
-    height: var(--Space-12);
+    width: var(--Space-32);
+    height: var(--Space-32);
     top: var(--Space-12);
     right: var(--Space-32);
     padding: 0;

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -1256,6 +1256,8 @@ export declare const NumberInput: {
     maxLength?: number
     icon?: IconTypes
     classOverrides?: string
+    labelColor?: string
+    labelWeight?: string
   }
   defaultProps: {
     type: string

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -1255,6 +1255,7 @@ export declare const NumberInput: {
     keepCharPositions?: boolean
     maxLength?: number
     icon?: IconTypes
+    classOverrides?: string
   }
   defaultProps: {
     type: string


### PR DESCRIPTION
### [Jira Task](https://ethoslife.atlassian.net/browse/GC-993)

### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [x] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?

### Screenshots and extra notes:
https://user-images.githubusercontent.com/84357906/176282490-dbb4226c-3827-45a5-8830-d5d98410c48a.mov