### PR TITLE
[CEQ2-164] feat: universal navbar support for renderCtaButton

### DIFF
--- a/src/components/UniversalNavbar/UniversalNavbar.d.ts
+++ b/src/components/UniversalNavbar/UniversalNavbar.d.ts
@@ -13,6 +13,8 @@ type UniversalNavbarProps = {
   logoHref?: string
   /** State if use is logged in */
   isLoggedIn?: boolean
+  /** Render props function to render additional CTA button in the Outer CTA div */
+  renderCtaButton?: (props: { isMobile: boolean }) => React.ReactNode
 }
 
 export declare const UniversalNavbar: React.FC<UniversalNavbarProps>

--- a/src/components/UniversalNavbar/UniversalNavbar.d.ts
+++ b/src/components/UniversalNavbar/UniversalNavbar.d.ts
@@ -13,7 +13,7 @@ type UniversalNavbarProps = {
   logoHref?: string
   /** State if use is logged in */
   isLoggedIn?: boolean
-  /** Render props function to render additional CTA button in the Outer CTA div */
+  /** render CTA node button in the Outer CTA div, prioritized over singleCta */
   renderCtaButton?: (props: { isMobile: boolean }) => React.ReactNode
 }
 

--- a/src/components/UniversalNavbarExpanded/MobileNav/MobileNav.js
+++ b/src/components/UniversalNavbarExpanded/MobileNav/MobileNav.js
@@ -72,6 +72,7 @@ BaseHamburger.propTypes = {
  * @param {object} singleCta = { href: string, title: string } - A single CTA Title/URL to link to in a reduced version of the navbar
  * @param {boolean} animateNavbar - navigation bar animation
  * @param {node} partnerLogoMobile - image should be 24px height and 24px width. Image format could be any.
+ * @param {node} renderCtaButton - render CTA node button in the Outer CTA div, prioritized over singleCta
  *
  * @return {JSX.Element}
  */
@@ -88,6 +89,7 @@ const MobileNav = ({
   singleCta = {},
   animateNavbar,
   partnerLogoMobile,
+  renderCtaButton,
 }) => {
   const [showMobileMenu, setShowMobileMenu] = useState(false)
   const toggleHamburger = () => {
@@ -159,12 +161,16 @@ const MobileNav = ({
                 {LogoGreen({ className: styles.logo })}
               </NavLink>
               <div className={styles.mobileCta}>
-                <CtaButton
-                  href={singleCta.href ? singleCta.href : links.CTA.href}
-                  trackingFunction={ctaButtonTrackingFunction}
-                  hideOnMobile={hideMobileCta}
-                  title={singleCta.title ? singleCta.title : links.CTA.title}
-                />
+                {renderCtaButton ? (
+                  renderCtaButton({ isMobile: true })
+                ) : (
+                  <CtaButton
+                    href={singleCta.href ? singleCta.href : links.CTA.href}
+                    trackingFunction={ctaButtonTrackingFunction}
+                    hideOnMobile={hideMobileCta}
+                    title={singleCta.title ? singleCta.title : links.CTA.title}
+                  />
+                )}
               </div>
               <Hamburger />
             </div>
@@ -212,15 +218,17 @@ const MobileNav = ({
             </>
           )}
         </div>
-        {!partnerLogoMobile && (
-          <CtaButton
-            buttonStyle={ctaButtonStyle}
-            href={singleCta.href ? singleCta.href : links.CTA.href}
-            trackingFunction={ctaButtonTrackingFunction}
-            hideOnMobile={hideMobileCta}
-            title={singleCta.title ? singleCta.title : links.CTA.title}
-          />
-        )}
+        {renderCtaButton
+          ? renderCtaButton({ isMobile: true })
+          : !partnerLogoMobile && (
+              <CtaButton
+                buttonStyle={ctaButtonStyle}
+                href={singleCta.href ? singleCta.href : links.CTA.href}
+                trackingFunction={ctaButtonTrackingFunction}
+                hideOnMobile={hideMobileCta}
+                title={singleCta.title ? singleCta.title : links.CTA.title}
+              />
+            )}
       </div>
     </>
   )
@@ -232,6 +240,7 @@ MobileNav.propTypes = {
   extraClass: PropTypes.string,
   ctaButtonTrackingFunction: PropTypes.func,
   itemTrackingFunction: PropTypes.func,
+  renderCtaButton: PropTypes.func,
   LinkComponent: PropTypes.object,
   logoHref: PropTypes.string.isRequired,
   secondaryLinksLinks: PropTypes.array.isRequired,
@@ -242,6 +251,10 @@ MobileNav.propTypes = {
   }),
   animateNavbar: PropTypes.bool,
   partnerLogoMobile: PropTypes.node,
+}
+
+MobileNav.defaultProps = {
+  renderCtaButton: undefined,
 }
 
 export default MobileNav

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -43,6 +43,7 @@ import { CTA_IDS } from '../UniversalNavbar/constants.js'
  * @param {boolean} isLoggedIn - check if user is logged in
  * @param {node} partnerLogo - image should be 24px height and width maximum 100px. Image format could be any.
  * @param {node} partnerLogoMobile - image should be 24px height and width maximum 100px. Image format could be any.
+ * @param {node} renderCtaButton - render additional CTA node button in the Outer CTA div
  *
  * @return {JSX.Element}
  */
@@ -66,6 +67,7 @@ const UniversalNavbarExpanded = ({
   isLoggedIn,
   partnerLogo,
   partnerLogoMobile,
+  renderCtaButton,
 }) => {
   let BELOW_ACCORDION_LINKS = [links.CTA]
 
@@ -148,6 +150,7 @@ const UniversalNavbarExpanded = ({
             LinkComponent={LinkComponent}
             singleCta={singleCta}
             partnerLogoMobile={partnerLogoMobile}
+            renderCtaButton={renderCtaButton}
           />
           <div className={laptopAndUpClasses.join(' ')}>
             <div className={styles.laptopAndUpContainer}>
@@ -197,17 +200,21 @@ const UniversalNavbarExpanded = ({
                   </>
                 )}
                 <div id={CTA_IDS.BUTTON.OUTER} className={styles.cta}>
-                  {!hideDesktopCta && (
-                    <CtaButton
-                      buttonStyle={ctaButtonStyle}
-                      href={singleCta.href ? singleCta.href : links.CTA.href}
-                      trackingFunction={trackCtaClick}
-                      id={CTA_IDS.BUTTON.INNER}
-                      title={
-                        singleCta.title ? singleCta.title : links.CTA.title
-                      }
-                    />
-                  )}
+                  {renderCtaButton
+                    ? renderCtaButton({ isMobile: false })
+                    : !hideDesktopCta && (
+                        <CtaButton
+                          buttonStyle={ctaButtonStyle}
+                          href={
+                            singleCta.href ? singleCta.href : links.CTA.href
+                          }
+                          trackingFunction={trackCtaClick}
+                          id={CTA_IDS.BUTTON.INNER}
+                          title={
+                            singleCta.title ? singleCta.title : links.CTA.title
+                          }
+                        />
+                      )}
                 </div>
               </div>
             </div>
@@ -330,6 +337,12 @@ UniversalNavbarExpanded.propTypes = {
   isLoggedIn: PropTypes.bool,
   partnerLogo: PropTypes.node,
   partnerLogoMobile: PropTypes.node,
+  /**
+   * Render props function to render additional CTA button in the Outer CTA div
+   * @param isMobile Boolean - Whether the CTA button is on mobile
+   * @returns {React.ReactNode} - The rendered CTA button
+   */
+  renderCtaButton: PropTypes.func,
 }
 
 UniversalNavbarExpanded.defaultProps = {
@@ -339,6 +352,7 @@ UniversalNavbarExpanded.defaultProps = {
   hideSearchIcon: false,
   hideAccountIcon: false,
   logoHref: '/',
+  renderCtaButton: undefined,
   trackCtaClick: () => {},
   links: {},
   estimateExperiment: false,

--- a/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
+++ b/src/components/UniversalNavbarExpanded/UniversalNavbarExpanded.js
@@ -43,7 +43,7 @@ import { CTA_IDS } from '../UniversalNavbar/constants.js'
  * @param {boolean} isLoggedIn - check if user is logged in
  * @param {node} partnerLogo - image should be 24px height and width maximum 100px. Image format could be any.
  * @param {node} partnerLogoMobile - image should be 24px height and width maximum 100px. Image format could be any.
- * @param {node} renderCtaButton - render additional CTA node button in the Outer CTA div
+ * @param {node} renderCtaButton - render CTA node button in the Outer CTA div, prioritized over singleCta
  *
  * @return {JSX.Element}
  */
@@ -338,7 +338,7 @@ UniversalNavbarExpanded.propTypes = {
   partnerLogo: PropTypes.node,
   partnerLogoMobile: PropTypes.node,
   /**
-   * Render props function to render additional CTA button in the Outer CTA div
+   * Render props function to render CTA button in the Outer CTA div
    * @param isMobile Boolean - Whether the CTA button is on mobile
    * @returns {React.ReactNode} - The rendered CTA button
    */


### PR DESCRIPTION
- [CEQ2-164] feat: universal navbar support for renderCtaButton

### Please review these reminders and either check the box or explain why not:

- [x] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [x] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

- https://github.com/getethos/cms-next/pull/1889

### Screenshots and extra notes:

See the [PR](https://github.com/getethos/cms-next/pull/1889)

[CEQ2-164]: https://ethoslife.atlassian.net/browse/CEQ2-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ