### PR TITLE
chore: change mobile padding to 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.3.26",
+  "version": "1.3.27",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -6,7 +6,7 @@
 
 :root {
   --ContainerMaxWidth: 1440px;
-  --ContainerPadding--Phone: var(--Space-24);
+  --ContainerPadding--Phone: var(--Space-16);
   --ContainerPadding--Tablet: var(--Space-48);
   --ContainerPadding--Laptop: var(--Space-72);
   --ContainerPadding--Desktop: var(--Space-80);

--- a/src/components/design-system.css
+++ b/src/components/design-system.css
@@ -178,7 +178,7 @@ textarea {
    ========================================================================== */
 :root {
   --ContainerMaxWidth: 1440px;
-  --ContainerPadding--Phone: var(--Space-24);
+  --ContainerPadding--Phone: var(--Space-16);
   --ContainerPadding--Tablet: var(--Space-48);
   --ContainerPadding--Laptop: var(--Space-72);
   --ContainerPadding--Desktop: var(--Space-80);


### PR DESCRIPTION
## [Jira Task](https://ethoslife.atlassian.net/browse/CD-81)

### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [x] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [x] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [x] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

- Changes for monorepo.

### Screenshots and extra notes:
Changed mobile padding from 24px to 16px and bumped version