### PR TITLE
[GC-1561] Deprecate Media, remove react-responsive

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "prettier": "^1.16.3",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
-    "react-responsive": "^8.0.0",
     "react-styleguidist": "10.2.1",
     "react-test-renderer": "^16.9.0",
     "sass-loader": "^8.0.0",

--- a/src/components/Media/Media.js
+++ b/src/components/Media/Media.js
@@ -1,16 +1,4 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import MediaQuery from 'react-responsive'
-
 export const Media = {
-  PhoneOnly,
-  PhoneAndTablet,
-  TabletOnly,
-  TabletAndLaptop,
-  TabletAndUp,
-  LaptopOnly,
-  LaptopAndUp,
-  DesktopOnly,
   BREAKPOINTS: {
     PHONE_RANGE_END: 599,
     TABLET_RANGE_START: 600,
@@ -40,48 +28,3 @@ Media.QUERIES = {
   LAPTOP_AND_UP: `(min-width: ${Media.BREAKPOINTS.LAPTOP_RANGE_START}px)`,
   DESKTOP_ONLY: `(min-width: ${Media.BREAKPOINTS.DESKTOP_RANGE_START}px)`,
 }
-
-function PhoneOnly({ children }) {
-  return <MediaQuery query={Media.QUERIES.PHONE_ONLY}>{children}</MediaQuery>
-}
-
-function PhoneAndTablet({ children }) {
-  return (
-    <MediaQuery query={Media.QUERIES.PHONE_AND_TABLET}>{children}</MediaQuery>
-  )
-}
-
-function TabletOnly({ children }) {
-  return <MediaQuery query={Media.QUERIES.TABLET_ONLY}>{children}</MediaQuery>
-}
-
-function TabletAndLaptop({ children }) {
-  return (
-    <MediaQuery query={Media.QUERIES.TABLET_AND_LAPTOP}>{children}</MediaQuery>
-  )
-}
-
-function TabletAndUp({ children }) {
-  return <MediaQuery query={Media.QUERIES.TABLET_AND_UP}>{children}</MediaQuery>
-}
-
-function LaptopAndUp({ children }) {
-  return <MediaQuery query={Media.QUERIES.LAPTOP_AND_UP}>{children}</MediaQuery>
-}
-
-function LaptopOnly({ children }) {
-  return <MediaQuery query={Media.QUERIES.LAPTOP_ONLY}>{children}</MediaQuery>
-}
-
-function DesktopOnly({ children }) {
-  return <MediaQuery query={Media.QUERIES.DESKTOP_ONLY}>{children}</MediaQuery>
-}
-
-PhoneAndTablet.propTypes = { children: PropTypes.node.isRequired }
-PhoneOnly.propTypes = { children: PropTypes.node.isRequired }
-TabletAndLaptop.propTypes = { children: PropTypes.node.isRequired }
-TabletAndUp.propTypes = { children: PropTypes.node.isRequired }
-TabletOnly.propTypes = { children: PropTypes.node.isRequired }
-LaptopAndUp.propTypes = { children: PropTypes.node.isRequired }
-LaptopOnly.propTypes = { children: PropTypes.node.isRequired }
-DesktopOnly.propTypes = { children: PropTypes.node.isRequired }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3442,11 +3442,6 @@ css-loader@^3.2.0:
     schema-utils "^2.7.0"
     semver "^6.3.0"
 
-css-mediaquery@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/css-mediaquery/-/css-mediaquery-0.1.2.tgz#6a2c37344928618631c54bd33cedd301da18bea0"
-  integrity sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=
-
 css-select@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -5485,7 +5480,7 @@ husky@^3.0.9:
     run-node "^1.0.0"
     slash "^3.0.0"
 
-hyphenate-style-name@^1.0.0, hyphenate-style-name@^1.0.3:
+hyphenate-style-name@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
   integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
@@ -7141,13 +7136,6 @@ markdown-to-jsx@^6.10.3:
     prop-types "^15.6.2"
     unquote "^1.1.0"
 
-matchmediaquery@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/matchmediaquery/-/matchmediaquery-0.3.1.tgz#8247edc47e499ebb7c58f62a9ff9ccf5b815c6d7"
-  integrity sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==
-  dependencies:
-    css-mediaquery "^0.1.2"
-
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -8741,16 +8729,6 @@ react-popper@^1.3.7:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-responsive@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-8.1.0.tgz#afcc2293c46a37b1e7926ff7fef66bcb147e7cba"
-  integrity sha512-U8Nv2/ZWACIw/fAE9XNPbc2Xo33X5q1bcCASc2SufvJ9ifB+o/rokfogfznSVcvS22hN1rafGi0uZD6GiVFEHw==
-  dependencies:
-    hyphenate-style-name "^1.0.0"
-    matchmediaquery "^0.3.0"
-    prop-types "^15.6.1"
-    shallow-equal "^1.1.0"
-
 react-select@^3.0.8:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.1.0.tgz#ab098720b2e9fe275047c993f0d0caf5ded17c27"
@@ -9633,11 +9611,6 @@ shallow-clone@^3.0.0:
   integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
   dependencies:
     kind-of "^6.0.2"
-
-shallow-equal@^1.1.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
-  integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## [Jira Task](https://ethoslife.atlassian.net/browse/GC-1561)

### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [ ] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

-

### Screenshots and extra notes:
- Remove `Media` component and `react-responsive` dependency. This was already deprecated.
- Going to wait to create a version for this until after preload work is done.