### PR TITLE
Lower z-index for Modal to be compatible with nested BaseModal in main app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.2.43",
+  "version": "1.2.44",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Variables.scss
+++ b/src/components/Variables.scss
@@ -4,7 +4,7 @@
 
 $z-index-navbar: 1;
 $z-index-middle: 2;
-$z-index-backdrop: 99;
-$z-index-modal: 100;
+$z-index-backdrop: 10;
+$z-index-modal: 15;
 
 $navbar-border: solid 1px var(--GrayStrokeAndDisabled--translucent);


### PR DESCRIPTION
## Description to come

In main app the following z-index value are used for BaseModal:
```
$base-modal-backdrop-z-index: 20;
$base-modal-modal-z-index: 21;
```

This PR makes the EDS Modal have a lower z-index to account for when BaseModal is nested inside of EDS Modal, like with the ACH details on the payment modal in checkout.



## [Jira Task]()

### Please review these reminders and either check the box or explain why not:

- [ ] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [ ] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

-

### Screenshots and extra notes:
