### PR TITLE
[GC-2691] universal navbar errors fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.3.26",
+  "version": "1.3.27",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/UniversalNavbarExpanded/DropdownNav/NestedCategories/CategoryLinks.js
+++ b/src/components/UniversalNavbarExpanded/DropdownNav/NestedCategories/CategoryLinks.js
@@ -8,7 +8,7 @@ export const CategoryLinks = ({ links, trackingFunction }) => {
   return (
     <div className={styles.linksWrapper}>
       {links.map((link) => (
-        <div className={styles.categoryLink} key={link.id}>
+        <div className={styles.categoryLink} key={`${link.id}_${link.title}`}>
           <NavLink
             itemLabel={link.title}
             href={link.href}

--- a/src/components/UniversalNavbarExpanded/DropdownNav/NestedCategories/NestedCategories.js
+++ b/src/components/UniversalNavbarExpanded/DropdownNav/NestedCategories/NestedCategories.js
@@ -12,7 +12,10 @@ export const NestedCategories = ({ child, trackingFunction }) => {
       <Banner cta={child.subnav.cta} />
       <div className={styles.categoriesWrapper}>
         {child.subnav.items.map((itemCategory) => (
-          <div className={styles.category} key={itemCategory.id}>
+          <div
+            className={styles.category}
+            key={`${itemCategory.id}_${itemCategory.category}`}
+          >
             <TitleSmall2.Serif.Book500 elementClasses={styles.categoryText}>
               {itemCategory.category}
             </TitleSmall2.Serif.Book500>

--- a/src/components/UniversalNavbarExpanded/MobileNav/NestedLinks/NestedLinks.js
+++ b/src/components/UniversalNavbarExpanded/MobileNav/NestedLinks/NestedLinks.js
@@ -36,7 +36,7 @@ export const NestedLinks = ({ link, trackingFunction, isNavVisible }) => {
       {subnav.items.map((subNavItem, idx) => (
         <div
           className={idx === activeAccordionItem ? styles.active : ''}
-          key={subNavItem.category}
+          key={`${subNavItem.id}_${subNavItem.category}`}
         >
           <div
             onClick={() => toggleAccordionItem(idx)}
@@ -51,7 +51,10 @@ export const NestedLinks = ({ link, trackingFunction, isNavVisible }) => {
             <AccordionToggleIcon />
           </div>
           {subNavItem.items.map((subItem) => (
-            <div key={subItem.id} className={styles.nestedCategoryChild}>
+            <div
+              key={`${subItem.id}_${subItem.title}`}
+              className={styles.nestedCategoryChild}
+            >
               <NavLink
                 trackingFunction={trackingFunction}
                 itemLabel={subItem.title}

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -257,8 +257,8 @@ UniversalNavbarExpanded.propTypes = {
       PropTypes.shape({
         title: PropTypes.string.isRequired,
         id: PropTypes.string.isRequired,
+        hasExpandedNav: PropTypes.bool,
         subnav: PropTypes.shape({
-          hasExpandedNav: PropTypes.bool.isRequired,
           cta: PropTypes.shape({
             href: PropTypes.string.isRequired,
             title: PropTypes.string.isRequired,


### PR DESCRIPTION
## [Jira Task](https://ethoslife.atlassian.net/browse/GC-2691)

### Please review these reminders and either check the box or explain why not:

- [ ] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [ ] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

- https://github.com/getethos/cms-next/pull/219

### Screenshots and extra notes:
Basically updated keys when mapping React components, so they do not throw errors.
