### PR TITLE
[RP-496] add optional data field for formotiv in checkboxinput 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/CheckboxInput2/CheckboxInput2.js
+++ b/src/components/CheckboxInput2/CheckboxInput2.js
@@ -28,6 +28,7 @@ export const CheckboxInput2 = ({
   tooltip,
   variant = 'default',
   facadeRenderer,
+  dataFormotiv = '',
   ...rest
 }) => {
   const initialChecked = currentValue || initialValue || false
@@ -118,6 +119,7 @@ export const CheckboxInput2 = ({
               type="checkbox"
               onChange={onChange}
               data-tid={rest['data-tid']}
+              data-formotiv={dataFormotiv}
               onKeyPress={onKeyPress}
               disabled={disabled}
               checked={resolvedIsChecked}
@@ -165,6 +167,8 @@ CheckboxInput2.propTypes = {
   id: PropTypes.string.isRequired,
   /** Required data-tid used as a unique id for targeting test selectors */
   'data-tid': PropTypes.string.isRequired,
+  /** data sent to formotiv used for behavioral analysis */
+  dataFormotiv: PropTypes.string,
   /** Optionally sets a default value for the checkbox */
   initialValue: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   /** Allows for brute force setting of whether checked or not. Usually,

--- a/src/components/CheckboxInput2/CheckboxInput2.js
+++ b/src/components/CheckboxInput2/CheckboxInput2.js
@@ -167,7 +167,7 @@ CheckboxInput2.propTypes = {
   id: PropTypes.string.isRequired,
   /** Required data-tid used as a unique id for targeting test selectors */
   'data-tid': PropTypes.string.isRequired,
-  /** data sent to formotiv used for behavioral analysis */
+  /** Data sent to formotiv used for behavioral analysis */
   dataFormotiv: PropTypes.string,
   /** Optionally sets a default value for the checkbox */
   initialValue: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),

--- a/src/components/CheckboxInput2/__snapshots__/CheckboxInput2.test.js.snap
+++ b/src/components/CheckboxInput2/__snapshots__/CheckboxInput2.test.js.snap
@@ -18,6 +18,7 @@ Array [
         <input
           checked={true}
           className="CheckboxInput "
+          data-formotiv=""
           data-tid="le-tid"
           id="le-check"
           name="le-check"
@@ -67,6 +68,7 @@ Array [
         <input
           checked={false}
           className="CheckboxInput "
+          data-formotiv=""
           data-tid="le-tid"
           id="le-check"
           name="le-check"


### PR DESCRIPTION
## [Jira Task](https://ethoslife.atlassian.net/browse/RP-496)

added new optional property to the checkboxinput2 component, to pass in data to formotiv for behavioral analysis.


### Please review these reminders and either check the box or explain why not:

- [ ] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [ ] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

-

### Screenshots and extra notes:

Tested the new eds component in local by using it with and without (change in local code) the new property in the checkbox type ask in main interview.

screenshot with the new data-formotiv property.
![Screenshot 2023-04-04 at 11 09 51 AM](https://user-images.githubusercontent.com/101541833/229677273-0417c85c-5a11-4343-9d67-b8781051ee9b.png)

screenshot without the new data-formotiv property (note that data-formotiv is blank as default value)

![Screenshot 2023-04-04 at 11 17 31 AM](https://user-images.githubusercontent.com/101541833/229678369-86526024-788e-4f9a-88e1-0820ff333dff.png)
