### PR TITLE
Introduce lime color + lime button for HP color palette rebrand experiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -200,6 +200,7 @@ PrivateButton.STYLES = {
   BLACK_OUTLINE: 'BlackOutline',
   SALAMANDER: 'Salamander',
   CYPRESS: 'Cypress',
+  LIME: 'Lime',
   WHITE_OUTLINE: 'WhiteOutline',
   STATEFUL: 'Stateful',
   STATEFUL_WHITE: 'Stateful White',
@@ -245,6 +246,10 @@ export const Button = {
     Cypress: ButtonFactory({
       size: PrivateButton.SIZES.MEDIUM,
       style: PrivateButton.STYLES.CYPRESS,
+    }),
+    Lime: ButtonFactory({
+      size: PrivateButton.SIZES.MEDIUM,
+      style: PrivateButton.STYLES.LIME,
     }),
     WhiteOutline: ButtonFactory({
       size: PrivateButton.SIZES.MEDIUM,

--- a/src/components/Button/Button.md
+++ b/src/components/Button/Button.md
@@ -32,6 +32,13 @@ Set of Design-approved public buttons.
 ```
 
 ```jsx
+<Button.Medium.Lime>Button.Medium.Lime</Button.Medium.Lime>
+<Button.Medium.Lime disabled={true}>
+  Button.Medium.Lime disabled
+</Button.Medium.Lime>
+```
+
+```jsx
 <div style={{ backgroundColor: 'var(--BrandForest)', padding: 20 }}>
   <strong style={{ color: 'white' }}>
     Background supplied so the button is visible.

--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -211,6 +211,34 @@
   }
 }
 
+.Button.Lime {
+  background-color: var(--BrandLime);
+  color: var(--GrayPrimary--opaque);
+  path {
+    fill: var(--GrayPrimary--opaque);
+  }
+  @include light-on-dark-font-smoothing;
+
+  &:not([disabled]) {
+    &:hover {
+      background-color: var(--LimeHover--translucent);
+    }
+
+    &:active {
+      background-color: var(--LimeHover--translucent);
+    }
+  }
+
+  &[disabled] {
+    border-color: var(--Transparent--white);
+    background-color: var(--BrandSand);
+    color: var(--GrayStrokeAndDisabled--translucent);
+    path {
+      fill: var(--GrayStrokeAndDisabled--translucent);
+    }
+  }
+}
+
 .Button.WhiteOutline {
   border-color: var(--White);
   background-color: var(--Transparent--white);

--- a/src/components/Colors.js
+++ b/src/components/Colors.js
@@ -10,6 +10,7 @@ export const COLORS = {
   BRAND_SALAMANDER: 'BrandSalamander',
   BRAND_SAND: 'BrandSand',
   BRAND_CYPRESS: 'BrandCypress',
+  BRAND_LIME: 'BrandLime',
 
   // Grayscales
   GRAY_DARK_HOVER: 'GrayDarkHover',

--- a/src/components/Colors.scss
+++ b/src/components/Colors.scss
@@ -34,6 +34,8 @@
   // Homepage rebrand experiment color palette
   --BrandCypress: #056257;
   --CypressHover--translucent: #056257c4;
+  --BrandLime: #e7fd7f;
+  --LimeHover--translucent: #e7fd7fc4;
 
   // Only use these reds in error states
   --BrandPasty: #ffe0de;

--- a/src/components/design-system.css
+++ b/src/components/design-system.css
@@ -152,6 +152,8 @@ textarea {
   --SalamanderHover--translucent: rgba(250, 100, 10, 0.8);
   --BrandCypress: #056257;
   --CypressHover--translucent: #056257c4;
+  --BrandLime: #e7fd7f;
+  --LimeHover--translucent: #e7fd7fc4;
   --BrandPasty: #ffe0de;
   --BrandSunburn: #e11f13;
 }

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -317,6 +317,7 @@ export declare const Button: {
     BlackOutline: (downstreamProps: downstreamButtonProps) => any
     Salamander: (downstreamProps: downstreamButtonProps) => any
     Cypress: (downstreamProps: downstreamButtonProps) => any
+    Lime: (downstreamProps: downstreamButtonProps) => any
     WhiteOutline: (downstreamProps: downstreamButtonProps) => any
     Stateful: {
       Default: (downstreamProps: downstreamButtonProps) => any

--- a/stats.json
+++ b/stats.json
@@ -1,5 +1,5 @@
 {
-  "cssBytes": 7066,
+  "cssBytes": 7129,
   "cssRules": 48,
   "cssTypeSelectors": 32,
   "cssClassSelectors": 30,

--- a/styleguide/content/color/color.md
+++ b/styleguide/content/color/color.md
@@ -90,8 +90,12 @@ Simply import the colors and utilize [CSS custom properties](https://developer.m
     <span class="Caption Theinhardt Regular400">White</span>
   </div>
   <div class="swatch-brand-BrandCypress">
-    <span class="Caption Theinhardt Medium500 GrayPrimary">`#fa640a`</span>
+    <span class="Caption Theinhardt Medium500 GrayPrimary">`#056257`</span>
     <span class="Caption Theinhardt Regular400 GraySecondary">BrandCypress</span>
+  </div>
+  <div class="swatch-brand-BrandLime">
+    <span class="Caption Theinhardt Medium500 GrayPrimary">`#E7FD7F`</span>
+    <span class="Caption Theinhardt Regular400 GraySecondary">BrandLime</span>
   </div>
 </div>
 

--- a/styleguide/content/color/color.scss
+++ b/styleguide/content/color/color.scss
@@ -55,6 +55,10 @@
   background-color: var(--BrandCypress);
 }
 
+.swatch-brand-BrandLime {
+  background-color: var(--BrandLime);
+}
+
 /* Neutrals */
 .swatch-brand-GrayPrimary {
   background-color: var(--GrayPrimary--opaque);


### PR DESCRIPTION
## [Jira Task](https://ethoslife.atlassian.net/browse/GC-1626)

New color and button to support updated SingleCTA module layout in CMS for HP color palette experiment.

### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [x] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):
- WIP

### Screenshots and extra notes:
![Screen Shot 2023-01-13 at 8 43 21 AM](https://user-images.githubusercontent.com/87672141/212396901-d4d907a0-0a88-464b-8a7b-ffe3ab7fa29b.png)
![Screen Shot 2023-01-13 at 8 42 24 AM](https://user-images.githubusercontent.com/87672141/212396905-2f68ff59-e756-4b3b-8790-b53dec8aac6a.png)
