### PR TITLE
[GC-1964] [NSLP follow up] On navigate back, useEffect to set initial background to white if scrolled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.3.19",
+  "version": "1.3.18",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -30,30 +30,21 @@ class ScrollDetector extends React.Component {
   }
 
   addScrollListener() {
-    console.log('addScrollListener is called before if')
     if (typeof window === 'undefined') return
-    console.log('addScrollListener is called after if')
     // Note that this scroll event must be attached to the document
     // and not the element itself -- so onScroll does not work
     window.addEventListener('scroll', this.updateScrollState)
   }
 
   removeScrollListener() {
-    console.log('removeScrollListener is called before if')
     if (typeof window === 'undefined') return
-    console.log('removeScrollListener is called before if')
     // Okay since removing an unregistered event listener has no effect
     // https://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-EventTarget-removeEventListener
     window.removeEventListener('scroll', this.updateScrollState)
   }
 
   updateScrollState = () => {
-    console.log('updateScrollState is called')
     const scrollTop = window.pageYOffset || window.document.scrollTop
-    console.log(`window.pageYOffset ${window.pageYOffset}`)
-    console.log(`window.document.scrollTop ${window.document.scrollTop}`)
-    console.log(`scrollTop ${scrollTop}`)
-    console.log(`this.props.offsetHeight ${this.props.offsetHeight}`)
     this.setState({ isScrolled: scrollTop > this.props.offsetHeight })
   }
 

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -21,6 +21,7 @@ class ScrollDetector extends React.Component {
   }
 
   componentDidMount() {
+    this.updateScrollState()
     this.addScrollListener()
   }
 
@@ -29,21 +30,30 @@ class ScrollDetector extends React.Component {
   }
 
   addScrollListener() {
+    console.log('addScrollListener is called before if')
     if (typeof window === 'undefined') return
+    console.log('addScrollListener is called after if')
     // Note that this scroll event must be attached to the document
     // and not the element itself -- so onScroll does not work
     window.addEventListener('scroll', this.updateScrollState)
   }
 
   removeScrollListener() {
+    console.log('removeScrollListener is called before if')
     if (typeof window === 'undefined') return
+    console.log('removeScrollListener is called before if')
     // Okay since removing an unregistered event listener has no effect
     // https://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-EventTarget-removeEventListener
     window.removeEventListener('scroll', this.updateScrollState)
   }
 
   updateScrollState = () => {
+    console.log('updateScrollState is called')
     const scrollTop = window.pageYOffset || window.document.scrollTop
+    console.log(`window.pageYOffset ${window.pageYOffset}`)
+    console.log(`window.document.scrollTop ${window.document.scrollTop}`)
+    console.log(`scrollTop ${scrollTop}`)
+    console.log(`this.props.offsetHeight ${this.props.offsetHeight}`)
     this.setState({ isScrolled: scrollTop > this.props.offsetHeight })
   }
 


### PR DESCRIPTION
## [Jira Task](https://ethoslife.atlassian.net/browse/GC-1964)
This PR fix the issue when navigating back, the navigation bar should turn to white color if the user is not at the top of the page


### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [x] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

https://github.com/getethos/cms/pull/7030

### Screenshots and extra notes:
Screenshots and manual test instruction is in this PR https://github.com/getethos/cms/pull/7030