### PR TITLE
[GC-1625] New Cypress color & button style used in homepage color palette experiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.2.45",
+  "version": "1.3.0",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -199,6 +199,7 @@ PrivateButton.STYLES = {
   BLACK: 'Black',
   BLACK_OUTLINE: 'BlackOutline',
   SALAMANDER: 'Salamander',
+  CYPRESS: 'Cypress',
   WHITE_OUTLINE: 'WhiteOutline',
   STATEFUL: 'Stateful',
   STATEFUL_WHITE: 'Stateful White',
@@ -240,6 +241,10 @@ export const Button = {
     Salamander: ButtonFactory({
       size: PrivateButton.SIZES.MEDIUM,
       style: PrivateButton.STYLES.SALAMANDER,
+    }),
+    Cypress: ButtonFactory({
+      size: PrivateButton.SIZES.MEDIUM,
+      style: PrivateButton.STYLES.CYPRESS,
     }),
     WhiteOutline: ButtonFactory({
       size: PrivateButton.SIZES.MEDIUM,

--- a/src/components/Button/Button.md
+++ b/src/components/Button/Button.md
@@ -25,6 +25,13 @@ Set of Design-approved public buttons.
 ```
 
 ```jsx
+<Button.Medium.Cypress>Button.Medium.Cypress</Button.Medium.Cypress>
+<Button.Medium.Cypress disabled={true}>
+  Button.Medium.Cypress disabled
+</Button.Medium.Cypress>
+```
+
+```jsx
 <div style={{ backgroundColor: 'var(--BrandForest)', padding: 20 }}>
   <strong style={{ color: 'white' }}>
     Background supplied so the button is visible.

--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -183,6 +183,34 @@
   }
 }
 
+.Button.Cypress {
+  background-color: var(--BrandCypress);
+  color: var(--White);
+  path {
+    fill: var(--White);
+  }
+  @include light-on-dark-font-smoothing;
+
+  &:not([disabled]) {
+    &:hover {
+      background-color: var(--CypressHover--translucent);
+    }
+
+    &:active {
+      background-color: var(--CypressHover--translucent);
+    }
+  }
+
+  &[disabled] {
+    border-color: var(--Transparent--white);
+    background-color: var(--BrandSand);
+    color: var(--GrayStrokeAndDisabled--translucent);
+    path {
+      fill: var(--GrayStrokeAndDisabled--translucent);
+    }
+  }
+}
+
 .Button.WhiteOutline {
   border-color: var(--White);
   background-color: var(--Transparent--white);

--- a/src/components/Colors.js
+++ b/src/components/Colors.js
@@ -9,6 +9,7 @@ export const COLORS = {
   BRAND_MOSS_TRANSLUSCENT: 'BrandMossTranslucent',
   BRAND_SALAMANDER: 'BrandSalamander',
   BRAND_SAND: 'BrandSand',
+  BRAND_CYPRESS: 'BrandCypress',
 
   // Grayscales
   GRAY_DARK_HOVER: 'GrayDarkHover',

--- a/src/components/Colors.scss
+++ b/src/components/Colors.scss
@@ -31,6 +31,10 @@
   // for Salamander Button hover pseudo-state
   --SalamanderHover--translucent: rgba(250, 100, 10, 0.8);
 
+  // Homepage rebrand experiment color palette
+  --BrandCypress: #056257;
+  --CypressHover--translucent: #056257c4;
+
   // Only use these reds in error states
   --BrandPasty: #ffe0de;
   --BrandSunburn: #e11f13;

--- a/src/components/design-system.css
+++ b/src/components/design-system.css
@@ -150,6 +150,8 @@ textarea {
   --Transparent--white: rgba(255, 255, 255, 0);
   --BrandMoss--translucent: rgba(219, 237, 229, 0.2);
   --SalamanderHover--translucent: rgba(250, 100, 10, 0.8);
+  --BrandCypress: #056257;
+  --CypressHover--translucent: #056257c4;
   --BrandPasty: #ffe0de;
   --BrandSunburn: #e11f13;
 }

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -316,6 +316,7 @@ export declare const Button: {
     Black: (downstreamProps: downstreamButtonProps) => any
     BlackOutline: (downstreamProps: downstreamButtonProps) => any
     Salamander: (downstreamProps: downstreamButtonProps) => any
+    Cypress: (downstreamProps: downstreamButtonProps) => any
     WhiteOutline: (downstreamProps: downstreamButtonProps) => any
     Stateful: {
       Default: (downstreamProps: downstreamButtonProps) => any

--- a/stats.json
+++ b/stats.json
@@ -1,5 +1,5 @@
 {
-  "cssBytes": 6997,
+  "cssBytes": 7066,
   "cssRules": 48,
   "cssTypeSelectors": 32,
   "cssClassSelectors": 30,

--- a/styleguide/content/color/color.md
+++ b/styleguide/content/color/color.md
@@ -89,6 +89,10 @@ Simply import the colors and utilize [CSS custom properties](https://developer.m
     <span class="Caption Theinhardt Medium500">`#ffffff`</span>
     <span class="Caption Theinhardt Regular400">White</span>
   </div>
+  <div class="swatch-brand-BrandCypress">
+    <span class="Caption Theinhardt Medium500 GrayPrimary">`#fa640a`</span>
+    <span class="Caption Theinhardt Regular400 GraySecondary">BrandCypress</span>
+  </div>
 </div>
 
 

--- a/styleguide/content/color/color.scss
+++ b/styleguide/content/color/color.scss
@@ -51,6 +51,10 @@
   background-color: var(--BrandMoss);
 }
 
+.swatch-brand-BrandCypress {
+  background-color: var(--BrandCypress);
+}
+
 /* Neutrals */
 .swatch-brand-GrayPrimary {
   background-color: var(--GrayPrimary--opaque);


### PR DESCRIPTION
## [Jira Task](https://ethoslife.atlassian.net/browse/GC-1625)
Supports new buttons used in multiple modules for the new homepage rebrand design experiment.
Easier to add the new color here than to write custom CSS to replicate button styles in CMS. 
The color variable will also be required for some custom CSS in CMS for this experiment as well.


### Please review these reminders and either check the box or explain why not:
- [x] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [x] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):
https://github.com/getethos/cms/pull/6876

### Screenshots and extra notes:
![Screen Shot 2023-01-10 at 2 31 55 PM](https://user-images.githubusercontent.com/87672141/211677462-96fd76d7-06f9-4edb-ab07-9e09076439c2.png)
![Screen Shot 2023-01-10 at 2 28 24 PM](https://user-images.githubusercontent.com/87672141/211677464-a3cce146-8ca3-4b80-b069-e2ef17a1ff82.png)
