### PR TITLE
add disabled prop to ZipInput

### DIFF
--- a/src/components/ZipInput/ZipInput.js
+++ b/src/components/ZipInput/ZipInput.js
@@ -96,6 +96,7 @@ export const ZipInput = (props) => {
         classOverrides={classOverrides}
         labelWeight={props.labelWeight}
         labelColor={props.labelColor}
+        disabled={props.disabled}
       />
       {getError(currentError, touched)}
     </>


### PR DESCRIPTION
## [Jira Task]()

### Please review these reminders and either check the box or explain why not:

- [ ] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [ ] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

-

### Screenshots and extra notes:
