### PR TITLE
Make tooltip device independent interactable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -111,16 +111,17 @@ export const Tooltip = ({
         <Reference>
           {({ ref }) =>
             children ? (
+              <div ref={ref} {...referenceProps}>
+                {children}
+              </div>
+            ) : (
               <div
+                className={styles.icon}
                 ref={ref}
                 onFocus={debouncedSetTooltipVisibility(true)}
                 onBlur={debouncedSetTooltipVisibility(false)}
                 {...referenceProps}
               >
-                {children}
-              </div>
-            ) : (
-              <div className={styles.icon} ref={ref} {...referenceProps}>
                 {tooltipVisible ? Tooltip.SVGS.iconHover : Tooltip.SVGS.icon}
               </div>
             )

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -89,6 +89,8 @@ export const Tooltip = ({
     onMouseOver: () => debouncedSetTooltipVisibility(true),
     onMouseOut: () => debouncedSetTooltipVisibility(false),
     onClick: () => setModalVisibility(true),
+    onFocus: () => debouncedSetTooltipVisibility(true),
+    onBlur: () => debouncedSetTooltipVisibility(false),
   }
 
   const popperProps = {

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -14,7 +14,7 @@ import styles from './Tooltip.module.scss'
 const BREAKPOINTS = Media.BREAKPOINTS
 const HEADER_ID = 'mobile-modal-heading'
 const DESC_ID = 'mobile-modal-description'
-const ACCESSIBILTY_ID = 'info-tooltip'
+const ACCESSIBILITY_ID = 'info-tooltip'
 
 export const Tooltip = ({
   label,
@@ -122,7 +122,7 @@ export const Tooltip = ({
                 role="button"
                 className={styles.icon}
                 ref={ref}
-                ariaLabelledBy={ACCESSIBILTY_ID}
+                ariaLabelledBy={ACCESSIBILITY_ID}
                 tabIndex={0}
                 {...referenceProps}
               >

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -118,9 +118,11 @@ export const Tooltip = ({
               </div>
             ) : (
               <div
+                role="button"
                 className={styles.icon}
                 ref={ref}
-                tabIndex={1}
+                aria-labelledby="info-tooltip"
+                tabIndex={0}
                 {...referenceProps}
               >
                 {tooltipVisible ? Tooltip.SVGS.iconHover : Tooltip.SVGS.icon}

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -121,7 +121,7 @@ export const Tooltip = ({
                 role="button"
                 className={styles.icon}
                 ref={ref}
-                aria-labelledby="info-tooltip"
+                ariaLabelledBy="info-tooltip"
                 tabIndex={0}
                 {...referenceProps}
               >

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -89,6 +89,8 @@ export const Tooltip = ({
     onMouseOver: () => debouncedSetTooltipVisibility(true),
     onMouseOut: () => debouncedSetTooltipVisibility(false),
     onClick: () => setModalVisibility(true),
+    onFocus: () => debouncedSetTooltipVisibility(true),
+    onBlur: () => debouncedSetTooltipVisibility(false),
   }
 
   const popperProps = {
@@ -119,8 +121,6 @@ export const Tooltip = ({
                 className={styles.icon}
                 ref={ref}
                 tabIndex={1}
-                onFocus={debouncedSetTooltipVisibility(true)}
-                onBlur={debouncedSetTooltipVisibility(false)}
                 {...referenceProps}
               >
                 {tooltipVisible ? Tooltip.SVGS.iconHover : Tooltip.SVGS.icon}

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -118,6 +118,7 @@ export const Tooltip = ({
               <div
                 className={styles.icon}
                 ref={ref}
+                tabIndex={1}
                 onFocus={debouncedSetTooltipVisibility(true)}
                 onBlur={debouncedSetTooltipVisibility(false)}
                 {...referenceProps}

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -14,6 +14,7 @@ import styles from './Tooltip.module.scss'
 const BREAKPOINTS = Media.BREAKPOINTS
 const HEADER_ID = 'mobile-modal-heading'
 const DESC_ID = 'mobile-modal-description'
+const ACCESSIBILTY_ID = 'info-tooltip'
 
 export const Tooltip = ({
   label,
@@ -121,7 +122,7 @@ export const Tooltip = ({
                 role="button"
                 className={styles.icon}
                 ref={ref}
-                ariaLabelledBy="info-tooltip"
+                ariaLabelledBy={ACCESSIBILTY_ID}
                 tabIndex={0}
                 {...referenceProps}
               >

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -111,17 +111,16 @@ export const Tooltip = ({
         <Reference>
           {({ ref }) =>
             children ? (
-              <div ref={ref} {...referenceProps}>
-                {children}
-              </div>
-            ) : (
               <div
-                className={styles.icon}
                 ref={ref}
                 onFocus={debouncedSetTooltipVisibility(true)}
                 onBlur={debouncedSetTooltipVisibility(false)}
                 {...referenceProps}
               >
+                {children}
+              </div>
+            ) : (
+              <div className={styles.icon} ref={ref} {...referenceProps}>
                 {tooltipVisible ? Tooltip.SVGS.iconHover : Tooltip.SVGS.icon}
               </div>
             )

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -89,8 +89,6 @@ export const Tooltip = ({
     onMouseOver: () => debouncedSetTooltipVisibility(true),
     onMouseOut: () => debouncedSetTooltipVisibility(false),
     onClick: () => setModalVisibility(true),
-    onFocus: () => debouncedSetTooltipVisibility(true),
-    onBlur: () => debouncedSetTooltipVisibility(false),
   }
 
   const popperProps = {
@@ -117,7 +115,13 @@ export const Tooltip = ({
                 {children}
               </div>
             ) : (
-              <div className={styles.icon} ref={ref} {...referenceProps}>
+              <div
+                className={styles.icon}
+                ref={ref}
+                onFocus={debouncedSetTooltipVisibility(true)}
+                onBlur={debouncedSetTooltipVisibility(false)}
+                {...referenceProps}
+              >
                 {tooltipVisible ? Tooltip.SVGS.iconHover : Tooltip.SVGS.icon}
               </div>
             )


### PR DESCRIPTION
## [GC-1078](https://ethoslife.atlassian.net/browse/GC-1078?atlOrigin=eyJpIjoiZWRjOGY1ZWRiNmI0NDg4ODg4ZWU3MjYxMmFmZTlmYjciLCJwIjoiaiJ9)
[GC-1076](https://ethoslife.atlassian.net/browse/GC-1076?atlOrigin=eyJpIjoiZGZmMzczNmRhZmNlNDkxM2I2ZmNjZjRiNWZhNjBlYjMiLCJwIjoiaiJ9)

### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [x] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

- https://ethoslife.atlassian.net/browse/GC-1076?atlOrigin=eyJpIjoiZGZmMzczNmRhZmNlNDkxM2I2ZmNjZjRiNWZhNjBlYjMiLCJwIjoiaiJ9
- https://ethoslife.atlassian.net/browse/GC-1078?atlOrigin=eyJpIjoiZWRjOGY1ZWRiNmI0NDg4ODg4ZWU3MjYxMmFmZTlmYjciLCJwIjoiaiJ9

### Screenshots and extra notes:

<img width="329" alt="Screenshot 2023-01-31 at 11 48 52 AM" src="https://user-images.githubusercontent.com/24817673/215891601-76f57130-e4b0-467d-9d20-0bfc309c3f00.png">

[GC-1078]: https://ethoslife.atlassian.net/browse/GC-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GC-1076]: https://ethoslife.atlassian.net/browse/GC-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ