### PR TITLE
dark salamander button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -199,6 +199,7 @@ PrivateButton.STYLES = {
   BLACK: 'Black',
   BLACK_OUTLINE: 'BlackOutline',
   SALAMANDER: 'Salamander',
+  DARK_SALAMANDER: 'DarkSalamander',
   CYPRESS: 'Cypress',
   LIME: 'Lime',
   WHITE_OUTLINE: 'WhiteOutline',
@@ -242,6 +243,10 @@ export const Button = {
     Salamander: ButtonFactory({
       size: PrivateButton.SIZES.MEDIUM,
       style: PrivateButton.STYLES.SALAMANDER,
+    }),
+    DarkSalamander: ButtonFactory({
+      size: PrivateButton.SIZES.MEDIUM,
+      style: PrivateButton.STYLES.DARK_SALAMANDER,
     }),
     Cypress: ButtonFactory({
       size: PrivateButton.SIZES.MEDIUM,

--- a/src/components/Button/Button.md
+++ b/src/components/Button/Button.md
@@ -25,6 +25,13 @@ Set of Design-approved public buttons.
 ```
 
 ```jsx
+<Button.Medium.DarkSalamander>Button.Medium.DarkSalamander</Button.Medium.DarkSalamander>
+<Button.Medium.DarkSalamander disabled={true}>
+  Button.Medium.DarkSalamander disabled
+</Button.Medium.DarkSalamander>
+```
+
+```jsx
 <Button.Medium.Cypress>Button.Medium.Cypress</Button.Medium.Cypress>
 <Button.Medium.Cypress disabled={true}>
   Button.Medium.Cypress disabled

--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -183,6 +183,34 @@
   }
 }
 
+.Button.DarkSalamander {
+  background-color: var(--BrandDarkSalamander);
+  color: var(--White);
+  path {
+    fill: var(--White);
+  }
+  @include light-on-dark-font-smoothing;
+
+  &:not([disabled]) {
+    &:hover {
+      background-color: var(--SalamanderHover--translucent);
+    }
+
+    &:active {
+      background-color: var(--SalamanderHover--translucent);
+    }
+  }
+
+  &[disabled] {
+    border-color: var(--Transparent--white);
+    background-color: var(--BrandSand);
+    color: var(--GrayStrokeAndDisabled--translucent);
+    path {
+      fill: var(--GrayStrokeAndDisabled--translucent);
+    }
+  }
+}
+
 .Button.Cypress {
   background-color: var(--BrandCypress);
   color: var(--White);

--- a/src/components/Colors.js
+++ b/src/components/Colors.js
@@ -8,6 +8,7 @@ export const COLORS = {
   BRAND_MOSS: 'BrandMoss',
   BRAND_MOSS_TRANSLUSCENT: 'BrandMossTranslucent',
   BRAND_SALAMANDER: 'BrandSalamander',
+  BRAND_DARK_SALAMANDER: 'BrandDarkSalamander',
   BRAND_SAND: 'BrandSand',
   BRAND_CYPRESS: 'BrandCypress',
   BRAND_LIME: 'BrandLime',

--- a/src/components/Colors.scss
+++ b/src/components/Colors.scss
@@ -5,6 +5,7 @@
   --BrandSand: #e5e0d9;
   --BrandDuckegg: #deebff;
   --BrandSalamander: #fa640a;
+  --BrandDarkSalamander: #f26d00;
   --BrandButtercup: #fff2e3;
   --BrandForest: #054742;
   --BrandMoss: #dbede5;

--- a/src/components/design-system.css
+++ b/src/components/design-system.css
@@ -133,6 +133,7 @@ textarea {
   --BrandSand: #e5e0d9;
   --BrandDuckegg: #deebff;
   --BrandSalamander: #fa640a;
+  --BrandDarkSalamander: #f26d00;
   --BrandButtercup: #fff2e3;
   --BrandForest: #054742;
   --BrandMoss: #dbede5;

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -316,6 +316,7 @@ export declare const Button: {
     Black: (downstreamProps: downstreamButtonProps) => any
     BlackOutline: (downstreamProps: downstreamButtonProps) => any
     Salamander: (downstreamProps: downstreamButtonProps) => any
+    DarkSalamander: (downstreamProps: downstreamButtonProps) => any
     Cypress: (downstreamProps: downstreamButtonProps) => any
     Lime: (downstreamProps: downstreamButtonProps) => any
     WhiteOutline: (downstreamProps: downstreamButtonProps) => any

--- a/stats.json
+++ b/stats.json
@@ -1,5 +1,5 @@
 {
-  "cssBytes": 7363,
+  "cssBytes": 7397,
   "cssRules": 49,
   "cssTypeSelectors": 32,
   "cssClassSelectors": 31,

--- a/styleguide/content/color/color.md
+++ b/styleguide/content/color/color.md
@@ -98,5 +98,11 @@ Simply import the colors and utilize [CSS custom properties](https://developer.m
     <span class="Caption Theinhardt Regular400 GraySecondary">BrandLime</span>
   </div>
 </div>
+<div class="flex-wrap">
+  <div class="swatch-brand-BrandDarkSalamander">
+    <span class="Caption Theinhardt Medium500">`#f26d00`</span>
+    <span class="Caption Theinhardt Regular400">BrandDarkSalamander</span>
+  </div>
+</div>
 
 

--- a/styleguide/content/color/color.scss
+++ b/styleguide/content/color/color.scss
@@ -35,6 +35,10 @@
   background-color: var(--BrandDuckegg);
 }
 
+.swatch-brand-BrandDarkSalamander {
+  background-color: var(--BrandDarkSalamander);
+}
+
 .swatch-brand-BrandSalamander {
   background-color: var(--BrandSalamander);
 }


### PR DESCRIPTION
## [Jira Task](https://ethoslife.atlassian.net/browse/GC-1885)

Support for CMS new SingleCTA module variation where Dark Salamander color button is used.

### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [x] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):
- WIP

### Screenshots and extra notes:
![Screen Shot 2023-02-22 at 5 22 10 PM](https://user-images.githubusercontent.com/87672141/220801169-3d65dd75-d296-467e-9825-17004e4832d6.png)

