### PR TITLE
Only fire trackingFunction in ToolTip once

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.2.39",
+  "version": "1.2.40",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -28,10 +28,17 @@ export const Tooltip = ({
   softCorners,
   trackingFunction,
 }) => {
+  const [analyticsFired, setAnalyticsFired] = useState(false)
   const [tooltipVisible, setTooltipVisibility] = useState(false)
   const [modalVisible, setModalVisibility] = useState(false)
   const debouncedSetTooltipVisibility = debounce(
-    (visibility) => setTooltipVisibility(visibility),
+    (visibility) => {
+      setTooltipVisibility(visibility)
+      if (visibility && !analyticsFired) {
+        trackingFunction()
+        setAnalyticsFired(true)
+      }
+    },
     300,
     {
       trailing: true,
@@ -45,13 +52,6 @@ export const Tooltip = ({
   }
 
   const modalStyle = [styles.mobileModal, softCorners ? styles.softCorners : '']
-
-  // Used for analytics event that indicates the Tooltip was displayed
-  useEffect(() => {
-    if (!!(tooltipVisible || modalVisible) && !!trackingFunction) {
-      trackingFunction()
-    }
-  }, [modalVisible, tooltipVisible])
 
   const renderModal = (
     <div>

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -34,7 +34,7 @@ export const Tooltip = ({
   const debouncedSetTooltipVisibility = debounce(
     (visibility) => {
       setTooltipVisibility(visibility)
-      if (visibility && !analyticsFired) {
+      if (trackingFunction && visibility && !analyticsFired) {
         trackingFunction()
         setAnalyticsFired(true)
       }

--- a/src/components/Tooltip/Tooltip.md
+++ b/src/components/Tooltip/Tooltip.md
@@ -8,7 +8,7 @@ To use a placeholder in its most basic form and with all defaults: provide two p
 import styles from './TooltipExamples.module.scss'
 ;<>
   <div className={styles.basicExample}>
-    Basic Tooltip <Tooltip label="Flip" details="Hi!" />
+    Basic Tooltip <Tooltip label="Flip" details="Hi!" trackingFunction={() => console.log('Analytics event!')}/>
   </div>
 </>
 ```


### PR DESCRIPTION
Follow up to #468 . Prevent excessive tracking events from firing on subsequent hovers or mobile modal interaction. 