### PR TITLE
Lazy Load Cloudinary Resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "dayjs": "^1.8.16",
     "dayjs-plugin-utc": "^0.1.2",
     "js-cookie": "^2.2.1",
-    "lazysizes": "^5.1.2",
     "lodash.debounce": "^4.0.8",
     "react-popper": "^1.3.7",
     "react-select": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Images/Images.js
+++ b/src/components/Images/Images.js
@@ -40,6 +40,7 @@ export const CloudinaryImage = ({
   width,
   height,
   crop,
+  lazyLoad,
   fetchpriority,
   ...rest
 }) => {
@@ -89,17 +90,19 @@ export const CloudinaryImage = ({
       ...baseImageSettings,
     })
 
-    return (
-      <img
-        key={publicId}
-        className={[styles.Image, ...imageClasses].join(' ')}
-        src={srcString}
-        srcSet={srcSetString}
-        alt={alt}
-        fetchpriority={fetchpriority}
-        loading="lazy"
-      />
-    )
+    const imgProps = {
+      key: publicId,
+      className: [styles.Image, ...imageClasses].join(' '),
+      src: srcString,
+      srcSet: srcSetString,
+      fetchpriority: fetchpriority,
+    }
+
+    if (lazyLoad) {
+      Object.assign(imgProps, { loading: 'lazy' })
+    }
+
+    return <img alt={alt} {...imgProps} />
   }
 
   const buildTags = () => {
@@ -170,16 +173,18 @@ export const CloudinaryImage = ({
       baseSvgSettings
     )
 
-    return (
-      <img
-        key={publicId}
-        src={svgUrl}
-        className={[styles.Svg, ...imageClasses].join(' ')}
-        alt={alt}
-        fetchpriority={fetchpriority}
-        loading="lazy"
-      />
-    )
+    const imgProps = {
+      key: publicId,
+      src: svgUrl,
+      className: [styles.Svg, ...imageClasses].join(' '),
+      fetchpriority: fetchpriority,
+    }
+
+    if (lazyLoad) {
+      Object.assign(imgProps, { loading: 'lazy' })
+    }
+
+    return <img alt={alt} {...imgProps} />
   }
 
   // Serve a simpler version if resource is SVG
@@ -266,12 +271,14 @@ CloudinaryImage.PUBLIC_PROPS = {
   alt: PropTypes.string,
   publicId: PropTypes.string.isRequired,
   crop: PropTypes.oneOf(Object.values(CloudinaryImage.CROP_METHODS)),
+  lazyLoad: PropTypes.bool,
   fetchpriority: PropTypes.oneOf(['high', 'low', 'auto']),
 }
 
 CloudinaryImage.defaultProps = {
   crop: CloudinaryImage.CROP_METHODS.FILL,
   alt: '',
+  lazyLoad: true,
   fetchpriority: 'auto',
 }
 

--- a/src/components/Images/Images.js
+++ b/src/components/Images/Images.js
@@ -2,13 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import useRequired from '../../hooks/useRequired.js'
 import useInvalid from '../../hooks/useInvalid.js'
-
 import { createCloudinaryLegacyURL } from '@cloudinary/url-gen'
-
-import { v4 as uuidv4 } from 'uuid'
-// eslint-disable-next-line
-import lazysizes from 'lazysizes'
-
 import { Media } from '../Media/Media'
 import styles from './Images.module.scss'
 
@@ -46,7 +40,6 @@ export const CloudinaryImage = ({
   width,
   height,
   crop,
-  lazyLoad,
   fetchpriority,
   ...rest
 }) => {
@@ -71,10 +64,6 @@ export const CloudinaryImage = ({
     ...defaultImageSettings,
   }
   let imageClasses = [className]
-  if (lazyLoad) {
-    imageClasses.push('lazyload')
-  }
-
   let reverseWidth, reverseHeight
 
   if (width) {
@@ -100,18 +89,15 @@ export const CloudinaryImage = ({
       ...baseImageSettings,
     })
 
-    if (lazyLoad) {
-      imageClasses.push(styles['blurUp'])
-    }
-
     return (
       <img
-        key={`${uuidv4()}`}
+        key={publicId}
         className={[styles.Image, ...imageClasses].join(' ')}
         src={srcString}
         srcSet={srcSetString}
         alt={alt}
         fetchpriority={fetchpriority}
+        loading="lazy"
       />
     )
   }
@@ -151,9 +137,9 @@ export const CloudinaryImage = ({
       const minMax = breakpoint < mediaBreakpoints.length - 1 ? `min` : `max`
       tags.push(
         <source
-          key={`${uuidv4()}`}
+          key={`key-${breakpoint}`}
           media={`(${minMax}-width: ${mediaBreakpoints[breakpoint]}px)`}
-          data-srcset={srcsetData.join(', ')}
+          srcSet={srcsetData.join(', ')}
         />
       )
 
@@ -162,19 +148,7 @@ export const CloudinaryImage = ({
         imageSettings
       )
 
-      const urlWithChainedLqipTransformation = createCloudinaryLegacyURL(
-        filePath(publicId),
-        {
-          ...imageSettings,
-          transformation: 'lqip',
-        }
-      )
-
-      if (lazyLoad) {
-        imageSrcSet.push(urlWithChainedLqipTransformation)
-      } else {
-        imageSrcSet.push(urlWithChainedTransformation)
-      }
+      imageSrcSet.push(urlWithChainedTransformation)
     }
 
     tags.push(buildImageTag(imageSrcSet))
@@ -198,10 +172,12 @@ export const CloudinaryImage = ({
 
     return (
       <img
-        data-src={svgUrl}
+        key={publicId}
+        src={svgUrl}
         className={[styles.Svg, ...imageClasses].join(' ')}
         alt={alt}
         fetchpriority={fetchpriority}
+        loading="lazy"
       />
     )
   }
@@ -290,14 +266,12 @@ CloudinaryImage.PUBLIC_PROPS = {
   alt: PropTypes.string,
   publicId: PropTypes.string.isRequired,
   crop: PropTypes.oneOf(Object.values(CloudinaryImage.CROP_METHODS)),
-  lazyLoad: PropTypes.bool,
   fetchpriority: PropTypes.oneOf(['high', 'low', 'auto']),
 }
 
 CloudinaryImage.defaultProps = {
   crop: CloudinaryImage.CROP_METHODS.FILL,
   alt: '',
-  lazyLoad: true,
   fetchpriority: 'auto',
 }
 

--- a/src/components/Images/Images.module.scss
+++ b/src/components/Images/Images.module.scss
@@ -19,12 +19,3 @@ figure {
   width: 100%;
   height: auto;
 }
-
-.blurUp {
-  filter: blur(5px);
-  transition: filter 500ms;
-
-  &:global(.lazyloaded) {
-    filter: blur(0);
-  }
-}

--- a/src/components/Images/__snapshots__/Images.spec.js.snap
+++ b/src/components/Images/__snapshots__/Images.spec.js.snap
@@ -3,27 +3,28 @@
 exports[`CloudinaryImage default rendering CloudinaryImage 1`] = `
 <picture>
   <source
-    data-srcset="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 3x"
     media="(min-width: 1200px)"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 3x"
   />
   <source
-    data-srcset="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 3x"
     media="(min-width: 900px)"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 3x"
   />
   <source
-    data-srcset="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 3x"
     media="(min-width: 600px)"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 3x"
   />
   <source
-    data-srcset="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 3x"
     media="(max-width: 599px)"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_1.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 1x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_2.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 2x, https://res.cloudinary.com/getethos/image/upload/c_fill,dpr_3.0,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 3x"
   />
   <img
     alt="alt text"
-    className="Image testImage lazyload blurUp"
+    className="Image testImage"
     fetchpriority="auto"
+    loading="lazy"
     src="https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,q_auto:eco,t_unsupported/v1/something.com/otherthing.png"
-    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_100,q_auto:eco,t_lqip,w_100/v1/something.com/otherthing.png 600w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_200,q_auto:eco,t_lqip,w_200/v1/something.com/otherthing.png 900w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_300,q_auto:eco,t_lqip,w_300/v1/something.com/otherthing.png 1200w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_400,q_auto:eco,t_lqip,w_400/v1/something.com/otherthing.png 1201w"
+    srcSet="https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_100,q_auto:eco,w_100/v1/something.com/otherthing.png 600w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_200,q_auto:eco,w_200/v1/something.com/otherthing.png 900w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_300,q_auto:eco,w_300/v1/something.com/otherthing.png 1200w, https://res.cloudinary.com/getethos/image/upload/c_fill,f_auto,fl_progressive:semi,h_400,q_auto:eco,w_400/v1/something.com/otherthing.png 1201w"
   />
 </picture>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6780,11 +6780,6 @@ lazy-ass@1.6.0:
   resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
   integrity sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
 
-lazysizes@^5.1.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/lazysizes/-/lazysizes-5.2.2.tgz#800e5914725fef1863bd9a1e19e1bb423c536f8b"
-  integrity sha512-fYgOv1Y35M86/7qyAdPPqoOhuyZrjxEAPxqwToRY2bO/PoBJ4lSqZYuZoavNp6eyuLpIAdHodpsPfj2Lkt86FQ==
-
 left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"


### PR DESCRIPTION
## [Jira Task](https://ethoslife.atlassian.net/browse/GC-1591)

### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [x] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?

### Screenshots and extra notes:
**lazy load in live**

https://user-images.githubusercontent.com/84357906/211723439-a2a7b665-68be-47ae-972c-7ec8d13532d4.mov

**current**
- During the initial page load we are sending `67` requests for `564kb` resource to be transferred 
<img width="1792" alt="current" src="https://user-images.githubusercontent.com/84357906/211724248-e0580894-7e3d-49a8-b9c9-72159815ae44.png">

**post-change**
-  During the initial page load we are sending `14` total requests for `201kb` resource to be transferred
<img width="1792" alt="lazyload" src="https://user-images.githubusercontent.com/84357906/211724532-3b10e5ed-5bec-41f6-87fa-060afe15a626.png">