### PR TITLE
[ceq2-1596] feat: add data attributes to Button 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethos-design-system",
-  "version": "1.3.38",
+  "version": "1.3.39",
   "description": "Ethos Design System v1",
   "main": "./src/components/index.js",
   "types": "./src/components/index.d.ts",

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -120,7 +120,7 @@ function PrivateButton({
       onClick={debouncedOnClick}
       data-tid={rest['data-tid']}
       role={role}
-      data-track-button={dataTrackButton}Add commentMore actions
+      data-track-button={dataTrackButton}
       data-properties={dataProperties}
     >
       {backArrowIcon && ArrowIconInline(true)}

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -63,6 +63,8 @@ function PrivateButton({
   backArrowIcon,
   refreshIcon,
   debounceDurationMs = DEFAULT_DEBOUNCE_DURATION_MS,
+  'data-track-button': dataTrackButton = true,
+  'data-properties': dataProperties,
   ...rest
 }) {
   const [isDebounced, debouncedOnClick] = useDebounce(
@@ -118,6 +120,8 @@ function PrivateButton({
       onClick={debouncedOnClick}
       data-tid={rest['data-tid']}
       role={role}
+      data-track-button={dataTrackButton}Add commentMore actions
+      data-properties={dataProperties}
     >
       {backArrowIcon && ArrowIconInline(true)}
       {ariaLabelId ? <span id={ariaLabelId}>{children}</span> : children}
@@ -176,6 +180,8 @@ PrivateButton.PUBLIC_PROPS = {
   role: PropTypes.string,
   children: PropTypes.node,
   'data-tid': PropTypes.string,
+  'data-track-button': PropTypes.bool,
+  'data-properties': PropTypes.string,
   disabled: PropTypes.bool,
   fullWidth: PropTypes.bool,
   name: PropTypes.string,


### PR DESCRIPTION
## [Jira Task]()

### Please review these reminders and either check the box or explain why not:
- Add data-track-button and data-properties attributes to Button

- Default value of data-track-button will be true

- [ ] Read and followed the [contributing guidelines](https://eds.eks.dev.ethos-int.com/#/Guidelines?id=section-contribute)?
- [ ] Component is exported from [index.js](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.js)?
- [ ] Type is exported from [index.d.ts](https://github.com/getethos/ethos-design-system/blob/master/src/components/index.d.ts) so Typescript users can consume it? Added a test and ran `yarn test:types`?
- [ ] Bumped the yarn version?

### Referencing PR or Branch (e.g. in CMS or monorepo):

-

### Screenshots and extra notes:
