### PR TITLE
remove deprecated yarn flag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
         run: yarn config set -H npmScopes.fortawesome.npmAuthToken ${{ secrets.FONTAWESOME_TOKEN_GITHUB }}
       - name: Install dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
-        run: yarn install --production=false
+        run: yarn install
       - name: Write .aws/config
         run: |
           mkdir -p ${GITHUB_WORKSPACE}/.aws


### PR DESCRIPTION
## [Jira Task]()

### Please review these reminders and either check the box or explain why not:

- [ ] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [ ] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

-

### Screenshots and extra notes:
