### PR TITLE
[GC-1587] Remove data-srcset when not lazyloading

### DIFF
--- a/src/components/Images/Images.js
+++ b/src/components/Images/Images.js
@@ -85,14 +85,26 @@ export const CloudinaryImage = ({
   }
 
   const buildImageTag = (srcSet) => {
-    const srcSetString = srcSet
-      .map((url, index) => {
-        if (index === 0) return `${url} ${mediaBreakpoints[index] + 1}w`
-        return `${url} ${mediaBreakpoints[index - 1]}w`
-      })
-      .reverse()
-      .join(', ')
+    const srcSetString = []
+    const sizesString = []
 
+    if (width) {
+      srcSet.forEach((url, index) => {
+        if (!width[index]) return
+        srcSetString.push(`${url} ${width[index]}w`)
+      })
+
+      width.forEach((val, index) => {
+        if (!width[index]) return
+        if (index === width.length - 1) {
+          sizesString.push(`${val}px`)
+        } else {
+          sizesString.push(
+            `(max-width: ${mobileFirstMediaBreakpoints[index]}px) ${val}px`
+          )
+        }
+      })
+    }
     // srcSet is the LQIP image, src is the fallback image for older browsers
     // that do not support the 'srcSet' attribute (IE zero support)
     const srcString = createCloudinaryLegacyURL(filePath(publicId), {
@@ -109,7 +121,8 @@ export const CloudinaryImage = ({
         key={`${uuidv4()}`}
         className={[styles.Image, ...imageClasses].join(' ')}
         src={srcString}
-        srcSet={srcSetString}
+        srcSet={srcSetString.join(', ')}
+        sizes={sizesString.join(', ')}
         alt={alt}
         fetchpriority={fetchpriority}
       />
@@ -166,7 +179,7 @@ export const CloudinaryImage = ({
         })
       } else {
         Object.assign(sourceAttrs, {
-          srcset: srcsetData.join(', '),
+          srcSet: srcsetData.join(', '),
         })
       }
       tags.push(<source {...sourceAttrs} />)

--- a/src/components/Images/Images.js
+++ b/src/components/Images/Images.js
@@ -149,13 +149,27 @@ export const CloudinaryImage = ({
       })
 
       const minMax = breakpoint < mediaBreakpoints.length - 1 ? `min` : `max`
-      tags.push(
-        <source
-          key={`${uuidv4()}`}
-          media={`(${minMax}-width: ${mediaBreakpoints[breakpoint]}px)`}
-          data-srcset={srcsetData.join(', ')}
-        />
-      )
+
+      const sourceAttrs = {
+        key: uuidv4(),
+        media: `(${minMax}-width: ${mediaBreakpoints[breakpoint]}px)`,
+      }
+
+      /**
+       * if we're lazy-loading, use data-srcset which lazysizes will transform
+       * to srcset, if not, just use srcset so we get the benefits of the <picture>
+       * tag and don't just fallback on <img> tag.
+       */
+      if (lazyLoad) {
+        Object.assign(sourceAttrs, {
+          ['data-srcset']: srcsetData.join(', '),
+        })
+      } else {
+        Object.assign(sourceAttrs, {
+          srcset: srcsetData.join(', '),
+        })
+      }
+      tags.push(<source {...sourceAttrs} />)
 
       const urlWithChainedTransformation = createCloudinaryLegacyURL(
         filePath(publicId),

--- a/src/components/Images/Images.js
+++ b/src/components/Images/Images.js
@@ -84,6 +84,14 @@ export const CloudinaryImage = ({
     reverseHeight = height.slice().reverse()
   }
 
+  /**
+   * src is a fallback for extremely old browserss
+   * srcSet is a fallback for browsers that don't support <source>
+   *   It should be a list of "{url} {size}w,"
+   * sizes should map to sourceset
+   *   It should directly reference sizes in srcSet
+   *   "(max-width: {breakpoint}px) {size}px"
+   */
   const buildImageTag = (srcSet) => {
     const srcSetString = []
     const sizesString = []

--- a/src/components/Images/Images.spec.js
+++ b/src/components/Images/Images.spec.js
@@ -29,6 +29,22 @@ describe('CloudinaryImage', () => {
     })
   })
 
+  describe('no height/width arrays', () => {
+    test('CloudinaryImage', () => {
+      const tree = renderer
+        .create(
+          <CloudinaryImage
+            publicId="something.com/otherthing.png"
+            className="testImage"
+            alt="alt text"
+            lazyLoad={false}
+          />
+        )
+        .toJSON()
+      expect(tree).toMatchSnapshot()
+    })
+  })
+
   describe('non-lazy rendering, no data-srcset', () => {
     test('CloudinaryImage', () => {
       const tree = renderer

--- a/src/components/Images/Images.spec.js
+++ b/src/components/Images/Images.spec.js
@@ -29,6 +29,24 @@ describe('CloudinaryImage', () => {
     })
   })
 
+  describe('non-lazy rendering, no data-srcset', () => {
+    test('CloudinaryImage', () => {
+      const tree = renderer
+        .create(
+          <CloudinaryImage
+            publicId="something.com/otherthing.png"
+            className="testImage"
+            alt="alt text"
+            width={[100, 200, 300, 400]}
+            height={[100, 200, 300, 400]}
+            lazyLoad={false}
+          />
+        )
+        .toJSON()
+      expect(tree).toMatchSnapshot()
+    })
+  })
+
   describe('methods', () => {
     test('filePath', () => {
       expect(Images.CLOUDINARY_CLOUD_NAME).toBe('getethos')

--- a/src/components/Images/__snapshots__/Images.spec.js.snap
+++ b/src/components/Images/__snapshots__/Images.spec.js.snap
@@ -28,7 +28,7 @@ exports[`CloudinaryImage default rendering CloudinaryImage 1`] = `
 </picture>
 `;
 
-exports[`CloudinaryImage non-lazy rendering CloudinaryImage 1`] = `
+exports[`CloudinaryImage non-lazy rendering, no data-srcset CloudinaryImage 1`] = `
 <picture>
   <source
     media="(min-width: 1200px)"

--- a/src/components/Images/__snapshots__/Images.spec.js.snap
+++ b/src/components/Images/__snapshots__/Images.spec.js.snap
@@ -22,8 +22,38 @@ exports[`CloudinaryImage default rendering CloudinaryImage 1`] = `
     alt="alt text"
     className="Image testImage lazyload blurUp"
     fetchpriority="auto"
+    sizes="(max-width: 599px) 100px, (max-width: 899px) 200px, (max-width: 1199px) 300px, 400px"
     src="https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,q_auto:eco,t_unsupported/v1/something.com/otherthing.png"
-    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_100,q_auto:eco,t_lqip,w_100/v1/something.com/otherthing.png 600w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_200,q_auto:eco,t_lqip,w_200/v1/something.com/otherthing.png 900w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_300,q_auto:eco,t_lqip,w_300/v1/something.com/otherthing.png 1200w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_400,q_auto:eco,t_lqip,w_400/v1/something.com/otherthing.png 1201w"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_400,q_auto:eco,t_lqip,w_400/v1/something.com/otherthing.png 100w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_300,q_auto:eco,t_lqip,w_300/v1/something.com/otherthing.png 200w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_200,q_auto:eco,t_lqip,w_200/v1/something.com/otherthing.png 300w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_100,q_auto:eco,t_lqip,w_100/v1/something.com/otherthing.png 400w"
+  />
+</picture>
+`;
+
+exports[`CloudinaryImage no height/width arrays CloudinaryImage 1`] = `
+<picture>
+  <source
+    media="(min-width: 1200px)"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,q_auto:eco/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,q_auto:eco/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,q_auto:eco/v1/something.com/otherthing.png 3x"
+  />
+  <source
+    media="(min-width: 900px)"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,q_auto:eco/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,q_auto:eco/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,q_auto:eco/v1/something.com/otherthing.png 3x"
+  />
+  <source
+    media="(min-width: 600px)"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,q_auto:eco/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,q_auto:eco/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,q_auto:eco/v1/something.com/otherthing.png 3x"
+  />
+  <source
+    media="(max-width: 599px)"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,q_auto:eco/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,q_auto:eco/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,q_auto:eco/v1/something.com/otherthing.png 3x"
+  />
+  <img
+    alt="alt text"
+    className="Image testImage"
+    fetchpriority="auto"
+    sizes=""
+    src="https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,q_auto:eco,t_unsupported/v1/something.com/otherthing.png"
+    srcSet=""
   />
 </picture>
 `;
@@ -32,26 +62,27 @@ exports[`CloudinaryImage non-lazy rendering, no data-srcset CloudinaryImage 1`] 
 <picture>
   <source
     media="(min-width: 1200px)"
-    srcset="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 3x"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 3x"
   />
   <source
     media="(min-width: 900px)"
-    srcset="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 3x"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 3x"
   />
   <source
     media="(min-width: 600px)"
-    srcset="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 3x"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 3x"
   />
   <source
     media="(max-width: 599px)"
-    srcset="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 3x"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 3x"
   />
   <img
     alt="alt text"
     className="Image testImage"
     fetchpriority="auto"
+    sizes="(max-width: 599px) 100px, (max-width: 899px) 200px, (max-width: 1199px) 300px, 400px"
     src="https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,q_auto:eco,t_unsupported/v1/something.com/otherthing.png"
-    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 600w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 900w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 1200w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 1201w"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 100w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 200w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 300w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 400w"
   />
 </picture>
 `;

--- a/src/components/Images/__snapshots__/Images.spec.js.snap
+++ b/src/components/Images/__snapshots__/Images.spec.js.snap
@@ -27,3 +27,31 @@ exports[`CloudinaryImage default rendering CloudinaryImage 1`] = `
   />
 </picture>
 `;
+
+exports[`CloudinaryImage non-lazy rendering CloudinaryImage 1`] = `
+<picture>
+  <source
+    media="(min-width: 1200px)"
+    srcset="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 3x"
+  />
+  <source
+    media="(min-width: 900px)"
+    srcset="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 3x"
+  />
+  <source
+    media="(min-width: 600px)"
+    srcset="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 3x"
+  />
+  <source
+    media="(max-width: 599px)"
+    srcset="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 3x"
+  />
+  <img
+    alt="alt text"
+    className="Image testImage"
+    fetchpriority="auto"
+    src="https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,q_auto:eco,t_unsupported/v1/something.com/otherthing.png"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 600w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 900w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 1200w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 1201w"
+  />
+</picture>
+`;


### PR DESCRIPTION
## [Jira Task](https://ethoslife.atlassian.net/browse/GC-1587)

### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [x] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Bumped the yarn version?

### Screenshots and extra notes:

- I would like for <source> elements to have a `srcset` attribute when they are not lazy loaded, this way we get some of the benefits of cloudinary image, webp, etc.
- There will be a separate CMS PR where we leverage this.

[GC-1587]: https://ethoslife.atlassian.net/browse/GC-1587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ